### PR TITLE
docs: add baileys-antiban to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,12 @@ is preserved, to make migration from Baileys straightforward.
 
 See [ATTRIBUTION.md](ATTRIBUTION.md) for the full attribution notice.
 
+## Ecosystem
+
+Middleware and tools that work on top of baileyrs:
+
+- **[baileys-antiban](https://github.com/kobie3717/baileys-antiban)** — Drop-in anti-ban middleware: rate limiting, warmup schedules, reply-ratio guard, contact graph warmer, and circadian presence choreography. Transport-agnostic as of v1.4 (works with both `baileys` and `@oxidezap/baileyrs`). [npm](https://www.npmjs.com/package/baileys-antiban)
+
 ## Disclaimer
 
 This project is not affiliated with, endorsed by, or in any way officially connected to


### PR DESCRIPTION
## Summary

Adds a small **Ecosystem** section to the README with a link to [baileys-antiban](https://github.com/kobie3717/baileys-antiban).

## Why

baileys-antiban v1.4.0 (just released) ships first-class support for `@oxidezap/baileyrs` alongside the original baileys. It's a drop-in middleware layer that adds rate limiting, warmup schedules, reply-ratio guard, contact graph warmer, and circadian presence choreography to any Baileys-compatible socket.

I figured a tiny mention in the README helps baileyrs users discover it and also demonstrates the "migration-friendly public API" value-prop concretely — existing middleware just works.

## Changes

- One new `## Ecosystem` section between "Relationship to Baileys" and "Disclaimer"
- Single bullet, no other edits

## Related

- baileys-antiban v1.4.0 release: https://github.com/kobie3717/baileys-antiban/releases/tag/v1.4.0
- Companion issue: oxidezap/baileyrs#1 (reachoutTimeLock emission)

No pressure to merge — totally your call if you'd rather keep the README minimal. Happy to reshape or drop if it doesn't fit your vision for the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Ecosystem" section to the README that showcases available tools and integrations, including the baileys-antiban middleware, providing users with information about external resources and enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->