### PR TITLE
test(e2e): unify bridge client factory and add QR autoresponder

### DIFF
--- a/src/Socket/transport.ts
+++ b/src/Socket/transport.ts
@@ -102,9 +102,9 @@ export const makeTransport = (config: TransportConfig): JsTransportCallbacks => 
 			// Await the actual close before returning. Without this, the caller
 			// (core's `connect_and_run` on a 515 reconnect path) can race-open a
 			// brand-new WebSocket while the previous TCP connection is still in
-			// CLOSING on the server side; some servers (notably the bartender
-			// mock) queue / reject the new accept() until the old one is fully
-			// released, stalling reconnect to the 20s connect-timeout ceiling.
+			// CLOSING on the server side; some servers queue/reject the new
+			// accept() until the old one is fully released, stalling reconnect
+			// to the 20s connect-timeout ceiling.
 			if (toClose.readyState === WebSocket.CLOSED) return
 
 			const closed = new Promise<void>(resolve => {

--- a/src/__tests__/e2e/baileys-handoff.test-e2e.ts
+++ b/src/__tests__/e2e/baileys-handoff.test-e2e.ts
@@ -55,6 +55,7 @@ import * as upstreamBaileys from 'baileys'
 import P from 'pino'
 import { Boom, DisconnectReason, jidNormalizedUser, makeWASocket, type proto } from '../../index.ts'
 import { expect } from '../expect.ts'
+import { attachQrAutoresponder } from './qr-autoresponder.ts'
 import { waitForEvent, waitForMessage } from './wait.ts'
 
 type WASocket = ReturnType<typeof makeWASocket>
@@ -147,6 +148,10 @@ async function createBridgeClient(label: string, authFolder?: string): Promise<B
 
 	// Persist as keys/creds advance — without this the swap reads stale state.
 	sock.ev.on('creds.update', saveCreds)
+
+	// Bartender mock-server is scan-driven; an external "phone" must POST
+	// the QR for pair-success to flow.
+	attachQrAutoresponder(sock, socketUrl)
 
 	const jid = await new Promise<string>((resolve, reject) => {
 		const tid = setTimeout(() => reject(new Error(`${label}: connect timeout (bridge)`)), 30_000)

--- a/src/__tests__/e2e/group-lifecycle.test-e2e.ts
+++ b/src/__tests__/e2e/group-lifecycle.test-e2e.ts
@@ -17,76 +17,15 @@
  * regressions that proto-level unit tests would miss.
  */
 
-import { mkdtempSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import process from 'node:process'
 import { after, before, describe, test } from 'node:test'
 import P from 'pino'
-import {
-	Boom,
-	DisconnectReason,
-	jidNormalizedUser,
-	makeWASocket,
-	type proto,
-	useMultiFileAuthState,
-	WAMessageStubType
-} from '../../index.ts'
+import { type proto, WAMessageStubType } from '../../index.ts'
 import { expect } from '../expect.ts'
+import { createTestClient, destroyTestClient, type TestClient } from './test-client.ts'
 import { waitForEvent, waitForMessage } from './wait.ts'
 
-type WASocket = ReturnType<typeof makeWASocket>
-
 const logger = P({ level: process.env.LOG_LEVEL ?? 'warn' })
-const socketUrl = process.env.SOCKET_URL ?? 'wss://127.0.0.1:8080/ws/chat'
-
-interface TestClient {
-	sock: WASocket
-	jid: string
-	lid?: string
-	authFolder: string
-	label: string
-}
-
-async function createTestClient(label: string): Promise<TestClient> {
-	const authFolder = mkdtempSync(join(tmpdir(), `baileys-grp-${label}-`))
-	const { state } = await useMultiFileAuthState(authFolder)
-
-	const sock = makeWASocket({
-		auth: state,
-		waWebSocketUrl: socketUrl,
-		logger: logger.child({ user: label })
-	})
-
-	const jid = await new Promise<string>((resolve, reject) => {
-		sock.ev.on('connection.update', update => {
-			if (update.connection === 'open') {
-				resolve(jidNormalizedUser(sock.user?.id))
-			} else if (update.connection === 'close') {
-				const reason = (update.lastDisconnect?.error as Boom)?.output?.statusCode
-				if (reason === DisconnectReason.loggedOut) {
-					reject(new Error(`${label}: Logged out`))
-				}
-			}
-		})
-	})
-
-	return { sock, jid, lid: sock.user?.lid, authFolder, label }
-}
-
-async function destroyTestClient(client: TestClient) {
-	try {
-		client.sock.setAutoReconnect(false)
-		await client.sock.end()
-	} catch {
-		/* ignore */
-	}
-	try {
-		rmSync(client.authFolder, { recursive: true, force: true })
-	} catch {
-		/* ignore */
-	}
-}
 
 function getTextContent(msg: proto.IWebMessageInfo): string | undefined {
 	return msg.message?.extendedTextMessage?.text || msg.message?.conversation || undefined
@@ -115,9 +54,9 @@ describe('E2E: Group lifecycle (create → message → promote → demote → ki
 
 	before(async () => {
 		;[alice, bob, charlie] = await Promise.all([
-			createTestClient('alice'),
-			createTestClient('bob'),
-			createTestClient('charlie')
+			createTestClient({ label: 'alice', folderPrefix: 'baileys-grp' }),
+			createTestClient({ label: 'bob', folderPrefix: 'baileys-grp' }),
+			createTestClient({ label: 'charlie', folderPrefix: 'baileys-grp' })
 		])
 		logger.info({ alice: alice.jid, bob: bob.jid, charlie: charlie.jid }, 'Trio paired')
 	})

--- a/src/__tests__/e2e/qr-autoresponder.ts
+++ b/src/__tests__/e2e/qr-autoresponder.ts
@@ -1,0 +1,57 @@
+/**
+ * In-test "phone simulator" that reads the first QR a `makeWASocket` client
+ * publishes via `connection.update` and POSTs it to the mock server's
+ * `/admin/mock-phone/scan-qr` endpoint.
+ *
+ * Mock servers that follow the scan-driven pairing model only send
+ * `<pair-success>` after a scan is submitted; external e2e harnesses
+ * without a real phone need this helper to unblock pairing. The endpoint
+ * accepts the raw 5-field QR string in the request body.
+ */
+
+import type { makeWASocket } from '../../index.ts'
+
+type WASocket = ReturnType<typeof makeWASocket>
+
+/** Translate a `ws[s]://host:port/ws/chat` URL into the matching admin
+ * `https?://host:port/admin/mock-phone/scan-qr` URL the mock exposes. */
+export function mockAdminScanQrUrl(socketUrl: string): string {
+	const httpScheme = socketUrl.startsWith('wss://') ? 'https://' : 'http://'
+	const afterScheme = socketUrl.split('://')[1] ?? socketUrl
+	const hostPort = afterScheme.split('/')[0] ?? afterScheme
+	return `${httpScheme}${hostPort}/admin/mock-phone/scan-qr`
+}
+
+/**
+ * Subscribe to `sock.ev.on('connection.update', …)` and forward the first QR
+ * to `mockAdminScanQrUrl(socketUrl)`. Returns an unsubscribe function so
+ * tests can clean up on teardown.
+ *
+ * The test:e2e script sets `NODE_TLS_REJECT_UNAUTHORIZED=0` so `fetch`
+ * accepts the mock's self-signed certificate.
+ */
+export function attachQrAutoresponder(sock: WASocket, socketUrl: string): () => void {
+	const url = mockAdminScanQrUrl(socketUrl)
+	let done = false
+
+	const listener = async (update: { qr?: string }) => {
+		if (done || !update.qr) return
+		done = true
+		try {
+			const resp = await fetch(url, {
+				method: 'POST',
+				body: update.qr,
+				headers: { 'content-type': 'text/plain' }
+			})
+			if (!resp.ok) {
+				const text = await resp.text().catch(() => '')
+				console.error(`qr-autoresponder: admin POST returned ${resp.status}: ${text}`)
+			}
+		} catch (e) {
+			console.error(`qr-autoresponder: admin POST failed: ${(e as Error).message}`)
+		}
+	}
+
+	sock.ev.on('connection.update', listener)
+	return () => sock.ev.off('connection.update', listener)
+}

--- a/src/__tests__/e2e/qr-autoresponder.ts
+++ b/src/__tests__/e2e/qr-autoresponder.ts
@@ -32,23 +32,32 @@ export function mockAdminScanQrUrl(socketUrl: string): string {
  */
 export function attachQrAutoresponder(sock: WASocket, socketUrl: string): () => void {
 	const url = mockAdminScanQrUrl(socketUrl)
-	let done = false
+	let succeeded = false
+	let inflight = false
 
 	const listener = async (update: { qr?: string }) => {
-		if (done || !update.qr) return
-		done = true
+		// `succeeded` permanently latches once the mock acks the scan; `inflight`
+		// just prevents racing duplicate POSTs while one is still pending. A
+		// failed first attempt must remain retryable because WA rotates QR
+		// values on a timer and the listener will see each rotation.
+		if (succeeded || inflight || !update.qr) return
+		inflight = true
 		try {
 			const resp = await fetch(url, {
 				method: 'POST',
 				body: update.qr,
 				headers: { 'content-type': 'text/plain' }
 			})
-			if (!resp.ok) {
+			if (resp.ok) {
+				succeeded = true
+			} else {
 				const text = await resp.text().catch(() => '')
 				console.error(`qr-autoresponder: admin POST returned ${resp.status}: ${text}`)
 			}
 		} catch (e) {
 			console.error(`qr-autoresponder: admin POST failed: ${(e as Error).message}`)
+		} finally {
+			inflight = false
 		}
 	}
 

--- a/src/__tests__/e2e/retrocompat-api.test-e2e.ts
+++ b/src/__tests__/e2e/retrocompat-api.test-e2e.ts
@@ -5,78 +5,24 @@
  * work correctly against the mock WA server.
  */
 
-import { mkdtempSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import process from 'node:process'
 import { after, before, describe, mock, test } from 'node:test'
 import P from 'pino'
-import {
-	type BinaryNode,
-	Boom,
-	DisconnectReason,
-	jidNormalizedUser,
-	makeWASocket,
-	useMultiFileAuthState
-} from '../../index.ts'
+import { type BinaryNode, Boom, DisconnectReason } from '../../index.ts'
 import { expect } from '../expect.ts'
-
-type WASocket = ReturnType<typeof makeWASocket>
+import { createTestClient, destroyTestClient } from './test-client.ts'
 
 const logger = P({ level: process.env.LOG_LEVEL ?? 'warn' })
-const socketUrl = process.env.SOCKET_URL ?? 'wss://127.0.0.1:8080/ws/chat'
-
-async function createTestClient(label: string): Promise<{
-	sock: WASocket
-	jid: string
-	authFolder: string
-}> {
-	const authFolder = mkdtempSync(join(tmpdir(), `baileys-compat-${label}-`))
-	const { state } = await useMultiFileAuthState(authFolder)
-
-	const sock = makeWASocket({
-		auth: state,
-		waWebSocketUrl: socketUrl,
-		logger: logger.child({ user: label })
-	})
-
-	const jid = await new Promise<string>((resolve, reject) => {
-		sock.ev.on('connection.update', update => {
-			if (update.connection === 'open') {
-				resolve(jidNormalizedUser(sock.user?.id))
-			} else if (update.connection === 'close') {
-				const reason = (update.lastDisconnect?.error as Boom)?.output?.statusCode
-				if (reason === DisconnectReason.loggedOut) {
-					reject(new Error(`${label}: Logged out`))
-				}
-			}
-		})
-	})
-
-	return { sock, jid, authFolder }
-}
-
-async function destroyTestClient(client: { sock: WASocket; authFolder: string }) {
-	try {
-		client.sock.setAutoReconnect(false)
-		await client.sock.end()
-	} catch {
-		/* ignore */
-	}
-
-	try {
-		rmSync(client.authFolder, { recursive: true, force: true })
-	} catch {
-		/* ignore */
-	}
-}
 
 describe('E2E: Retrocompat API', { timeout: 30_000 }, () => {
 	let alice: Awaited<ReturnType<typeof createTestClient>>
 	let bob: Awaited<ReturnType<typeof createTestClient>>
 
 	before(async () => {
-		;[alice, bob] = await Promise.all([createTestClient('compat-alice'), createTestClient('compat-bob')])
+		;[alice, bob] = await Promise.all([
+			createTestClient({ label: 'compat-alice', folderPrefix: 'baileys-compat' }),
+			createTestClient({ label: 'compat-bob', folderPrefix: 'baileys-compat' })
+		])
 		logger.info({ alice: alice.jid, bob: bob.jid }, 'Both users connected')
 	})
 

--- a/src/__tests__/e2e/send-receive-message.test-e2e.ts
+++ b/src/__tests__/e2e/send-receive-message.test-e2e.ts
@@ -1,22 +1,17 @@
 import { Buffer } from 'node:buffer'
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
 import process from 'node:process'
 import { after, before, describe, test } from 'node:test'
 import P from 'pino'
 import {
-	Boom,
-	DisconnectReason,
 	downloadMediaMessage,
 	type DownloadMediaMessageContext,
-	jidNormalizedUser,
 	makeWASocket,
 	proto,
-	useMultiFileAuthState,
 	type WAMessage
 } from '../../index.ts'
 import { expect } from '../expect.ts'
+import { createTestClient, destroyTestClient } from './test-client.ts'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -25,53 +20,6 @@ import { expect } from '../expect.ts'
 type WASocket = ReturnType<typeof makeWASocket>
 
 const logger = P({ level: process.env.LOG_LEVEL ?? 'warn' })
-const socketUrl = process.env.SOCKET_URL ?? 'wss://127.0.0.1:8080/ws/chat'
-
-async function createTestClient(label: string): Promise<{
-	sock: WASocket
-	jid: string
-	lid?: string
-	authFolder: string
-}> {
-	const authFolder = mkdtempSync(join(tmpdir(), `baileys-e2e-${label}-`))
-	const { state } = await useMultiFileAuthState(authFolder)
-
-	const sock = makeWASocket({
-		auth: state,
-		waWebSocketUrl: socketUrl,
-		logger: logger.child({ user: label })
-	})
-
-	const jid = await new Promise<string>((resolve, reject) => {
-		sock.ev.on('connection.update', update => {
-			if (update.connection === 'open') {
-				resolve(jidNormalizedUser(sock.user?.id))
-			} else if (update.connection === 'close') {
-				const reason = (update.lastDisconnect?.error as Boom)?.output?.statusCode
-				if (reason === DisconnectReason.loggedOut) {
-					reject(new Error(`${label}: Logged out`))
-				}
-			}
-		})
-	})
-
-	return { sock, jid, lid: sock.user?.lid, authFolder }
-}
-
-async function destroyTestClient(client: { sock: WASocket; authFolder: string }) {
-	try {
-		client.sock.setAutoReconnect(false)
-		await client.sock.end()
-	} catch {
-		/* ignore */
-	}
-
-	try {
-		rmSync(client.authFolder, { recursive: true, force: true })
-	} catch {
-		/* ignore */
-	}
-}
 
 function waitForMessage(
 	sock: WASocket,
@@ -117,7 +65,10 @@ describe('E2E: Two-user messaging', { timeout: 60_000 }, () => {
 	let bob: Awaited<ReturnType<typeof createTestClient>>
 
 	before(async () => {
-		;[alice, bob] = await Promise.all([createTestClient('alice'), createTestClient('bob')])
+		;[alice, bob] = await Promise.all([
+			createTestClient({ label: 'alice' }),
+			createTestClient({ label: 'bob' })
+		])
 		logger.info({ alice: alice.jid, bob: bob.jid }, 'Both users connected')
 	})
 

--- a/src/__tests__/e2e/send-receive-message.test-e2e.ts
+++ b/src/__tests__/e2e/send-receive-message.test-e2e.ts
@@ -65,10 +65,7 @@ describe('E2E: Two-user messaging', { timeout: 60_000 }, () => {
 	let bob: Awaited<ReturnType<typeof createTestClient>>
 
 	before(async () => {
-		;[alice, bob] = await Promise.all([
-			createTestClient({ label: 'alice' }),
-			createTestClient({ label: 'bob' })
-		])
+		;[alice, bob] = await Promise.all([createTestClient({ label: 'alice' }), createTestClient({ label: 'bob' })])
 		logger.info({ alice: alice.jid, bob: bob.jid }, 'Both users connected')
 	})
 

--- a/src/__tests__/e2e/test-client.ts
+++ b/src/__tests__/e2e/test-client.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared factory for e2e bridge clients.
+ *
+ * Each test file used to ship its own ~25-line `createTestClient` with the
+ * same boilerplate (mkdtemp + useMultiFileAuthState + makeWASocket + wait
+ * for `connection.update`). They are now thin wrappers over this module.
+ *
+ * The `baileys-handoff` test still has its own factories (createBridgeClient
+ * + createUpstreamClient) because it needs the upstream-baileys auth-state
+ * format on disk and a separate sock implementation; that file uses
+ * [`attachQrAutoresponder`] directly from `qr-autoresponder.ts`.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import P from 'pino'
+import {
+	Boom,
+	DisconnectReason,
+	jidNormalizedUser,
+	makeWASocket,
+	useMultiFileAuthState
+} from '../../index.ts'
+import { attachQrAutoresponder } from './qr-autoresponder.ts'
+
+type WASocket = ReturnType<typeof makeWASocket>
+
+const defaultLogger = P({ level: process.env.LOG_LEVEL ?? 'warn' })
+const defaultSocketUrl = process.env.SOCKET_URL ?? 'wss://127.0.0.1:8080/ws/chat'
+
+export interface CreateTestClientOptions {
+	/** Logger child name and tmp-folder slug. */
+	label: string
+	/** Tmp-dir prefix when auto-creating an auth folder. Default `baileys-e2e`. */
+	folderPrefix?: string
+	/** Override the default mock-server WebSocket URL. */
+	socketUrl?: string
+	/** Override the default connect timeout. Default 30_000 ms. */
+	connectTimeoutMs?: number
+	/** Pre-existing auth folder (rarely needed here; handoff uses its own factory). */
+	authFolder?: string
+}
+
+export interface TestClient {
+	sock: WASocket
+	jid: string
+	lid?: string
+	authFolder: string
+	label: string
+}
+
+/** Pair a fresh bridge client and wait until `connection.update` resolves
+ * `connection === 'open'`. Auto-attaches the QR autoresponder so the
+ * mock-server's scan-driven pairing flow can complete. */
+export async function createTestClient(opts: CreateTestClientOptions): Promise<TestClient> {
+	const folderPrefix = opts.folderPrefix ?? 'baileys-e2e'
+	const folder = opts.authFolder ?? mkdtempSync(join(tmpdir(), `${folderPrefix}-${opts.label}-`))
+	const url = opts.socketUrl ?? defaultSocketUrl
+	const timeoutMs = opts.connectTimeoutMs ?? 30_000
+
+	const { state } = await useMultiFileAuthState(folder)
+
+	const sock = makeWASocket({
+		auth: state,
+		waWebSocketUrl: url,
+		logger: defaultLogger.child({ user: opts.label })
+	})
+
+	attachQrAutoresponder(sock, url)
+
+	const jid = await new Promise<string>((resolve, reject) => {
+		const tid = setTimeout(() => reject(new Error(`${opts.label}: connect timeout`)), timeoutMs)
+		sock.ev.on('connection.update', update => {
+			if (update.connection === 'open') {
+				clearTimeout(tid)
+				resolve(jidNormalizedUser(sock.user?.id))
+			} else if (update.connection === 'close') {
+				const reason = (update.lastDisconnect?.error as Boom)?.output?.statusCode
+				if (reason === DisconnectReason.loggedOut) {
+					clearTimeout(tid)
+					reject(new Error(`${opts.label}: Logged out`))
+				}
+			}
+		})
+	})
+
+	return { sock, jid, lid: sock.user?.lid, authFolder: folder, label: opts.label }
+}
+
+/** Disable auto-reconnect, close the socket, then remove the auth folder.
+ * Swallows errors so cleanup is best-effort and never fails a teardown. */
+export async function destroyTestClient(client: { sock: WASocket; authFolder: string }): Promise<void> {
+	try {
+		client.sock.setAutoReconnect(false)
+		await client.sock.end()
+	} catch {
+		/* ignore */
+	}
+
+	try {
+		rmSync(client.authFolder, { recursive: true, force: true })
+	} catch {
+		/* ignore */
+	}
+}

--- a/src/__tests__/e2e/test-client.ts
+++ b/src/__tests__/e2e/test-client.ts
@@ -16,13 +16,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
 import P from 'pino'
-import {
-	Boom,
-	DisconnectReason,
-	jidNormalizedUser,
-	makeWASocket,
-	useMultiFileAuthState
-} from '../../index.ts'
+import { Boom, DisconnectReason, jidNormalizedUser, makeWASocket, useMultiFileAuthState } from '../../index.ts'
 import { attachQrAutoresponder } from './qr-autoresponder.ts'
 
 type WASocket = ReturnType<typeof makeWASocket>


### PR DESCRIPTION
## Summary

- Move the duplicated `createTestClient` boilerplate into a shared
  `test-client.ts` factory.
- Add `attachQrAutoresponder`: on the first `connection.update.qr`,
  POSTs the QR to `/admin/mock-phone/scan-qr` so scan-driven mocks
  complete pairing without a real phone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added shared E2E test client utilities to standardize setup/teardown across suites.
  * Added a QR autoresponder to support mock-server pairing; wired it into relevant handoff/bridge tests.
  * Consolidated per-test client lifecycle management to reduce duplication and streamline tests.

* **Chores**
  * Minor clarification to an inline comment about reconnect/closing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->