### PR TITLE
fix: zombie connection after stream-error 500

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@oxidezap/baileyrs",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxidezap/baileyrs",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "license": "MIT",
       "dependencies": {
         "pino": "^9.6",
-        "whatsapp-rust-bridge": "0.6.0-alpha.27"
+        "whatsapp-rust-bridge": "0.6.0-alpha.28"
       },
       "devDependencies": {
         "@types/node": "^22",
@@ -2699,9 +2699,9 @@
       }
     },
     "node_modules/whatsapp-rust-bridge": {
-      "version": "0.6.0-alpha.27",
-      "resolved": "https://registry.npmjs.org/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.6.0-alpha.27.tgz",
-      "integrity": "sha512-krJUgiDQkIAqRjjnNrG+vW68tqInRlCpn0vs2AJCl2YbkdTSqPeDuaBd+kK/vwLmZoWuCq0ivB2oHcBGDLf8sA==",
+      "version": "0.6.0-alpha.28",
+      "resolved": "https://registry.npmjs.org/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.6.0-alpha.28.tgz",
+      "integrity": "sha512-LmXT5W3TvNKCGAmRffckGr/HtYc1Ce3LJ3YMqpXbR9MoTwfy7n0kZt8BEo7QH7wquc/8Ya8FiEiH1vl7aZWv/w==",
       "license": "MIT"
     },
     "node_modules/win-guid": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oxidezap/baileyrs",
   "type": "module",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "A Rust-powered WhatsApp Web library for JavaScript, with a Baileys-compatible API",
   "keywords": [
     "whatsapp",
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "pino": "^9.6",
-    "whatsapp-rust-bridge": "0.6.0-alpha.27"
+    "whatsapp-rust-bridge": "0.6.0-alpha.28"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -113,10 +113,15 @@ type DispatcherFn<T extends CanonicalEvent['type']> = (evt: CanonicalByType<T>, 
  */
 type DispatcherMap = { [K in CanonicalEvent['type']]: DispatcherFn<K> }
 
-const emitClose = (ctx: SocketContext, reason: string, statusCode: number) =>
+const emitClose = (
+	ctx: SocketContext,
+	reason: string,
+	statusCode: number,
+	data?: Record<string, unknown>
+) =>
 	ctx.ev.emit('connection.update', {
 		connection: 'close',
-		lastDisconnect: { error: new Boom(reason, { statusCode }), date: new Date() }
+		lastDisconnect: { error: new Boom(reason, { statusCode, data }), date: new Date() }
 	} as Partial<ConnectionState>)
 
 /**
@@ -203,7 +208,13 @@ const DISPATCHERS: DispatcherMap = {
 		const status = mapConnectFailureToDisconnect(evt.reason)
 		emitClose(ctx, evt.message ?? 'Connection failure', status)
 	},
-	streamError: (evt, { ctx }) => emitClose(ctx, 'Stream error: ' + evt.code, DisconnectReason.badSession),
+	// Preserve the wire code on `boom.data.streamErrorCode` so consumers can
+	// branch on the actual `<stream:error code="...">` (e.g. 500 vs an
+	// unknown code) without losing the canonical DisconnectReason.badSession.
+	streamError: (evt, { ctx }) =>
+		emitClose(ctx, 'Stream error: ' + evt.code, DisconnectReason.badSession, {
+			streamErrorCode: evt.code
+		}),
 	streamReplaced: (_, { ctx }) =>
 		emitConnectionUpdate(ctx, {
 			connection: 'close',

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -113,12 +113,7 @@ type DispatcherFn<T extends CanonicalEvent['type']> = (evt: CanonicalByType<T>, 
  */
 type DispatcherMap = { [K in CanonicalEvent['type']]: DispatcherFn<K> }
 
-const emitClose = (
-	ctx: SocketContext,
-	reason: string,
-	statusCode: number,
-	data?: Record<string, unknown>
-) =>
+const emitClose = (ctx: SocketContext, reason: string, statusCode: number, data?: Record<string, unknown>) =>
 	ctx.ev.emit('connection.update', {
 		connection: 'close',
 		lastDisconnect: { error: new Boom(reason, { statusCode, data }), date: new Date() }

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -441,7 +441,15 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 				ev.emit('connection.update', {
 					connection: 'close',
 					lastDisconnect: {
-						error: err instanceof Error ? err : new Boom(String(err), { statusCode: 500 }),
+						// restartRequired (515) signals "Rust read loop crashed
+						// unrecoverably, restart the sock". Previously mapped to
+						// 500, which collided with the server-side <stream:error
+						// code="500"> path and made it impossible for consumers
+						// to tell the two apart.
+						error:
+							err instanceof Error
+								? err
+								: new Boom(String(err), { statusCode: DisconnectReason.restartRequired }),
 						date: new Date()
 					}
 				} as Partial<ConnectionState>)

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -446,10 +446,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 						// 500, which collided with the server-side <stream:error
 						// code="500"> path and made it impossible for consumers
 						// to tell the two apart.
-						error:
-							err instanceof Error
-								? err
-								: new Boom(String(err), { statusCode: DisconnectReason.restartRequired }),
+						error: err instanceof Error ? err : new Boom(String(err), { statusCode: DisconnectReason.restartRequired }),
 						date: new Date()
 					}
 				} as Partial<ConnectionState>)


### PR DESCRIPTION
- **fix(socket): preserve stream-error wire code on Boom.data**
- **fix(socket): use restartRequired (515) for run() rejection**
- **chore: bump to 0.0.22 + whatsapp-rust-bridge 0.6.0-alpha.28**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Connection close events now preserve and provide access to original error codes, enabling better differentiation between disconnection reasons.
  * Improved error classification to distinguish restart-required scenarios from other failure types.

* **Chores**
  * Version bumped to 0.0.22
  * Dependencies updated

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oxidezap/baileyrs/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->