### PR TITLE
fix(wrap-legacy-store): bridge Rust↔JS libsignal chain-counter off-by-one

### DIFF
--- a/src/Utils/__tests__/wrap-legacy-store-session-ratchet.test.ts
+++ b/src/Utils/__tests__/wrap-legacy-store-session-ratchet.test.ts
@@ -1,0 +1,270 @@
+// Ratchet semantic equivalence across the wrap-legacy-store boundary:
+// chain converted Rust→JS (or back) must derive identical message keys.
+// Pins the off-by-one between Rust `chain_key.index` and JS `chainKey.counter`.
+
+import { Buffer } from 'node:buffer'
+import { createHmac } from 'node:crypto'
+import { describe, test } from 'node:test'
+import SessionRecord from 'libsignal/src/session_record.js'
+import { proto as bridgeProto } from 'whatsapp-rust-bridge/proto-types'
+import { expect } from '../../__tests__/expect.ts'
+import { fill, makeWrapped, BRIDGE_SESSION_KEY_LID, UPSTREAM_SESSION_KEY_LID } from './_legacy-store-fixtures.ts'
+
+const MSG_SEED = Buffer.from([0x01])
+const CHAIN_SEED = Buffer.from([0x02])
+const hmac = (key: Buffer, seed: Buffer): Buffer => createHmac('sha256', key).update(seed).digest() as Buffer
+
+function walkChain(initialKey: Buffer, n: number): { keyAfterNSteps: Buffer; msgKeys: Buffer[] } {
+	let k: Buffer = Buffer.from(initialKey)
+	const msgKeys: Buffer[] = []
+	for (let i = 0; i < n; i++) {
+		msgKeys.push(hmac(k, MSG_SEED))
+		k = hmac(k, CHAIN_SEED)
+	}
+	return { keyAfterNSteps: k, msgKeys }
+}
+
+// Matches libsignal's in-memory shape after SessionRecord.deserialize.
+interface JSChainShape {
+	chainKey: { counter: number; key: Buffer }
+	chainType: number
+	messageKeys: Record<string, Buffer>
+}
+
+// Replica of libsignal's private SessionCipher.fillMessageKeys.
+function jsFillMessageKeys(chain: JSChainShape, target: number): void {
+	while (chain.chainKey.counter < target) {
+		const key = chain.chainKey.key
+		chain.chainKey.counter += 1
+		chain.messageKeys[chain.chainKey.counter] = hmac(key, MSG_SEED)
+		chain.chainKey.key = hmac(key, CHAIN_SEED)
+	}
+}
+
+interface BuildChainOpts {
+	initialChainKey: Buffer
+	senderRustIndex?: number
+	receiverRustIndex?: number
+	senderRatchetPub?: Uint8Array
+	receiverRatchetPub?: Uint8Array
+}
+
+function buildBridgeProto(opts: BuildChainOpts): Uint8Array {
+	const {
+		initialChainKey,
+		senderRustIndex = 0,
+		receiverRustIndex = 0,
+		senderRatchetPub = fill(33, 2),
+		receiverRatchetPub = fill(33, 5)
+	} = opts
+	return bridgeProto.RecordStructure.encode(
+		bridgeProto.RecordStructure.create({
+			currentSession: bridgeProto.SessionStructure.create({
+				sessionVersion: 3,
+				localIdentityPublic: fill(33, 9),
+				remoteIdentityPublic: fill(33, 8),
+				rootKey: fill(32, 11),
+				previousCounter: 0,
+				senderChain: {
+					senderRatchetKey: senderRatchetPub,
+					senderRatchetKeyPrivate: fill(32, 3),
+					chainKey: { index: senderRustIndex, key: new Uint8Array(initialChainKey) },
+					messageKeys: []
+				},
+				receiverChains: [
+					{
+						senderRatchetKey: receiverRatchetPub,
+						chainKey: { index: receiverRustIndex, key: new Uint8Array(initialChainKey) },
+						messageKeys: []
+					}
+				],
+				remoteRegistrationId: 1234,
+				localRegistrationId: 5678,
+				aliceBaseKey: fill(33, 7)
+			}),
+			previousSessions: []
+		})
+	).finish()
+}
+
+interface JsSessionOpts {
+	senderRatchetPub: Buffer
+	senderRatchetPriv: Buffer
+	chainKey: Buffer
+	counter: number
+}
+
+function buildJsSession(opts: JsSessionOpts) {
+	const baseKey = Buffer.from(fill(33, 7))
+	return {
+		_sessions: {
+			[baseKey.toString('base64')]: {
+				registrationId: 9999,
+				currentRatchet: {
+					ephemeralKeyPair: {
+						pubKey: opts.senderRatchetPub.toString('base64'),
+						privKey: opts.senderRatchetPriv.toString('base64')
+					},
+					lastRemoteEphemeralKey: Buffer.alloc(0).toString('base64'),
+					previousCounter: 0,
+					rootKey: Buffer.from(fill(32, 11)).toString('base64')
+				},
+				indexInfo: {
+					baseKey: baseKey.toString('base64'),
+					baseKeyType: 1,
+					closed: -1,
+					used: 0,
+					created: 0,
+					remoteIdentityKey: Buffer.from(fill(33, 8)).toString('base64')
+				},
+				_chains: {
+					[opts.senderRatchetPub.toString('base64')]: {
+						chainKey: { counter: opts.counter, key: opts.chainKey.toString('base64') },
+						chainType: 1,
+						messageKeys: {}
+					}
+				}
+			}
+		},
+		version: 'v1' as const
+	}
+}
+
+async function writeProtoAndReadJS(protoBytes: Uint8Array): Promise<ReturnType<typeof SessionRecord.deserialize>> {
+	const { wrapped, keys } = await makeWrapped()
+	await wrapped.set('session', BRIDGE_SESSION_KEY_LID, protoBytes)
+	const stored = keys.raw['session']?.[UPSTREAM_SESSION_KEY_LID]
+	if (!stored) throw new Error('wrapper did not write session under upstream key')
+	return SessionRecord.deserialize(stored)
+}
+
+function chainFor(rec: ReturnType<typeof SessionRecord.deserialize>, ratchetPub: Uint8Array) {
+	const session = rec.getOpenSession()
+	if (!session) throw new Error('no open session')
+	const chain = session._chains[Buffer.from(ratchetPub).toString('base64')]
+	if (!chain) throw new Error(`no chain for ratchet ${Buffer.from(ratchetPub).toString('hex').slice(0, 12)}…`)
+	return chain
+}
+
+describe('wrap-legacy-store: Rust↔JS chain-key index/counter mapping', () => {
+	const senderRatchet = fill(33, 2)
+	const receiverRatchet = fill(33, 5)
+
+	test('fresh Rust chain (index=0) → JS counter=-1', async () => {
+		const rec = await writeProtoAndReadJS(
+			buildBridgeProto({ initialChainKey: Buffer.from(fill(32, 42)), senderRustIndex: 0 })
+		)
+		expect(chainFor(rec, senderRatchet).chainKey.counter).toBe(-1)
+	})
+
+	test('Rust index=N → JS counter=N-1 for arbitrary N', async () => {
+		for (const n of [0, 1, 2, 5, 17, 100, 940]) {
+			const rec = await writeProtoAndReadJS(
+				buildBridgeProto({ initialChainKey: Buffer.from(fill(32, 50)), senderRustIndex: n })
+			)
+			expect(chainFor(rec, senderRatchet).chainKey.counter).toBe(n - 1)
+		}
+	})
+
+	test('receiver chain mirrors sender chain mapping', async () => {
+		const rec = await writeProtoAndReadJS(
+			buildBridgeProto({
+				initialChainKey: Buffer.from(fill(32, 11)),
+				senderRustIndex: 0,
+				receiverRustIndex: 5
+			})
+		)
+		expect(chainFor(rec, receiverRatchet).chainKey.counter).toBe(4)
+	})
+
+	test('JS counter=N → Rust index=N+1 (inverse direction)', async () => {
+		const { wrapped, keys } = await makeWrapped()
+		keys.raw['session'] = {
+			[UPSTREAM_SESSION_KEY_LID]: buildJsSession({
+				senderRatchetPub: Buffer.from(fill(33, 2)),
+				senderRatchetPriv: Buffer.from(fill(32, 3)),
+				chainKey: Buffer.from(fill(32, 70)),
+				counter: 6
+			})
+		}
+		const protoBytes = (await wrapped.get('session', BRIDGE_SESSION_KEY_LID)) as Uint8Array
+		const decoded = bridgeProto.RecordStructure.decode(protoBytes)
+		expect(decoded.currentSession?.senderChain?.chainKey?.index).toBe(7)
+	})
+
+	test('fresh JS chain (counter=-1) → Rust index=0', async () => {
+		const { wrapped, keys } = await makeWrapped()
+		keys.raw['session'] = {
+			[UPSTREAM_SESSION_KEY_LID]: buildJsSession({
+				senderRatchetPub: Buffer.from(fill(33, 2)),
+				senderRatchetPriv: Buffer.from(fill(32, 3)),
+				chainKey: Buffer.from(fill(32, 21)),
+				counter: -1
+			})
+		}
+		const protoBytes = (await wrapped.get('session', BRIDGE_SESSION_KEY_LID)) as Uint8Array
+		const decoded = bridgeProto.RecordStructure.decode(protoBytes)
+		expect(decoded.currentSession?.senderChain?.chainKey?.index).toBe(0)
+	})
+})
+
+describe('wrap-legacy-store: ratchet semantic equivalence after Rust→JS', () => {
+	const senderRatchet = fill(33, 2)
+	const receiverRatchet = fill(33, 5)
+
+	test('JS derives the same msg key Rust would derive natively', async () => {
+		const k0 = Buffer.from(fill(32, 99))
+		const { keyAfterNSteps: k3 } = walkChain(k0, 3)
+		const rec = await writeProtoAndReadJS(buildBridgeProto({ initialChainKey: k3, senderRustIndex: 3 }))
+		const chain = chainFor(rec, senderRatchet)
+
+		expect(chain.chainKey.counter).toBe(2)
+		expect(chain.chainKey.key.equals(k3)).toBe(true)
+
+		const jsChain: JSChainShape = {
+			chainKey: { counter: chain.chainKey.counter, key: chain.chainKey.key },
+			chainType: chain.chainType,
+			messageKeys: {}
+		}
+		jsFillMessageKeys(jsChain, 3)
+		const { msgKeys: expected } = walkChain(k0, 4)
+		expect(jsChain.messageKeys[3]!.equals(expected[3]!)).toBe(true)
+	})
+
+	test('receiver chain decrypts the next inbound msg after roundtrip', async () => {
+		const k0 = Buffer.from(fill(32, 33))
+		const { keyAfterNSteps: kN } = walkChain(k0, 5)
+		const rec = await writeProtoAndReadJS(
+			buildBridgeProto({ initialChainKey: kN, senderRustIndex: 0, receiverRustIndex: 5 })
+		)
+		const chain = chainFor(rec, receiverRatchet)
+		expect(chain.chainKey.counter).toBe(4)
+
+		const jsChain: JSChainShape = {
+			chainKey: { counter: chain.chainKey.counter, key: chain.chainKey.key },
+			chainType: chain.chainType,
+			messageKeys: {}
+		}
+		jsFillMessageKeys(jsChain, 5)
+		const { msgKeys: expected } = walkChain(k0, 6)
+		expect(jsChain.messageKeys[5]!.equals(expected[5]!)).toBe(true)
+	})
+
+	test('Rust→JS→Rust is a fixed point for chain state (index + bytes)', async () => {
+		const initial = Buffer.from(fill(32, 77))
+		const original = buildBridgeProto({
+			initialChainKey: initial,
+			senderRustIndex: 4,
+			receiverRustIndex: 6
+		})
+		const { wrapped } = await makeWrapped()
+		await wrapped.set('session', BRIDGE_SESSION_KEY_LID, original)
+		const round = (await wrapped.get('session', BRIDGE_SESSION_KEY_LID)) as Uint8Array
+		const decoded = bridgeProto.RecordStructure.decode(round)
+
+		expect(decoded.currentSession?.senderChain?.chainKey?.index).toBe(4)
+		expect(decoded.currentSession?.receiverChains?.[0]?.chainKey?.index).toBe(6)
+		expect(Buffer.from(decoded.currentSession?.senderChain?.chainKey?.key ?? []).equals(initial)).toBe(true)
+		expect(Buffer.from(decoded.currentSession?.receiverChains?.[0]?.chainKey?.key ?? []).equals(initial)).toBe(true)
+	})
+})

--- a/src/Utils/wrap-legacy-store.ts
+++ b/src/Utils/wrap-legacy-store.ts
@@ -554,10 +554,15 @@ const CHAIN_TYPE_RECEIVING = 2
 const BASE_KEY_TYPE_OURS = 1
 const BASE_KEY_TYPE_THEIRS = 2
 
-const b64 = (b: Uint8Array | undefined | null): string =>
-	b ? Buffer.from(b).toString('base64') : Buffer.alloc(0).toString('base64')
+// Non-nullable to keep the empty-vs-missing distinction visible at call sites.
+const b64 = (b: Uint8Array): string => Buffer.from(b).toString('base64')
+const fromB64 = (s: string): Buffer => Buffer.from(s, 'base64')
 
-const fromB64 = (s: string | undefined | null): Buffer => (s ? Buffer.from(s, 'base64') : Buffer.alloc(0))
+const EMPTY_BYTES = new Uint8Array()
+
+// Rust `chain_key.index` and JS `chainKey.counter` differ by 1 (fresh = 0 vs -1).
+const rustIndexToJsCounter = (index: number | null | undefined): number => (index ?? 0) - 1
+const jsCounterToRustIndex = (counter: number): number => counter + 1
 
 // Reuse the proto-types interfaces directly so `RecordStructure.create({…})`
 // type-checks without casts. `proto.SessionStructure.IChain` etc. live under
@@ -583,6 +588,8 @@ function deriveProtoMessageKey(seed: Buffer, counter: number): BridgeMessageKeyP
 	const t1 = expand(Buffer.alloc(0), 0x01)
 	const t2 = expand(t1, 0x02)
 	const t3 = expand(t2, 0x03)
+	// Message keys use the same counter/index value in both impls — only the
+	// chain key has the off-by-one (see `rustIndexToJsCounter`).
 	return {
 		index: counter,
 		cipherKey: new Uint8Array(t1),
@@ -626,23 +633,24 @@ function sessionStructureToEntry(session: BridgeSessionProto, closedTs: number):
 			? lastReceiver.senderRatchetKey
 			: !weAreAlice && session.aliceBaseKey && session.aliceBaseKey.length > 0
 				? session.aliceBaseKey
-				: new Uint8Array()
+				: EMPTY_BYTES
 
-	const senderRatchetPub = session.senderChain.senderRatchetKey ?? new Uint8Array()
-	const senderRatchetPriv = session.senderChain.senderRatchetKeyPrivate ?? new Uint8Array()
+	const senderRatchetPub = session.senderChain.senderRatchetKey ?? EMPTY_BYTES
+	const senderRatchetPriv = session.senderChain.senderRatchetKeyPrivate ?? EMPTY_BYTES
 
 	const _chains: Record<string, UpstreamChainEntry> = {}
-	if (session.senderChain.chainKey?.key && senderRatchetPub.length > 0) {
+	const senderChainKey = session.senderChain.chainKey
+	if (senderChainKey?.key?.length && senderRatchetPub.length > 0) {
 		_chains[b64(senderRatchetPub)] = {
-			chainKey: { counter: session.senderChain.chainKey.index ?? 0, key: b64(session.senderChain.chainKey.key) },
+			chainKey: { counter: rustIndexToJsCounter(senderChainKey.index), key: b64(senderChainKey.key) },
 			chainType: CHAIN_TYPE_SENDING,
 			messageKeys: {}
 		}
 	}
 	for (const rc of receiverChains) {
-		if (!rc.chainKey?.key || !rc.senderRatchetKey || rc.senderRatchetKey.length === 0) continue
+		if (!rc.chainKey?.key?.length || !rc.senderRatchetKey?.length) continue
 		_chains[b64(rc.senderRatchetKey)] = {
-			chainKey: { counter: rc.chainKey.index ?? 0, key: b64(rc.chainKey.key) },
+			chainKey: { counter: rustIndexToJsCounter(rc.chainKey.index), key: b64(rc.chainKey.key) },
 			chainType: CHAIN_TYPE_RECEIVING,
 			messageKeys: {}
 		}
@@ -663,7 +671,7 @@ function sessionStructureToEntry(session: BridgeSessionProto, closedTs: number):
 			closed: closedTs,
 			used: now,
 			created: now,
-			remoteIdentityKey: b64(session.remoteIdentityPublic ?? new Uint8Array())
+			remoteIdentityKey: b64(session.remoteIdentityPublic ?? EMPTY_BYTES)
 		},
 		_chains
 	}
@@ -711,8 +719,11 @@ function entryToSessionStructure(entry: UpstreamSessionEntry): BridgeSessionProt
 		senderRatchetKey: new Uint8Array(senderRatchetPub),
 		senderRatchetKeyPrivate: new Uint8Array(senderRatchetPriv),
 		chainKey: senderChainEntry
-			? { index: senderChainEntry.chainKey.counter, key: new Uint8Array(fromB64(senderChainEntry.chainKey.key)) }
-			: { index: 0, key: new Uint8Array() },
+			? {
+					index: jsCounterToRustIndex(senderChainEntry.chainKey.counter),
+					key: new Uint8Array(fromB64(senderChainEntry.chainKey.key))
+				}
+			: { index: 0, key: EMPTY_BYTES },
 		messageKeys: [] // sender chain is sequential — no skipped cache either side
 	}
 
@@ -721,7 +732,7 @@ function entryToSessionStructure(entry: UpstreamSessionEntry): BridgeSessionProt
 		if (ch.chainType !== CHAIN_TYPE_RECEIVING) continue
 		receiverChains.push({
 			senderRatchetKey: new Uint8Array(fromB64(k)),
-			chainKey: { index: ch.chainKey.counter, key: new Uint8Array(fromB64(ch.chainKey.key)) },
+			chainKey: { index: jsCounterToRustIndex(ch.chainKey.counter), key: new Uint8Array(fromB64(ch.chainKey.key)) },
 			// JS holds 32-byte HMAC seeds; Rust holds the post-HKDF split.
 			// Lossless JS→Rust derivation via deriveProtoMessageKey.
 			messageKeys: jsChainMessageKeysToProto(ch.messageKeys)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an off-by-one mismatch in chain-key index mapping between implementations, ensuring consistent session state handling.

* **Tests**
  * Added comprehensive test suites validating chain-key index/counter conversion accuracy and semantic equivalence across roundtrip operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oxidezap/baileyrs/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->