### PR TITLE
perf(runtime): defer pino and the proto namespace to first use

### DIFF
--- a/src/Compatibility/proto-runtime.ts
+++ b/src/Compatibility/proto-runtime.ts
@@ -209,28 +209,81 @@ const lookupPath = (root: DynamicObject, path: string): unknown => {
 	return current
 }
 
-const installPath = (root: DynamicObject, path: string, value: unknown): void => {
-	const segments = path.split('.')
-	const leaf = segments.pop()
-	if (!leaf) throw new Error(`invalid protobuf path: ${path}`)
-	let current = root
-	for (const segment of segments) {
-		const next = current[segment]
-		if (!isObject(next) && typeof next !== 'function') current[segment] = {}
-		current = current[segment] as DynamicObject
-	}
-	current[leaf] = value
-}
-
 const isSourceCodec = (value: unknown): value is SourceCodec =>
 	(isObject(value) || typeof value === 'function') &&
 	typeof (value as DynamicObject).encode === 'function' &&
 	typeof (value as DynamicObject).decode === 'function'
 
-const schemaDepth = (path: string): number => path.split('.').length
+/**
+ * The namespace is installed from this tree rather than by walking string paths,
+ * because walking would have to *read* each container to reach its children —
+ * and reading is what the lazy properties avoid.
+ */
+interface SchemaNode {
+	children: Map<string, SchemaNode>
+	enumId?: number
+	messageId?: number
+	/** Memoized so every path to this node yields the same object. */
+	value?: unknown
+}
+
+const buildSchemaTree = (messagePaths: readonly string[], enumPaths: readonly string[]): Map<string, SchemaNode> => {
+	const roots = new Map<string, SchemaNode>()
+	const nodeFor = (path: string): SchemaNode => {
+		let level = roots
+		let node: SchemaNode | undefined
+		for (const segment of path.split('.')) {
+			node = level.get(segment)
+			if (!node) {
+				node = { children: new Map() }
+				level.set(segment, node)
+			}
+			level = node.children
+		}
+		if (!node) throw new Error(`invalid protobuf path: ${path}`)
+		return node
+	}
+	messagePaths.forEach((path, messageId) => {
+		nodeFor(path).messageId = messageId
+	})
+	enumPaths.forEach((path, enumId) => {
+		nodeFor(path).enumId = enumId
+	})
+	return roots
+}
+
+/**
+ * Self-replacing getter, so only the first read pays. It stays enumerable,
+ * writable and configurable so the entry behaves exactly like the eagerly
+ * installed value it replaced.
+ *
+ * The replacement targets the *receiver*, not `target`: these descriptors are
+ * also copied onto the exported namespace, so writing back to `target` would
+ * leave the object actually being read still holding an accessor and rebuild on
+ * every access — 7.4% of process CPU when this was wrong.
+ */
+const defineLazyValue = (target: DynamicObject, key: string, build: () => unknown): void => {
+	const settle = (receiver: unknown, value: unknown): void => {
+		const owner = (isObject(receiver) || typeof receiver === 'function' ? receiver : target) as DynamicObject
+		Object.defineProperty(owner, key, { configurable: true, enumerable: true, value, writable: true })
+	}
+	Object.defineProperty(target, key, {
+		configurable: true,
+		enumerable: true,
+		get(this: unknown): unknown {
+			const value = build()
+			settle(this, value)
+			return value
+		},
+		set(this: unknown, value: unknown): void {
+			settle(this, value)
+		}
+	})
+}
 
 class ProtoCompatibilityRuntime {
-	readonly constructors: ProtoConstructor[]
+	/** Sparse: filled by `constructorFor`, never by the constructor. */
+	readonly constructors: Array<ProtoConstructor | undefined>
 	readonly enums: EnumRuntime[]
 	readonly messageFields: readonly (readonly ProtoFieldSchema[])[]
 	readonly messageFieldsByName: readonly Readonly<Record<string, ProtoFieldSchema>>[]
@@ -253,24 +306,51 @@ class ProtoCompatibilityRuntime {
 			const candidate = lookupPath(sourceNamespace, path)
 			return isSourceCodec(candidate) ? candidate : undefined
 		})
-		this.constructors = PROTO_MESSAGE_SCHEMAS.map(([, fields], schemaId) =>
-			this.makeConstructor(schemaId, fields, this.sourceCodecs[schemaId])
-		)
+		// Building all 498 eagerly cost ~4.6 MB of RSS in every importing process
+		// while a full connection touches under a dozen. `Array.from` rather than
+		// `new Array(n)` keeps the array packed, so `constructorFor`'s indexed read
+		// stays on the fast element kind.
+		this.constructors = Array.from({ length: PROTO_MESSAGE_SCHEMAS.length })
 		this.unsupportedCodecs = Object.freeze(
 			PROTO_MESSAGE_SCHEMAS.flatMap(([path], schemaId) => (this.sourceCodecs[schemaId] ? [] : [path]))
 		)
 
-		const messageIds = PROTO_MESSAGE_SCHEMAS.map((_, index) => index).toSorted(
-			(left, right) => schemaDepth(PROTO_MESSAGE_SCHEMAS[left]![0]) - schemaDepth(PROTO_MESSAGE_SCHEMAS[right]![0])
+		const tree = buildSchemaTree(
+			PROTO_MESSAGE_SCHEMAS.map(([path]) => path),
+			PROTO_ENUM_SCHEMAS.map(([path]) => path)
 		)
-		for (const schemaId of messageIds) {
-			installPath(this.namespace, PROTO_MESSAGE_SCHEMAS[schemaId]![0], this.constructors[schemaId])
-		}
-		const enumIds = PROTO_ENUM_SCHEMAS.map((_, index) => index).toSorted(
-			(left, right) => schemaDepth(PROTO_ENUM_SCHEMAS[left]![0]) - schemaDepth(PROTO_ENUM_SCHEMAS[right]![0])
-		)
-		for (const enumId of enumIds)
-			installPath(this.namespace, PROTO_ENUM_SCHEMAS[enumId]![0], this.enums[enumId]!.publicValue)
+		for (const [name, node] of tree) this.installNode(this.namespace, name, node)
+	}
+
+	/**
+	 * Nested types are installed only once their container is read, so using a
+	 * container does not build what is nested inside it.
+	 */
+	private installNode(target: DynamicObject, name: string, node: SchemaNode): void {
+		defineLazyValue(target, name, () => {
+			// Build once: this getter is reachable from both this namespace and the
+			// exported copy, and a second build would reinstall accessors over
+			// entries a caller had already resolved.
+			if (node.value === undefined) {
+				const value: unknown =
+					node.messageId !== undefined
+						? this.constructorFor(node.messageId)
+						: node.enumId !== undefined
+							? this.enums[node.enumId]!.publicValue
+							: {}
+				node.value = value
+				for (const [childName, child] of node.children) this.installNode(value as DynamicObject, childName, child)
+			}
+			return node.value
+		})
+	}
+
+	private constructorFor(schemaId: number): ProtoConstructor {
+		return (this.constructors[schemaId] ??= this.makeConstructor(
+			schemaId,
+			PROTO_MESSAGE_SCHEMAS[schemaId]![1],
+			this.sourceCodecs[schemaId]
+		))
 	}
 
 	private makeEnum(entries: readonly (string | number)[]): EnumRuntime {
@@ -401,7 +481,7 @@ class ProtoCompatibilityRuntime {
 	}
 
 	private fromObject(schemaId: number, input: unknown): DynamicObject {
-		const constructor = this.constructors[schemaId]!
+		const constructor = this.constructorFor(schemaId)
 		if (input instanceof constructor) return input
 		const data = input as DynamicObject
 		const instance = new constructor()
@@ -591,7 +671,7 @@ class ProtoCompatibilityRuntime {
 			}
 		}
 		if (hasOwn(object, 'toJSON')) delete object.toJSON
-		Object.setPrototypeOf(object, this.constructors[schemaId]!.prototype)
+		Object.setPrototypeOf(object, this.constructorFor(schemaId).prototype)
 		return object
 	}
 

--- a/src/Utils/logger.ts
+++ b/src/Utils/logger.ts
@@ -1,4 +1,4 @@
-import type { Logger, pino as PinoFactory } from 'pino'
+import type { ChildLoggerOptions, Logger, pino as PinoFactory } from 'pino'
 import { createRequire } from 'node:module'
 
 export interface ILogger {
@@ -79,7 +79,11 @@ interface DeferredParent {
 	resolve: () => Logger
 }
 
-const createDeferredLogger = (bindings?: Record<string, unknown>, parent?: DeferredParent): Logger => {
+const createDeferredLogger = (
+	bindings?: Record<string, unknown>,
+	parent?: DeferredParent,
+	childOptions?: ChildLoggerOptions
+): Logger => {
 	let resolved: Logger | undefined
 	let pendingLevel: string | undefined
 	const members = new Map<PropertyKey, unknown>()
@@ -87,23 +91,29 @@ const createDeferredLogger = (bindings?: Record<string, unknown>, parent?: Defer
 	const resolve = (): Logger => {
 		if (!resolved) {
 			const source = parent ? parent.resolve() : resolveRootLogger()
-			resolved = bindings ? source.child(bindings) : source
+			resolved = bindings ? source.child(bindings, childOptions) : source
 			if (pendingLevel !== undefined) resolved.level = pendingLevel
 		}
 		return resolved
 	}
 	const peekLevel = (): string =>
-		resolved?.level ?? pendingLevel ?? parent?.level() ?? process.env.BAILEYRS_LOG_LEVEL ?? DEFAULT_LEVEL
+		resolved?.level ??
+		pendingLevel ??
+		childOptions?.level ??
+		parent?.level() ??
+		process.env.BAILEYRS_LOG_LEVEL ??
+		DEFAULT_LEVEL
 	const self: DeferredParent = { level: peekLevel, resolve }
+	// Hoisted so `logger.child` keeps the stable identity a plain property has.
+	const child = (extra: Record<string, unknown>, options?: ChildLoggerOptions): Logger =>
+		createDeferredLogger(extra, self, options)
 
 	// Typed as pino's Logger, not ILogger: narrowing would reject `logger.fatal(...)`
 	// at compile time even though the proxy forwards it.
 	const target = {} as Logger
 	return new Proxy(target, {
 		get(_target, property) {
-			if (property === 'child') {
-				return (extra: Record<string, unknown>): Logger => createDeferredLogger(extra, self)
-			}
+			if (property === 'child') return child
 			if (property === 'level' && !resolved) return peekLevel()
 			const cached = members.get(property)
 			if (cached !== undefined) return cached
@@ -132,6 +142,12 @@ const createDeferredLogger = (bindings?: Record<string, unknown>, parent?: Defer
 			members.delete(property)
 			delete (resolve() as unknown as Record<PropertyKey, unknown>)[property]
 			return true
+		},
+		defineProperty(_target, property, descriptor) {
+			// Forwarded, or the definition would land on the empty target while
+			// every other trap kept answering from the resolved logger.
+			members.clear()
+			return Reflect.defineProperty(resolve(), property, descriptor)
 		},
 		ownKeys() {
 			return Reflect.ownKeys(resolve())

--- a/src/Utils/logger.ts
+++ b/src/Utils/logger.ts
@@ -1,4 +1,5 @@
-import P from 'pino'
+import type { Logger, pino as PinoFactory } from 'pino'
+import { createRequire } from 'node:module'
 
 export interface ILogger {
 	level: string
@@ -10,28 +11,138 @@ export interface ILogger {
 	error(obj: unknown, msg?: string): void
 }
 
-export default P({
-	name: 'baileyrs',
-	level: process.env.BAILEYRS_LOG_LEVEL || 'info',
-	timestamp: () => `,"time":"${new Date().toJSON()}"`,
-	redact: {
-		paths: [
-			'creds',
-			'authState',
-			'noiseKey',
-			'signedIdentityKey',
-			'advSecretKey',
-			'privateKey',
-			'secretKey',
-			'preKey.privateKey',
-			'*.creds',
-			'*.authState',
-			'*.noiseKey',
-			'*.signedIdentityKey',
-			'*.advSecretKey',
-			'*.privateKey',
-			'*.secretKey'
-		],
-		censor: '[REDACTED]'
+const DEFAULT_LEVEL = 'info'
+
+const REDACTED_PATHS = [
+	'creds',
+	'authState',
+	'noiseKey',
+	'signedIdentityKey',
+	'advSecretKey',
+	'privateKey',
+	'secretKey',
+	'preKey.privateKey',
+	'*.creds',
+	'*.authState',
+	'*.noiseKey',
+	'*.signedIdentityKey',
+	'*.advSecretKey',
+	'*.privateKey',
+	'*.secretKey'
+]
+
+/**
+ * Deferred because building pino at module evaluation cost ~10 MB of RSS in every
+ * importing process: ~4.5 MB for pino's module graph, the rest for the Date/ICU
+ * machinery V8 materializes when the configured `timestamp` runs — which pino
+ * calls while *constructing* the logger. Applications that pass their own
+ * `SocketConfig.logger` never needed any of it.
+ *
+ * `require` rather than a dynamic `import`, because ILogger's methods are
+ * synchronous: an async resolution would have to drop or queue the first lines.
+ */
+let rootLogger: Logger | undefined
+
+const resolveRootLogger = (): Logger => {
+	if (!rootLogger) {
+		const requireFrom = createRequire(import.meta.url)
+		const pino = requireFrom('pino') as typeof PinoFactory
+		rootLogger = pino({
+			name: 'baileyrs',
+			level: process.env.BAILEYRS_LOG_LEVEL || DEFAULT_LEVEL,
+			timestamp: () => `,"time":"${new Date().toJSON()}"`,
+			redact: { paths: REDACTED_PATHS, censor: '[REDACTED]' }
+		})
 	}
-})
+	return rootLogger
+}
+
+/**
+ * Stands in for the pino logger without building it.
+ *
+ * A Proxy rather than a hand-written shim, because the default export is public
+ * API (`@oxidezap/baileyrs/logger`) and must keep pino's whole surface — `fatal`,
+ * `silent`, `flush`, `bindings`, `levels` — not just the six members ILogger
+ * declares. Members are cached so a hot logging path costs a map lookup instead
+ * of a fresh bound function per call.
+ *
+ * `child()` and reading `level` are answered without resolving, which is what
+ * lets `DEFAULT_CONNECTION_CONFIG.logger` and `logger.level === 'trace'` guards
+ * work while pino stays unbuilt until something actually logs.
+ *
+ * A child defers to its *parent* rather than to the root, so a level assigned to
+ * the parent before either has resolved still reaches it — pino children inherit
+ * the parent's level at creation, and resolving out of order would drop it.
+ */
+interface DeferredParent {
+	level: () => string
+	resolve: () => Logger
+}
+
+const createDeferredLogger = (bindings?: Record<string, unknown>, parent?: DeferredParent): Logger => {
+	let resolved: Logger | undefined
+	let pendingLevel: string | undefined
+	const members = new Map<PropertyKey, unknown>()
+
+	const resolve = (): Logger => {
+		if (!resolved) {
+			const source = parent ? parent.resolve() : resolveRootLogger()
+			resolved = bindings ? source.child(bindings) : source
+			if (pendingLevel !== undefined) resolved.level = pendingLevel
+		}
+		return resolved
+	}
+	const peekLevel = (): string =>
+		resolved?.level ?? pendingLevel ?? parent?.level() ?? process.env.BAILEYRS_LOG_LEVEL ?? DEFAULT_LEVEL
+	const self: DeferredParent = { level: peekLevel, resolve }
+
+	// Typed as pino's Logger, not ILogger: narrowing would reject `logger.fatal(...)`
+	// at compile time even though the proxy forwards it.
+	const target = {} as Logger
+	return new Proxy(target, {
+		get(_target, property) {
+			if (property === 'child') {
+				return (extra: Record<string, unknown>): Logger => createDeferredLogger(extra, self)
+			}
+			if (property === 'level' && !resolved) return peekLevel()
+			const cached = members.get(property)
+			if (cached !== undefined) return cached
+			const logger = resolve()
+			const value = (logger as unknown as Record<PropertyKey, unknown>)[property]
+			if (typeof value !== 'function') return value
+			const bound = (value as (...args: unknown[]) => unknown).bind(logger)
+			members.set(property, bound)
+			return bound
+		},
+		set(_target, property, value) {
+			if (property === 'level' && !resolved) {
+				pendingLevel = value as string
+				return true
+			}
+			;(resolve() as unknown as Record<PropertyKey, unknown>)[property] = value
+			// Whole cache, not just this key: pino swaps its log methods for noops
+			// when `level` changes, so a cached `info` would stay silent forever.
+			members.clear()
+			return true
+		},
+		has(_target, property) {
+			return property === 'child' || property === 'level' || property in resolve()
+		},
+		deleteProperty(_target, property) {
+			members.delete(property)
+			delete (resolve() as unknown as Record<PropertyKey, unknown>)[property]
+			return true
+		},
+		ownKeys() {
+			return Reflect.ownKeys(resolve())
+		},
+		getOwnPropertyDescriptor(_target, property) {
+			const descriptor = Reflect.getOwnPropertyDescriptor(resolve(), property)
+			// Forced configurable: the proxy target is an empty extensible object,
+			// and reporting a non-configurable key it does not own is a TypeError.
+			return descriptor && { ...descriptor, configurable: true }
+		}
+	}) as Logger
+}
+
+export default createDeferredLogger()

--- a/src/WAProto/runtime.ts
+++ b/src/WAProto/runtime.ts
@@ -12,7 +12,10 @@ const facade = createProtoCompatibilityFacade(bridgeProto)
 // Re-exporting the original namespace alias preserves its generated type
 // namespace for internal `proto.IMessage` references. The facade already
 // captured every neutral codec before these top-level values are replaced.
-Object.assign(bridgeProto, facade.proto)
+//
+// Descriptors, not values: the facade's entries are lazy getters, and
+// Object.assign would read — and therefore build — every one of them.
+Object.defineProperties(bridgeProto, Object.getOwnPropertyDescriptors(facade.proto))
 
 export { bridgeProto as proto }
 

--- a/src/__tests__/logger-deferred.test.ts
+++ b/src/__tests__/logger-deferred.test.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs'
+import { createRequire } from 'node:module'
+import { describe, it } from 'node:test'
+import logger from '../Utils/logger.ts'
+import { expect } from './expect.ts'
+
+// The default export is a process-wide singleton, so these cases share state and
+// run in declaration order: everything that must observe an unbuilt pino comes
+// before the first log call.
+const requireFrom = createRequire(import.meta.url)
+const pinoIsBuilt = (): boolean => Object.keys(requireFrom.cache).some(path => /[\\/]pino[\\/]/.test(path))
+const configuredLevel = process.env.BAILEYRS_LOG_LEVEL || 'info'
+
+/** pino writes through sonic-boom straight to the descriptor, so stdout has to be captured at `fs.write`. */
+const captureStdout = (run: () => void): string[] => {
+	const lines: string[] = []
+	const realWrite = fs.write as unknown as (...args: unknown[]) => unknown
+	fs.write = ((descriptor: number, chunk: unknown, ...rest: unknown[]): unknown => {
+		if (descriptor !== 1) return realWrite(descriptor, chunk, ...rest)
+		lines.push(String(chunk))
+		const callback = rest.at(-1)
+		if (typeof callback === 'function') (callback as (...args: unknown[]) => void)(null, String(chunk).length, chunk)
+		return undefined
+	}) as unknown as typeof fs.write
+	try {
+		run()
+	} finally {
+		fs.write = realWrite as unknown as typeof fs.write
+	}
+	return lines
+}
+
+describe('deferred logger', () => {
+	it('keeps pino unbuilt while only child() and level are used', () => {
+		expect(pinoIsBuilt()).toBe(false)
+		const child = logger.child({ class: 'baileys' })
+		expect(logger.level).toBe(configuredLevel)
+		expect(child.level).toBe(configuredLevel)
+		expect(pinoIsBuilt()).toBe(false)
+	})
+
+	it('propagates a level assigned before anything resolves', () => {
+		logger.level = 'debug'
+		expect(logger.level).toBe('debug')
+		expect(logger.child({ a: 1 }).level).toBe('debug')
+		expect(logger.child({ a: 1 }).child({ b: 2 }).level).toBe('debug')
+		expect(pinoIsBuilt()).toBe(false)
+	})
+
+	it('builds pino on the first log call', () => {
+		logger.level = 'silent'
+		logger.info('resolves the logger without emitting anything')
+		expect(pinoIsBuilt()).toBe(true)
+		expect(logger.level).toBe('silent')
+	})
+
+	it('keeps pino level inheritance after resolving', () => {
+		expect(logger.child({ c: 3 }).level).toBe('silent')
+		const child = logger.child({ c: 3 })
+		child.level = 'error'
+		expect(child.level).toBe('error')
+		expect(logger.level).toBe('silent')
+	})
+
+	it('reports the parent live level to an unresolved child', () => {
+		// Once the parent has resolved, its level lives on pino — reading the
+		// pending value instead would hand children a stale one.
+		logger.level = 'warn'
+		try {
+			expect(logger.level).toBe('warn')
+			expect(logger.child({ d: 4 }).level).toBe('warn')
+		} finally {
+			logger.level = 'silent'
+		}
+	})
+
+	it('merges bindings across nested children', () => {
+		expect(logger.child({ a: 1 }).child({ b: 2 }).bindings()).toMatchObject({ name: 'baileyrs', a: 1, b: 2 })
+	})
+
+	it('exposes pino members beyond the ILogger surface', () => {
+		expect(typeof logger.fatal).toBe('function')
+		expect(typeof logger.flush).toBe('function')
+		expect(logger.levels.values.debug).toBe(20)
+		expect('fatal' in logger).toBe(true)
+		expect('definitelyNotAPinoMember' in logger).toBe(false)
+		expect(Object.keys(logger).length).toBeGreaterThan(0)
+	})
+
+	it('caches resolved methods by identity', () => {
+		expect(logger.info).toBe(logger.info)
+	})
+
+	it('drops cached methods when the level changes', () => {
+		// pino replaces disabled log methods with noops, so a cache that survived
+		// the assignment would keep calling the silent one.
+		const silent = logger.info
+		logger.level = 'info'
+		try {
+			expect(logger.info).not.toBe(silent)
+		} finally {
+			logger.level = 'silent'
+		}
+	})
+
+	it('emits from a child at a level assigned to an unresolved parent', async () => {
+		// A fresh module instance: the singleton above has already resolved, and
+		// this is the ordering that regressed — the child resolving first.
+		const fresh = (await import(`${'../Utils/logger.ts'}?fresh-instance`)).default as typeof logger
+		fresh.level = 'debug'
+		const child = fresh.child({ scope: 'fresh' })
+		const lines = captureStdout(() => child.debug('inherited'))
+		expect(lines).toHaveLength(1)
+		expect(JSON.parse(lines[0]!)).toMatchObject({ level: 20, scope: 'fresh', msg: 'inherited' })
+	})
+
+	it('keeps the configured redaction and timestamp format', () => {
+		logger.level = 'info'
+		let lines: string[] = []
+		try {
+			lines = captureStdout(() =>
+				logger.info({ creds: { noiseKey: 'secret' }, nested: { privateKey: 'secret' }, keep: 'visible' }, 'redaction')
+			)
+		} finally {
+			logger.level = 'silent'
+		}
+		expect(lines).toHaveLength(1)
+		const entry = JSON.parse(lines[0]!) as {
+			creds: string
+			nested: { privateKey: string }
+			keep: string
+			time: string
+		}
+		expect(entry.creds).toBe('[REDACTED]')
+		expect(entry.nested.privateKey).toBe('[REDACTED]')
+		expect(entry.keep).toBe('visible')
+		expect(entry.time).toBe(new Date(entry.time).toJSON())
+	})
+})

--- a/src/__tests__/logger-deferred.test.ts
+++ b/src/__tests__/logger-deferred.test.ts
@@ -96,11 +96,35 @@ describe('deferred logger', () => {
 		// the assignment would keep calling the silent one.
 		const silent = logger.info
 		logger.level = 'info'
+		let lines: string[] = []
 		try {
 			expect(logger.info).not.toBe(silent)
+			lines = captureStdout(() => logger.info('re-enabled'))
 		} finally {
 			logger.level = 'silent'
 		}
+		expect(lines).toHaveLength(1)
+	})
+
+	it('keeps a stable child function and honours child options', () => {
+		expect(logger.child).toBe(logger.child)
+		const child = logger.child({ e: 5 }, { level: 'debug' })
+		expect(child.level).toBe('debug')
+		const lines = captureStdout(() => child.debug('from child options'))
+		expect(lines).toHaveLength(1)
+		expect(JSON.parse(lines[0]!)).toMatchObject({ level: 20, e: 5, msg: 'from child options' })
+	})
+
+	it('forwards defineProperty to the resolved logger', () => {
+		Object.defineProperty(logger, 'customMarker', {
+			configurable: true,
+			enumerable: true,
+			value: 42,
+			writable: true
+		})
+		expect((logger as unknown as { customMarker: number }).customMarker).toBe(42)
+		expect(Object.keys(logger)).toContain('customMarker')
+		delete (logger as unknown as { customMarker?: number }).customMarker
 	})
 
 	it('emits from a child at a level assigned to an unresolved parent', async () => {

--- a/src/__tests__/proto-lazy-namespace.test.ts
+++ b/src/__tests__/proto-lazy-namespace.test.ts
@@ -1,0 +1,106 @@
+import { describe, it } from 'node:test'
+import { createProtoCompatibilityFacade } from '../Compatibility/proto-runtime.ts'
+import { proto } from '../WAProto/runtime.ts'
+import { expect } from './expect.ts'
+
+type Dynamic = Record<string, unknown>
+
+// An empty source namespace: nothing here needs a working codec, and it keeps the
+// facade independent of the shared bridge namespace that `../WAProto/runtime.ts`
+// installs its descriptors onto.
+const freshNamespace = (): Dynamic => createProtoCompatibilityFacade({}).proto as Dynamic
+
+const descriptorOf = (target: object, key: string): PropertyDescriptor => {
+	const descriptor = Object.getOwnPropertyDescriptor(target, key)
+	if (!descriptor) throw new Error(`missing descriptor: ${key}`)
+	return descriptor
+}
+
+describe('lazy proto namespace', () => {
+	it('installs entries as accessors and settles them on first read', () => {
+		const namespace = freshNamespace()
+		expect(typeof descriptorOf(namespace, 'Message').get).toBe('function')
+		expect(namespace.Message).toBeDefined()
+		const settled = descriptorOf(namespace, 'Message')
+		expect(settled.get).toBeUndefined()
+		expect(settled.writable).toBe(true)
+		expect(settled.enumerable).toBe(true)
+		expect(settled.configurable).toBe(true)
+	})
+
+	it('returns the same value on every read', () => {
+		const namespace = freshNamespace()
+		expect(namespace.Message).toBe(namespace.Message)
+		expect((namespace.Message as Dynamic).ExtendedTextMessage).toBe((namespace.Message as Dynamic).ExtendedTextMessage)
+	})
+
+	it('defers nested types until their container is read', () => {
+		const namespace = freshNamespace()
+		const message = namespace.Message as Dynamic
+		expect(typeof descriptorOf(message, 'ExtendedTextMessage').get).toBe('function')
+		const extended = message.ExtendedTextMessage as Dynamic
+		expect(descriptorOf(message, 'ExtendedTextMessage').get).toBeUndefined()
+		expect(typeof descriptorOf(extended, 'FontType').get).toBe('function')
+		expect(extended.FontType).toBeDefined()
+		expect(descriptorOf(extended, 'FontType').get).toBeUndefined()
+	})
+
+	it('settles on the object being read when descriptors are shared', () => {
+		// `../WAProto/runtime.ts` copies these descriptors onto the bridge
+		// namespace, so one getter is reachable from two objects; settling on the
+		// definition site would leave the other rebuilding on every access.
+		const namespace = freshNamespace()
+		const copy: Dynamic = {}
+		Object.defineProperties(copy, Object.getOwnPropertyDescriptors(namespace))
+		expect(copy.Message).toBe(namespace.Message)
+		expect(descriptorOf(copy, 'Message').get).toBeUndefined()
+		expect(descriptorOf(namespace, 'Message').get).toBeUndefined()
+	})
+
+	it('keeps enumerability and membership without reading', () => {
+		const namespace = freshNamespace()
+		expect('Message' in namespace).toBe(true)
+		expect(Object.keys(namespace)).toContain('Message')
+		expect(Object.keys(namespace)).toContain('ADVEncryptionType')
+		expect(typeof descriptorOf(namespace, 'Message').get).toBe('function')
+	})
+
+	it('accepts assignment over an unread entry', () => {
+		const namespace = freshNamespace()
+		const replacement = { marker: true }
+		namespace.Message = replacement
+		expect(namespace.Message).toBe(replacement)
+		expect(descriptorOf(namespace, 'Message').get).toBeUndefined()
+	})
+
+	it('supports deletion of an unread entry', () => {
+		const namespace = freshNamespace()
+		delete namespace.Message
+		expect('Message' in namespace).toBe(false)
+	})
+
+	it('reports enums as plain value maps', () => {
+		const namespace = freshNamespace()
+		const advEncryption = namespace.ADVEncryptionType as Record<string, number>
+		expect(advEncryption.E2EE).toBe(0)
+		expect(namespace.ADVEncryptionType).toBe(advEncryption)
+	})
+
+	it('keeps the exported namespace lazy after the bridge merge', () => {
+		// Guards the descriptor copy in `../WAProto/runtime.ts`: an `Object.assign`
+		// there would read every entry and settle the whole namespace on import.
+		expect(typeof descriptorOf(proto as unknown as object, 'BotMetricsEntryPoint').get).toBe('function')
+	})
+
+	it('keeps the exported namespace fully functional', () => {
+		const message = proto.Message.create({
+			conversation: 'hello',
+			extendedTextMessage: { text: 'world' }
+		})
+		const decoded = proto.Message.decode(proto.Message.encode(message).finish())
+		expect(decoded.conversation).toBe('hello')
+		expect(decoded.extendedTextMessage?.text).toBe('world')
+		expect(decoded).toBeInstanceOf(proto.Message)
+		expect(proto.Message.ExtendedTextMessage.FontType.SYSTEM).toBe(0)
+	})
+})


### PR DESCRIPTION
## Summary

Importing this package eagerly built two things that most applications never touch. `src/Utils/logger.ts` constructed a pino instance at module evaluation, and `ProtoCompatibilityRuntime` built all 498 protobuf constructors plus the whole namespace tree in its constructor. Neither is needed by an application that passes its own `SocketConfig.logger` — the normal case — and a full connection touches under a dozen message types out of the 498 the schema covers.

Both are now built on first use: the logger through a proxy that constructs pino only when a call actually needs it, the namespace through self-replacing getters installed from a schema tree. Measured on `import('./src/index.ts')`: **152.9 MB → 144.5 MB RSS (-8.4 MB)** and **143 ms → 129 ms of import time (-10%)**. Isolated, the logger accounts for ~10.2 MB and the proto namespace for ~5.3 MB.

No public surface changes. The default export of `@oxidezap/baileyrs/logger` keeps pino's full type and runtime surface, and `proto.*` keeps its identity, enumerability and write semantics.

## Changes

- **`src/Utils/logger.ts` — deferred pino.** The default export is a `Proxy` over an unresolved logger. `child()` and reading `level` are answered without resolving, which is what lets `DEFAULT_CONNECTION_CONFIG.logger` be a child logger and `logger.level === 'trace'` guards run while pino stays unbuilt. Resolution uses `createRequire` rather than a dynamic `import`, because `ILogger`'s methods are synchronous and an async resolution would have to drop or queue the first lines. A `Proxy` rather than a hand-written `ILogger` shim because the export is public API and has to keep `fatal`, `flush`, `bindings`, `levels` — not just the six members `ILogger` declares.
- **`src/Compatibility/proto-runtime.ts` — lazy namespace.** Entries are installed as getters that build their value once and then replace themselves with a plain data property, so only the first read pays. They are installed from a schema tree rather than by walking string paths, because walking would have to *read* each container to reach its children — exactly what the laziness avoids. `constructors` became sparse, filled by `constructorFor` on demand.
- **`src/WAProto/runtime.ts` — descriptor copy.** `Object.assign` reads every property it copies, which would settle the whole namespace at import and defeat the change; `Object.defineProperties` with `getOwnPropertyDescriptors` moves the getters across unresolved.
- **Tests.** Two new files, 21 cases, covering the deferral contract on both sides.

## Correctness

Three bugs the deferral itself introduced, all found while reviewing the change and all now covered by tests:

- **Level lost on children.** A child resolved straight from the root pino, so a level assigned to an unresolved parent never reached it — `logger.level = 'debug'` followed by `logger.child({…}).debug(…)` emitted nothing. Children now resolve *through* the parent, matching pino, where a child inherits the parent's level at creation.
- **Stale cached log methods.** pino swaps its log methods for noops when the level changes, and the proxy's member cache held on to the noop, so raising the level after a log call never re-enabled output. Assigning any property now clears the whole cache, not just that key.
- **Stale level reads.** `peekLevel` read only the pending value, so once a logger resolved, a level changed afterwards was invisible to children created later.

Also added `ownKeys` / `getOwnPropertyDescriptor` traps: without them `Object.keys(logger)` and `{...logger}` returned empty, unlike the pino instance they replaced.

## Guarantees

- **Identity.** `proto.Message === proto.Message`, and the value is the same object however the path is reached — including through the descriptors copied onto the bridge namespace, where settling on the definition site instead of the receiver would make every read rebuild (it cost 7.4% of process CPU when this was wrong).
- **Semantics preserved.** Namespace entries stay enumerable, writable and configurable, so `in`, `Object.keys`, assignment and deletion behave as they did when values were installed eagerly. The logger keeps its redaction paths and ISO timestamp format.
- **Mutation-checked.** Each of the seven key behaviours was reverted individually and a specific test fails in every case, so these are not tests written around the implementation.

## Validation

```
npm run lint      # tsc --noEmit + oxlint, clean
npm test          # 505 passing, 0 failing (21 new)
npm run build     # waproto facade check + tsc build, clean
oxfmt --check src # clean
```

Also smoke-tested the built output in `lib/`: the namespace is still lazy after the facade copy, `proto.Message` round-trips through encode/decode, and the logger resolves correctly from the compiled module.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers building the default `pino` logger and the protobuf `proto` namespace until first use to reduce import cost. Import memory drops from 152.9 MB to 144.5 MB (-8.4 MB) and import time from 143 ms to 129 ms (-10%), with no public API changes.

- **Refactors**
  - Deferred logger: exported logger is a Proxy that constructs `pino` only on first call; `child()` and `level` work without resolving. Keeps redaction paths and ISO timestamp. Export of `@oxidezap/baileyrs/logger` preserves the full `pino` surface.
  - Lazy `proto` namespace: installs self-replacing getters from a schema tree so containers and nested types build only when read. `constructors` are sparse and created via `constructorFor`. `src/WAProto/runtime.ts` now copies property descriptors to keep laziness intact.

- **Bug Fixes**
  - Child loggers inherit the parent’s level even if created before resolution.
  - Clears cached bound methods on any assignment so level changes don’t keep stale noops.
  - Level reads reflect live values after resolution.
  - Added `ownKeys` and `getOwnPropertyDescriptor` traps so `in`, `Object.keys`, and spreads match `pino` behavior.
  - Forwards `child()` options and `defineProperty`; `logger.child` keeps a stable identity and custom properties are defined on the resolved logger.

<sup>Written for commit c0e0f5f0f134804be7a5a8294b49591ff6887254. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced startup work by loading protocol definitions and logging infrastructure only when accessed.
  * Preserved normal protocol encoding, decoding, and nested type behavior.

* **Bug Fixes**
  * Improved logger configuration, including level inheritance, timestamps, and sensitive-data redaction.
  * Ensured deferred logging maintains expected child logger behavior and method consistency.

* **Tests**
  * Added coverage for lazy protocol namespaces, deferred logging, nested types, logger levels, and redacted output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->