### PR TITLE
feat: inflate history sync through the bridge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@oxidezap/baileyrs",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxidezap/baileyrs",
-      "version": "0.0.32",
+      "version": "0.0.33",
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5",
-        "whatsapp-rust-bridge": "0.6.0-alpha.42"
+        "whatsapp-rust-bridge": "0.6.0-alpha.43"
       },
       "devDependencies": {
         "@bufbuild/protobuf": "^2.13.0",
@@ -3177,9 +3177,9 @@
       }
     },
     "node_modules/whatsapp-rust-bridge": {
-      "version": "0.6.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.6.0-alpha.42.tgz",
-      "integrity": "sha512-PfEWoKwRA8f186rroyq+ILX196OBGM2jPsgCLxmTxsa4eMmg/9ZAw/B6K3Hd+jpmlMWGiKXvd1RcjHNejBbX3g==",
+      "version": "0.6.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.6.0-alpha.43.tgz",
+      "integrity": "sha512-bBSQig0E4AFYacTKhP73P9RTxZYzOGrQSxrAszjtIkAwpdWSS5IqSw1yEfXo80P6X1u0egzK4KdadSCd/upQOg==",
       "license": "MIT"
     },
     "node_modules/win-guid": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oxidezap/baileyrs",
   "type": "module",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "A Rust-powered WhatsApp Web library for JavaScript, with a Baileys-compatible API",
   "keywords": [
     "whatsapp",
@@ -78,7 +78,7 @@
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5",
-    "whatsapp-rust-bridge": "0.6.0-alpha.42"
+    "whatsapp-rust-bridge": "0.6.0-alpha.43"
   },
   "devDependencies": {
     "@bufbuild/protobuf": "^2.13.0",

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -942,9 +942,12 @@ export const downloadContentFromMessage = async (
 		)
 	}
 
+	// `url` is seeded because the media guard downstream keys off its presence,
+	// and content addressed only by `directPath` (history-sync notifications
+	// carry no `url` field at all) would otherwise be rejected as non-media.
 	const fakeMessage = {
 		key: {} as WAMessage['key'],
-		message: { [`${type}Message`]: mediaContent } as WAMessageContent
+		message: { [`${type}Message`]: { url: null, ...mediaContent } } as WAMessageContent
 	} as WAMessage
 
 	return downloadMediaMessage(fakeMessage, 'stream', opts, {

--- a/src/Utils/process-history-message.ts
+++ b/src/Utils/process-history-message.ts
@@ -11,9 +11,7 @@
  * keeping the WAProto namespace as our re-export.
  */
 
-import { pipeline } from 'node:stream/promises'
-import { promisify } from 'node:util'
-import { createInflate, inflate } from 'node:zlib'
+import { inflateZlib } from 'whatsapp-rust-bridge'
 import { proto } from '../WAProto/runtime.ts'
 import type { Chat, Contact, LIDMapping, WAMessage } from '../Types/index.ts'
 import { WAProto } from '../Types/index.ts'
@@ -25,7 +23,6 @@ import { downloadContentFromMessage, normalizeMessageContent } from './messages.
 import { createSparseArray } from './sparse-array.ts'
 
 const STUB = WAProto.WebMessageInfo.StubType
-const inflatePromise = promisify(inflate)
 
 const extractPnFromMessages = (messages: proto.IHistorySyncMsg[]): string | undefined => {
 	for (let index = 0; index < messages.length; index++) {
@@ -219,11 +216,9 @@ export const downloadHistory = async (
 	options: RequestInit
 ): Promise<proto.HistorySync> => {
 	const stream = await downloadContentFromMessage(msg, 'md-msg-hist', { options })
-	const inflater = createInflate()
-	const chunks: Buffer[] = []
-	inflater.on('data', (chunk: Buffer) => chunks.push(chunk))
-	await pipeline(stream, inflater)
-	return proto.HistorySync.decode(Buffer.concat(chunks))
+	const compressed: Buffer[] = []
+	for await (const chunk of stream) compressed.push(chunk as Buffer)
+	return proto.HistorySync.decode(inflateZlib(Buffer.concat(compressed)))
 }
 
 /** Resolve inline or external history-sync content and normalize its public payload. */
@@ -233,7 +228,7 @@ export const downloadAndProcessHistorySyncNotification = async (
 	logger?: ILogger
 ): Promise<ProcessedHistorySync> => {
 	const historyMsg = msg.initialHistBootstrapInlinePayload
-		? proto.HistorySync.decode(await inflatePromise(msg.initialHistBootstrapInlinePayload))
+		? proto.HistorySync.decode(inflateZlib(msg.initialHistBootstrapInlinePayload))
 		: await downloadHistory(msg, options)
 
 	return processHistoryMessage(historyMsg, logger)

--- a/src/__tests__/history-sync-inflate.test.ts
+++ b/src/__tests__/history-sync-inflate.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from 'node:test'
+import { deflateSync } from 'node:zlib'
+import type { WasmWhatsAppClient } from 'whatsapp-rust-bridge'
+import { proto } from '../WAProto/runtime.ts'
+import { _registerActiveBridgeClient } from '../Utils/messages.ts'
+import { downloadAndProcessHistorySyncNotification, downloadHistory } from '../Utils/process-history-message.ts'
+import { expect } from './expect.ts'
+
+const historySync = (pushnames: number): Uint8Array =>
+	proto.HistorySync.encode({
+		syncType: proto.HistorySync.HistorySyncType.PUSH_NAME,
+		pushnames: Array.from({ length: pushnames }, (_, index) => ({
+			id: `55119999${String(index).padStart(5, '0')}@s.whatsapp.net`,
+			pushname: `Contact ${index}`
+		}))
+	}).finish()
+
+/** Serves `bytes` split into `chunkSize` pieces, so the concat path is exercised. */
+const clientStreaming = (bytes: Uint8Array, chunkSize: number): WasmWhatsAppClient =>
+	({
+		downloadMediaStream: () =>
+			new ReadableStream<Uint8Array>({
+				start(controller) {
+					for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+						controller.enqueue(bytes.subarray(offset, offset + chunkSize))
+					}
+					controller.close()
+				}
+			})
+	}) as unknown as WasmWhatsAppClient
+
+const mediaNotification = {
+	directPath: '/v/history',
+	mediaKey: new Uint8Array(32),
+	fileSha256: new Uint8Array(32),
+	fileEncSha256: new Uint8Array(32),
+	fileLength: 1
+}
+
+describe('history-sync inflate through the bridge', () => {
+	it('decodes an inline compressed payload', async () => {
+		const result = await downloadAndProcessHistorySyncNotification(
+			{ initialHistBootstrapInlinePayload: deflateSync(historySync(1)) },
+			{}
+		)
+		expect(result.contacts).toEqual([{ id: '5511999900000@s.whatsapp.net', notify: 'Contact 0' }])
+	})
+
+	it('decodes a payload larger than the inflater scratch buffer', async () => {
+		const result = await downloadAndProcessHistorySyncNotification(
+			{ initialHistBootstrapInlinePayload: deflateSync(historySync(5000)) },
+			{}
+		)
+		expect(result.contacts).toHaveLength(5000)
+		expect(result.contacts[4999]).toEqual({ id: '5511999904999@s.whatsapp.net', notify: 'Contact 4999' })
+	})
+
+	it('reassembles a chunked download before inflating', async () => {
+		const compressed = deflateSync(historySync(300))
+		_registerActiveBridgeClient(clientStreaming(compressed, 64))
+		const history = await downloadHistory(mediaNotification, {})
+		expect(history.pushnames).toHaveLength(300)
+		expect(history.syncType).toBe(proto.HistorySync.HistorySyncType.PUSH_NAME)
+	})
+
+	it('survives a download delivered as a single chunk', async () => {
+		const compressed = deflateSync(historySync(10))
+		_registerActiveBridgeClient(clientStreaming(compressed, compressed.length))
+		const history = await downloadHistory(mediaNotification, {})
+		expect(history.pushnames).toHaveLength(10)
+	})
+
+	it('rejects a payload that is not a zlib stream', async () => {
+		await expect(
+			downloadAndProcessHistorySyncNotification({ initialHistBootstrapInlinePayload: Buffer.from('not zlib') }, {})
+		).rejects.toThrow()
+	})
+
+	it('rejects a truncated compressed payload', async () => {
+		const truncated = deflateSync(historySync(50)).subarray(0, 20)
+		_registerActiveBridgeClient(clientStreaming(truncated, 8))
+		await expect(downloadHistory(mediaNotification, {})).rejects.toThrow()
+	})
+})


### PR DESCRIPTION
The bridge now exposes a bounded zlib inflate, so the two compat entry points that still reached for node:zlib can use it. That drops node:zlib, node:util and node:stream/promises from this module and puts the decompression on the same pooled, size-capped inflater the core already uses for its own history-sync path, instead of a second implementation with no ceiling.

downloadHistory also fixes a guard it could never pass: downloadContentFromMessage built its synthetic media message straight from the caller's content, and the media check downstream keys off the presence of `url`. A HistorySyncNotification has no such field, so the call failed as "not a media message" for every real notification. Seeding a null `url` keeps the directPath and mediaKey checks doing the real validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch history sync decompression to the bounded, pooled inflater in `whatsapp-rust-bridge` to align with core and drop Node zlib usage. Also fix the media guard so real history notifications download correctly.

- **Bug Fixes**
  - Seed `url: null` in the synthetic media message so the media check runs; validation now relies on `directPath` and `mediaKey` and accepts real `HistorySyncNotification`s.

- **Dependencies**
  - Remove `node:zlib`, `node:util`, and `node:stream/promises`.

<sup>Written for commit 78a10ae326a26c836e5544fad53eeacfc3a21df2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

