### PR TITLE
fix(deps): bump @oxidezap/whatsapp-rust-bridge to 0.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.6.0",
+        "@oxidezap/whatsapp-rust-bridge": "0.6.4",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -974,9 +974,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.6.0.tgz",
-      "integrity": "sha512-VXVlJbrHzE9I7NnSIA9mkeWk+UTTde2DKHs3lhe/GKpuZfZxqCOCm5H8EY2+fFTYrwi84CqkyXOU/55wygMzFA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.6.4.tgz",
+      "integrity": "sha512-SvKAucV7m2G/Pa7e6J6mPQKauuANP8sy1E4Kh4e4u3E//jzhwz18JDFzqspuGPl5XuQL4MshqADU8P5c7H3lZA==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -75,10 +75,10 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
+    "@oxidezap/whatsapp-rust-bridge": "0.6.4",
     "long": "^5.3.2",
     "pino": "^10.3.1",
-    "protobufjs": "^7.6.5",
-    "@oxidezap/whatsapp-rust-bridge": "0.6.0"
+    "protobufjs": "^7.6.5"
   },
   "devDependencies": {
     "@bufbuild/protobuf": "^2.13.0",

--- a/src/__tests__/e2e/handle-probe.ts
+++ b/src/__tests__/e2e/handle-probe.ts
@@ -53,7 +53,10 @@ const GC_SETTLE_MS = 60
  * upgrade fails loudly here instead of silently reporting zero leaks.
  */
 function instrument(source: string): string {
-	const created = source.match(/function (\w+)\(\w+,\w+,\w+\)\{let (\w+)=\{a:\w+,b:\w+,cnt:1\}/)
+	// `[\w$]` rather than `\w`: `$` is a valid identifier character and the
+	// minifier does emit it, so a name like `h$` slipped past a `\w+` and read
+	// as a wasm-bindgen shape change that had not happened.
+	const created = source.match(/function ([\w$]+)\([\w$]+,[\w$]+,[\w$]+\)\{let ([\w$]+)=\{a:[\w$]+,b:[\w$]+,cnt:1\}/)
 	if (!created) throw new Error('handle probe: closure helper not found in the bridge bundle')
 	let out = source.replace(created[0], created[0].replace('{let ', '{globalThis.__handleProbe.made++;let '))
 
@@ -61,7 +64,7 @@ function instrument(source: string): string {
 	// hooks in at the unref assignment that follows them. That assignment sits
 	// inside a `return` sequence, so the hook has to be an expression: keying
 	// live handles by the record lets survivors be reported with their stack.
-	const unref = out.match(/(\w+)\._wbg_cb_unref=\(\)=>\{if\(--(\w+)\.cnt===0\)/)
+	const unref = out.match(/([\w$]+)\._wbg_cb_unref=\(\)=>\{if\(--([\w$]+)\.cnt===0\)/)
 	if (!unref) throw new Error('handle probe: unref hook not found in the bridge bundle')
 	out = out.replace(
 		unref[0],
@@ -69,7 +72,7 @@ function instrument(source: string): string {
 			`${unref[0]}globalThis.__handleProbe.freed++,globalThis.__handleProbe.alive.delete(${unref[2]}),`
 	)
 
-	const finalizer = out.match(/new FinalizationRegistry\(\((\w+)\)=>(\w+)\.__wbindgen_export5\(\1\.a,\1\.b\)\)/)
+	const finalizer = out.match(/new FinalizationRegistry\(\(([\w$]+)\)=>([\w$]+)\.__wbindgen_export5\(\1\.a,\1\.b\)\)/)
 	if (!finalizer) throw new Error('handle probe: closure FinalizationRegistry not found in the bridge bundle')
 	out = out.replace(
 		finalizer[0],


### PR DESCRIPTION
Takes the bridge release that restores the type declarations.

`0.6.3` shipped a `.d.ts` missing **183 of its 297** exported types while still declaring methods that referenced them, so the earlier bump attempt failed to typecheck here — `dts-drift` caught it, along with four `TS2305: has no exported member` errors on `UsyncQuery`, `UsyncResponse` and `UsyncUser`. `0.6.4` is back to 297, with the 29 `Usync` declarations present.

Verified against the published tarball before bumping, not just by the version number:

```
0.6.0  297 exported types  (29 Usync)
0.6.3  114                 ( 0)        <- broken
0.6.4  297                 (29)        <- this
```

## Checks

536/536 tests, `npm run lint` (tsc + oxlint) clean, `oxfmt --check` clean, `npm run build` fine. Lockfile resolves from the registry with the matching integrity.

## On the commit type

`fix(deps):`, not `chore(deps):` — only feat/fix/perf produce a release, so a chore-typed bump would sit on `main` unpublished until an unrelated commit dragged it out. That is the convention #17 documents in the release workflow header, and this repo previously used `chore(deps):` for exactly this kind of change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `@oxidezap/whatsapp-rust-bridge` to 0.6.4 to restore the full `.d.ts` (including all Usync types) and resolve TS2305 errors introduced in 0.6.3. Also update the handle-probe test to match `$` in minified identifiers so the leak check hooks correctly.

<sup>Written for commit 2e16f3c5d8e97eb41707deb9944d41ef5e831a3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

