### PR TITLE
fix(connection)!: make close mean the socket is finished, as upstream does

### DIFF
--- a/Example/example.ts
+++ b/Example/example.ts
@@ -57,7 +57,38 @@ const byteFmt = (bytes: number) => {
 /** `<failure reason="405">` — the wire code baileyrs reports for an outdated build. */
 const CLIENT_OUTDATED_STATUS = 405
 
-const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+/**
+ * `setTimeout` caps at 2^31-1 ms (~24.8 days) and fires *immediately* past
+ * that, so a long temporary ban would reconnect at once instead of waiting it
+ * out. Chunked so the wait actually holds.
+ */
+const delay = async (ms: number) => {
+	const MAX_TIMEOUT_MS = 2_147_483_647
+	let left = ms
+	while (left > 0) {
+		const chunk = Math.min(left, MAX_TIMEOUT_MS)
+		await new Promise(resolve => setTimeout(resolve, chunk))
+		left -= chunk
+	}
+}
+
+/**
+ * Keep trying to rebuild the socket, detached from any event handler.
+ *
+ * Used when the first attempt threw: giving up there would leave the bot
+ * offline for good, which is the failure this whole reconnect path exists to
+ * avoid.
+ */
+const reconnectLater = async (attempt = 1): Promise<void> => {
+	const backoffMs = Math.min(60_000, 5_000 * 2 ** (attempt - 1))
+	await delay(backoffMs)
+	try {
+		await startSock()
+	} catch (err) {
+		logger.error({ err, attempt, backoffMs }, 'reconnect attempt failed')
+		return reconnectLater(attempt + 1)
+	}
+}
 
 /**
  * How long to wait before replacing a terminally closed socket, or `undefined`
@@ -148,8 +179,18 @@ const startSock = async () => {
 						logger.fatal({ statusCode }, 'connection closed for good; not reconnecting')
 					} else {
 						logger.warn({ statusCode, retryDelayMs }, 'connection closed for good, starting a new socket')
-						if (retryDelayMs > 0) await delay(retryDelayMs)
-						await startSock()
+						// `ev.process` invokes this handler with `void handler(events)`
+						// and attaches no rejection handler, so anything thrown here —
+						// `fetchLatestWaWebVersion()` failing, the auth store refusing
+						// to load — becomes an unhandled rejection that can take the
+						// process down, and the bot stays offline either way.
+						try {
+							if (retryDelayMs > 0) await delay(retryDelayMs)
+							await startSock()
+						} catch (err) {
+							logger.error({ err }, 'failed to start the replacement socket; retrying')
+							void reconnectLater()
+						}
 					}
 					// This socket is spent; the rest of the batch would run
 					// against a closed one. `benchmark.ts` does the same.

--- a/Example/example.ts
+++ b/Example/example.ts
@@ -54,6 +54,41 @@ const byteFmt = (bytes: number) => {
 	return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`
 }
 
+/** `<failure reason="405">` — the wire code baileyrs reports for an outdated build. */
+const CLIENT_OUTDATED_STATUS = 405
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+/**
+ * How long to wait before replacing a terminally closed socket, or `undefined`
+ * when replacing it is pointless.
+ *
+ * A `close` from baileyrs always means the engine gave up, but "gave up" covers
+ * failures with very different answers. Reconnecting immediately on all of them
+ * turns a temporary ban or an outdated build into a create/teardown loop that
+ * hammers the server, because the replacement is rejected just as fast.
+ */
+const reconnectDelayFor = (statusCode: number | undefined, error: Boom | undefined): number | undefined => {
+	switch (statusCode) {
+		case DisconnectReason.loggedOut:
+			// Needs a fresh pairing, not a fresh socket.
+			return undefined
+		case CLIENT_OUTDATED_STATUS:
+			// The server rejected this build; the next one is rejected too.
+			return undefined
+		case DisconnectReason.forbidden: {
+			// Temporary ban. `expire` is unix-seconds, carried on the Boom's data.
+			const expire = (error?.data as { expire?: number } | undefined)?.expire
+			if (!expire) return undefined
+			return Math.max(0, expire * 1000 - Date.now())
+		}
+		default:
+			// A replaced session, an expired CAT, a generic failure: worth
+			// another socket, but not instantly.
+			return 5_000
+	}
+}
+
 // start a connection
 const startSock = async () => {
 	// Two auth modes:
@@ -94,7 +129,8 @@ const startSock = async () => {
 				const update = events['connection.update']
 				const { connection, lastDisconnect, qr } = update
 				if (connection === 'close') {
-					const statusCode = (lastDisconnect?.error as Boom)?.output?.statusCode
+					const boom = lastDisconnect?.error as Boom | undefined
+					const statusCode = boom?.output?.statusCode
 					// `close` means this socket is finished, exactly as in upstream
 					// Baileys. Transient drops never reach here: the Rust engine
 					// retries those on a fibonacci backoff and reports
@@ -105,10 +141,14 @@ const startSock = async () => {
 					// a replaced session, an outdated build, a temporary ban, an
 					// unrecoverable <failure>. Ignoring it leaves the bot offline
 					// for good.
-					if (statusCode === DisconnectReason.loggedOut) {
-						logger.fatal('Connection closed. You are logged out.')
+					// Recreating blindly is as wrong as ignoring it: several of
+					// these reject the replacement just as fast.
+					const retryDelayMs = reconnectDelayFor(statusCode, boom)
+					if (retryDelayMs === undefined) {
+						logger.fatal({ statusCode }, 'connection closed for good; not reconnecting')
 					} else {
-						logger.warn({ statusCode }, 'connection closed for good, starting a new socket')
+						logger.warn({ statusCode, retryDelayMs }, 'connection closed for good, starting a new socket')
+						if (retryDelayMs > 0) await delay(retryDelayMs)
 						await startSock()
 					}
 					// This socket is spent; the rest of the batch would run

--- a/Example/example.ts
+++ b/Example/example.ts
@@ -111,6 +111,9 @@ const startSock = async () => {
 						logger.warn({ statusCode }, 'connection closed for good, starting a new socket')
 						await startSock()
 					}
+					// This socket is spent; the rest of the batch would run
+					// against a closed one. `benchmark.ts` does the same.
+					return
 				}
 
 				if (qr) {

--- a/Example/example.ts
+++ b/Example/example.ts
@@ -95,11 +95,22 @@ const startSock = async () => {
 				const { connection, lastDisconnect, qr } = update
 				if (connection === 'close') {
 					const statusCode = (lastDisconnect?.error as Boom)?.output?.statusCode
+					// `close` means this socket is finished, exactly as in upstream
+					// Baileys. Transient drops never reach here: the Rust engine
+					// retries those on a fibonacci backoff and reports
+					// `connection: 'connecting'`, so recreating the socket below
+					// can never race one the engine is still restoring.
+					//
+					// What does reach here is a disconnect the engine gave up on —
+					// a replaced session, an outdated build, a temporary ban, an
+					// unrecoverable <failure>. Ignoring it leaves the bot offline
+					// for good.
 					if (statusCode === DisconnectReason.loggedOut) {
 						logger.fatal('Connection closed. You are logged out.')
+					} else {
+						logger.warn({ statusCode }, 'connection closed for good, starting a new socket')
+						await startSock()
 					}
-					// Other disconnects are handled automatically by the Rust engine
-					// (auto-reconnect with fibonacci backoff). No need to call startSock().
 				}
 
 				if (qr) {

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ need no source changes**. Two things do:
 
 - Carrying an existing pairing across takes a one-line import swap, see
   [Migrating from Upstream Baileys](#migrating-from-upstream-baileys).
-- If your `connection.update` handler was written for a baileyrs before
-  0.1, see [Gotchas](#gotchas): a `close` now always means the socket is
-  finished, and you have to recreate it. Code written against upstream
+- If your `connection.update` handler was written for a version of baileyrs
+  before 0.1, see [Gotchas](#gotchas): a `close` now always means the socket
+  is finished, and you have to recreate it. Code written against upstream
   Baileys already does the right thing.
 
 
@@ -98,7 +98,10 @@ async function connectToWhatsApp() {
             if (statusCode === DisconnectReason.loggedOut) {
                 console.log('Logged out')
             } else {
-                connectToWhatsApp()
+                // Back off first: a temporary ban (403, with an `expire` on
+                // `error.data`) or an outdated build (405) rejects the
+                // replacement just as fast. See Gotchas for the full policy.
+                setTimeout(connectToWhatsApp, 5_000)
             }
         }
         if (connection === 'open') {
@@ -182,8 +185,18 @@ A few behaviors that differ from upstream — almost always to your advantage:
   `connection: 'close'` is only emitted once the engine has given up — a
   replaced session, an outdated build, a temporary ban, an unrecoverable
   `<failure>` — and by then the socket has already released its resources.
-  Handle it the upstream way: recreate the socket unless the reason is
-  `loggedOut`. Ignoring it leaves the bot permanently offline.
+  Ignoring it leaves the bot permanently offline, so handle it the upstream
+  way and build a replacement — with three exceptions, because some of those
+  failures reject the replacement just as fast:
+
+  | `statusCode` | what to do |
+  | --- | --- |
+  | `DisconnectReason.loggedOut` (401) | stop; needs a fresh pairing |
+  | `405` | stop; the server rejected this build, and the next one too |
+  | `DisconnectReason.forbidden` (403) | wait until `lastDisconnect.error.data.expire` (unix seconds) — it is a temporary ban |
+  | anything else | reconnect, after a short delay |
+
+  `Example/example.ts` implements exactly this.
 - **No `getMessage` / `cachedGroupMetadata` polyfill required.** The Rust
   side caches group metadata and message keys natively. You can still pass
   them — they're respected as overrides — but they're optional.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,16 @@ import makeWASocket from '@oxidezap/baileyrs'
 ### Drop-in replacement for upstream Baileys
 
 baileyrs is API-compatible with [@whiskeysockets/baileys](https://github.com/WhiskeySockets/Baileys).
-Existing projects switch over by aliasing the package — **no source changes needed**
-(one exception: carrying an existing pairing across takes a one-line import swap,
-see [Migrating from Upstream Baileys](#migrating-from-upstream-baileys)):
+Existing projects switch over by aliasing the package — **the API and imports
+need no source changes**. Two things do:
+
+- Carrying an existing pairing across takes a one-line import swap, see
+  [Migrating from Upstream Baileys](#migrating-from-upstream-baileys).
+- If your `connection.update` handler was written for a baileyrs before
+  0.1, see [Gotchas](#gotchas): a `close` now always means the socket is
+  finished, and you have to recreate it. Code written against upstream
+  Baileys already does the right thing.
+
 
 ```sh
 npm install @whiskeysockets/baileys@npm:@oxidezap/baileyrs
@@ -78,24 +85,31 @@ now resolves to baileyrs.
 import makeWASocket, { Boom, DisconnectReason, useMultiFileAuthState } from '@oxidezap/baileyrs'
 
 const { state } = await useMultiFileAuthState('auth_info')
-const sock = makeWASocket({ auth: state })
 
-sock.ev.on('connection.update', ({ connection, lastDisconnect }) => {
-    if (connection === 'close') {
-        // `close` means this socket is finished — same as upstream Baileys.
-        // Transient drops never get here; the Rust engine retries those and
-        // reports `connecting`.
-        const statusCode = (lastDisconnect?.error as Boom)?.output?.statusCode
-        if (statusCode === DisconnectReason.loggedOut) {
-            console.log('Logged out')
-        } else {
-            connectToWhatsApp()
+async function connectToWhatsApp() {
+    const sock = makeWASocket({ auth: state })
+
+    sock.ev.on('connection.update', ({ connection, lastDisconnect }) => {
+        if (connection === 'close') {
+            // `close` means this socket is finished — same as upstream Baileys.
+            // Transient drops never get here; the Rust engine retries those and
+            // reports `connecting`.
+            const statusCode = (lastDisconnect?.error as Boom)?.output?.statusCode
+            if (statusCode === DisconnectReason.loggedOut) {
+                console.log('Logged out')
+            } else {
+                connectToWhatsApp()
+            }
         }
-    }
-    if (connection === 'open') {
-        console.log('Connected')
-    }
-})
+        if (connection === 'open') {
+            console.log('Connected')
+        }
+    })
+
+    return sock
+}
+
+const sock = await connectToWhatsApp()
 
 sock.ev.on('messages.upsert', ({ messages }) => {
     for (const msg of messages) {

--- a/README.md
+++ b/README.md
@@ -106,17 +106,18 @@ async function connectToWhatsApp() {
         }
     })
 
+    // Register every handler in here. A replacement socket is a new emitter,
+    // so anything attached outside stops firing after the first reconnect.
+    sock.ev.on('messages.upsert', ({ messages }) => {
+        for (const msg of messages) {
+            console.log('received message', msg.key.id)
+        }
+    })
+
     return sock
 }
 
 const sock = await connectToWhatsApp()
-
-sock.ev.on('messages.upsert', ({ messages }) => {
-    for (const msg of messages) {
-        console.log('received message', msg.key.id)
-    }
-})
-
 await sock.sendMessage('1234567890@s.whatsapp.net', { text: 'Hello!' })
 ```
 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,12 @@ async function connectToWhatsApp() {
             if (statusCode === DisconnectReason.loggedOut || statusCode === 405) {
                 console.log('Closed for good', statusCode)
             } else if (statusCode === DisconnectReason.forbidden) {
-                // Temporary ban: `expire` is unix seconds.
+                // Temporary ban: `expire` is unix seconds. A missing or past
+                // expiry means the ban is over — reconnect like any other
+                // terminal close rather than staying offline forever.
                 const expire = (lastDisconnect?.error as Boom)?.data?.expire
                 console.log('Temporarily banned until', expire)
-                if (expire) waitUntil(expire * 1000).then(connectToWhatsApp)
+                waitUntil(typeof expire === 'number' ? expire * 1000 : 0).then(connectToWhatsApp)
             } else {
                 setTimeout(connectToWhatsApp, 5_000)
             }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ so existing integrations can migrate with minimal changes. See
 | Media encrypt/decrypt | Node.js crypto | Rust AES-256-CBC + HMAC |
 | Media upload/download | JS fetch + temp files | Rust with CDN failover, auth refresh, resumable upload |
 | Key management | JS auth state | Rust `PersistenceManager` |
-| Auto-reconnect | Manual `startSock()` loop | Built-in with fibonacci backoff |
+| Auto-reconnect | Manual `startSock()` loop | Transient drops retried in Rust (fibonacci backoff); terminal ones still yours |
 
 ## Documentation
 
@@ -82,11 +82,15 @@ const sock = makeWASocket({ auth: state })
 
 sock.ev.on('connection.update', ({ connection, lastDisconnect }) => {
     if (connection === 'close') {
+        // `close` means this socket is finished — same as upstream Baileys.
+        // Transient drops never get here; the Rust engine retries those and
+        // reports `connecting`.
         const statusCode = (lastDisconnect?.error as Boom)?.output?.statusCode
         if (statusCode === DisconnectReason.loggedOut) {
             console.log('Logged out')
+        } else {
+            connectToWhatsApp()
         }
-        // Auto-reconnect is handled by the Rust engine — no need to call makeWASocket again
     }
     if (connection === 'open') {
         console.log('Connected')
@@ -156,9 +160,15 @@ preserved. No QR re-scan, no logged-out events.
 
 A few behaviors that differ from upstream — almost always to your advantage:
 
-- **Auto-reconnect is built in.** Don't call `makeWASocket()` again from
-  `connection.update`'s `'close'` branch. The Rust engine retries with
-  fibonacci backoff; opening a second socket leaks the first one.
+- **Auto-reconnect is built in, but `close` still means `close`.** The Rust
+  engine retries transient drops on a fibonacci backoff and reports them as
+  `connection: 'connecting'`, so the canonical upstream handler never fires
+  for those and you never end up with two sockets on one account. A
+  `connection: 'close'` is only emitted once the engine has given up — a
+  replaced session, an outdated build, a temporary ban, an unrecoverable
+  `<failure>` — and by then the socket has already released its resources.
+  Handle it the upstream way: recreate the socket unless the reason is
+  `loggedOut`. Ignoring it leaves the bot permanently offline.
 - **No `getMessage` / `cachedGroupMetadata` polyfill required.** The Rust
   side caches group metadata and message keys natively. You can still pass
   them — they're respected as overrides — but they're optional.

--- a/README.md
+++ b/README.md
@@ -101,8 +101,12 @@ async function connectToWhatsApp() {
             if (statusCode === DisconnectReason.loggedOut || statusCode === 405) {
                 console.log('Closed for good', statusCode)
             } else if (statusCode === DisconnectReason.forbidden) {
+                // Temporary ban: `expire` is unix seconds. `Example/example.ts`
+                // chunks the wait, since setTimeout caps at ~24.8 days.
                 const expire = (lastDisconnect?.error as Boom)?.data?.expire
+                const waitMs = expire ? Math.max(0, expire * 1000 - Date.now()) : 0
                 console.log('Temporarily banned until', expire)
+                if (expire) setTimeout(connectToWhatsApp, Math.min(waitMs, 2_147_483_647))
             } else {
                 setTimeout(connectToWhatsApp, 5_000)
             }

--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ import makeWASocket, { Boom, DisconnectReason, useMultiFileAuthState } from '@ox
 
 const { state } = await useMultiFileAuthState('auth_info')
 
+// setTimeout caps at ~2^31-1 ms (~24.8 days) and fires immediately past that,
+// so a long ban has to be waited out in chunks.
+async function waitUntil(deadlineMs: number) {
+    for (let left = deadlineMs - Date.now(); left > 0; left = deadlineMs - Date.now()) {
+        await new Promise(resolve => setTimeout(resolve, Math.min(left, 2_147_483_647)))
+    }
+}
+
 async function connectToWhatsApp() {
     const sock = makeWASocket({ auth: state })
 
@@ -101,12 +109,10 @@ async function connectToWhatsApp() {
             if (statusCode === DisconnectReason.loggedOut || statusCode === 405) {
                 console.log('Closed for good', statusCode)
             } else if (statusCode === DisconnectReason.forbidden) {
-                // Temporary ban: `expire` is unix seconds. `Example/example.ts`
-                // chunks the wait, since setTimeout caps at ~24.8 days.
+                // Temporary ban: `expire` is unix seconds.
                 const expire = (lastDisconnect?.error as Boom)?.data?.expire
-                const waitMs = expire ? Math.max(0, expire * 1000 - Date.now()) : 0
                 console.log('Temporarily banned until', expire)
-                if (expire) setTimeout(connectToWhatsApp, Math.min(waitMs, 2_147_483_647))
+                if (expire) waitUntil(expire * 1000).then(connectToWhatsApp)
             } else {
                 setTimeout(connectToWhatsApp, 5_000)
             }

--- a/README.md
+++ b/README.md
@@ -95,12 +95,15 @@ async function connectToWhatsApp() {
             // Transient drops never get here; the Rust engine retries those and
             // reports `connecting`.
             const statusCode = (lastDisconnect?.error as Boom)?.output?.statusCode
-            if (statusCode === DisconnectReason.loggedOut) {
-                console.log('Logged out')
+            // See the reconnect table under Gotchas: a few terminal closes
+            // reject the replacement just as fast, so they are not worth
+            // retrying — or not yet. `Example/example.ts` has the full policy.
+            if (statusCode === DisconnectReason.loggedOut || statusCode === 405) {
+                console.log('Closed for good', statusCode)
+            } else if (statusCode === DisconnectReason.forbidden) {
+                const expire = (lastDisconnect?.error as Boom)?.data?.expire
+                console.log('Temporarily banned until', expire)
             } else {
-                // Back off first: a temporary ban (403, with an `expire` on
-                // `error.data`) or an outdated build (405) rejects the
-                // replacement just as fast. See Gotchas for the full policy.
                 setTimeout(connectToWhatsApp, 5_000)
             }
         }

--- a/src/Compatibility/websocket-client.ts
+++ b/src/Compatibility/websocket-client.ts
@@ -124,6 +124,11 @@ export class WebSocketClient extends EventEmitter {
 	connect(): void {
 		const client = this.getClient()
 		if (!client || client.isConnected()) return
+		// A close in flight has already told the client to disconnect, which is
+		// exactly what makes `isConnected()` false above. Reopening here would
+		// clear the `closing` phase, and the next `close()` would start a second
+		// disconnect against the same client while the first is still running.
+		if (this.closeState.phase === 'closing') return
 		this.closeState = { phase: 'open' }
 		void client.connect().catch(error => this.emit('error', error))
 	}

--- a/src/Compatibility/websocket-client.ts
+++ b/src/Compatibility/websocket-client.ts
@@ -5,6 +5,12 @@ import { DEF_CALLBACK_PREFIX, DEF_TAG_PREFIX } from '../Defaults/index.ts'
 import type { SocketConfig } from '../Types/index.ts'
 
 type ReadyState = 0 | 1 | 2 | 3
+
+/** Both settled phases carry the same promise, so a late caller awaits the real close. */
+type CloseState =
+	| { readonly phase: 'open' }
+	| { readonly phase: 'closing'; readonly done: Promise<void> }
+	| { readonly phase: 'closed'; readonly done: Promise<void> }
 type EventListener = Parameters<EventEmitter['on']>[1]
 
 const isRawNodeEventName = (eventName: string | symbol): boolean =>
@@ -18,10 +24,13 @@ export class WebSocketClient extends EventEmitter {
 	readonly config: SocketConfig
 	protected readonly socket: { readonly readyState: ReadyState }
 
-	private closing = false
-	private closed = false
-	/** The in-flight `close()`, so a second caller joins it instead of skipping it. */
-	private closingPromise: Promise<void> | undefined
+	/**
+	 * One value rather than a pair of booleans plus a promise that could
+	 * disagree with them. `closing` carries the in-flight close so a second
+	 * caller joins it instead of returning while the first `disconnect()` is
+	 * still running — which is how teardown reached `free()` on a busy client.
+	 */
+	private closeState: CloseState = { phase: 'open' }
 	private readonly getClient: () => WasmWhatsAppClient | undefined
 	private listenerMutationDepth = 0
 
@@ -43,15 +52,15 @@ export class WebSocketClient extends EventEmitter {
 	}
 
 	get isClosed(): boolean {
-		return this.closed
+		return this.closeState.phase === 'closed'
 	}
 
 	get isClosing(): boolean {
-		return this.closing
+		return this.closeState.phase === 'closing'
 	}
 
 	get isConnecting(): boolean {
-		return !this.isOpen && !this.closing && !this.closed
+		return !this.isOpen && this.closeState.phase === 'open'
 	}
 
 	get hasRawNodeListeners(): boolean {
@@ -115,7 +124,7 @@ export class WebSocketClient extends EventEmitter {
 	connect(): void {
 		const client = this.getClient()
 		if (!client || client.isConnected()) return
-		this.closed = false
+		this.closeState = { phase: 'open' }
 		void client.connect().catch(error => this.emit('error', error))
 	}
 
@@ -123,27 +132,30 @@ export class WebSocketClient extends EventEmitter {
 	 * Idempotent, and a second caller joins the first rather than returning
 	 * while it is still going.
 	 *
-	 * The early return used to be bare: `void ws.close(); await sock.end()`
-	 * saw `closing` already set, returned immediately, and let teardown reach
-	 * `free()` with the original `disconnect()` still in flight — the wasm heap
-	 * corruption `bridge-free-safety.test.ts` documents. Awaiting a *second*
-	 * `disconnect()` does not join the first one; sharing the promise does.
+	 * The early return used to be bare: `void ws.close(); await sock.end()` saw
+	 * the flag, returned immediately, and let teardown reach `free()` with the
+	 * original `disconnect()` still in flight — the wasm heap corruption
+	 * `bridge-free-safety.test.ts` documents. Awaiting a *second* `disconnect()`
+	 * does not join the first one.
+	 *
+	 * The state is stored before `disconnect()` is called, and the work is
+	 * deferred by a microtask to make that ordering hold: an inline async body
+	 * runs eagerly to its first `await`, so `disconnect()` would be invoked
+	 * while the state still said `open`, and anything it reaches synchronously
+	 * that calls back into `close()` would issue a second one.
 	 */
 	async close(): Promise<void> {
-		if (this.closed) return
-		if (this.closingPromise) return this.closingPromise
+		if (this.closeState.phase !== 'open') return this.closeState.done
 
-		this.closing = true
-		this.closingPromise = (async () => {
+		const done: Promise<void> = Promise.resolve().then(async () => {
 			try {
 				await this.getClient()?.disconnect()
 			} finally {
-				this.closing = false
-				this.closed = true
-				this.closingPromise = undefined
+				this.closeState = { phase: 'closed', done }
 			}
-		})()
-		return this.closingPromise
+		})
+		this.closeState = { phase: 'closing', done }
+		return done
 	}
 
 	send(str: string | Uint8Array, cb?: (err?: Error) => void): boolean {
@@ -159,8 +171,8 @@ export class WebSocketClient extends EventEmitter {
 
 	private get readyState(): ReadyState {
 		if (this.isOpen) return 1
-		if (this.closing) return 2
-		if (this.closed) return 3
+		if (this.closeState.phase === 'closing') return 2
+		if (this.closeState.phase === 'closed') return 3
 		return 0
 	}
 }

--- a/src/Compatibility/websocket-client.ts
+++ b/src/Compatibility/websocket-client.ts
@@ -20,6 +20,8 @@ export class WebSocketClient extends EventEmitter {
 
 	private closing = false
 	private closed = false
+	/** The in-flight `close()`, so a second caller joins it instead of skipping it. */
+	private closingPromise: Promise<void> | undefined
 	private readonly getClient: () => WasmWhatsAppClient | undefined
 	private listenerMutationDepth = 0
 
@@ -117,15 +119,31 @@ export class WebSocketClient extends EventEmitter {
 		void client.connect().catch(error => this.emit('error', error))
 	}
 
+	/**
+	 * Idempotent, and a second caller joins the first rather than returning
+	 * while it is still going.
+	 *
+	 * The early return used to be bare: `void ws.close(); await sock.end()`
+	 * saw `closing` already set, returned immediately, and let teardown reach
+	 * `free()` with the original `disconnect()` still in flight — the wasm heap
+	 * corruption `bridge-free-safety.test.ts` documents. Awaiting a *second*
+	 * `disconnect()` does not join the first one; sharing the promise does.
+	 */
 	async close(): Promise<void> {
-		if (this.closing || this.closed) return
+		if (this.closed) return
+		if (this.closingPromise) return this.closingPromise
+
 		this.closing = true
-		try {
-			await this.getClient()?.disconnect()
-		} finally {
-			this.closing = false
-			this.closed = true
-		}
+		this.closingPromise = (async () => {
+			try {
+				await this.getClient()?.disconnect()
+			} finally {
+				this.closing = false
+				this.closed = true
+				this.closingPromise = undefined
+			}
+		})()
+		return this.closingPromise
 	}
 
 	send(str: string | Uint8Array, cb?: (err?: Error) => void): boolean {

--- a/src/Socket/bridge-client-owner.ts
+++ b/src/Socket/bridge-client-owner.ts
@@ -167,7 +167,17 @@ export const makeBridgeClientOwner = (opts: BridgeClientOwnerOptions): BridgeCli
 			// `close()` owns the client from the moment it starts, and keeps it
 			// published for the whole of teardown — releasing it here as well
 			// would be two disconnect/free sequences on one handle. Join instead.
-			if (state.phase === 'closing' || state.phase === 'closed') return state.done
+			//
+			// Joining without adopting the failure: `close()` rejects when
+			// teardown rethrows the first auth-store flush error, and this is
+			// best-effort cleanup called from `init()`'s catch. Propagating it
+			// would make `initPromise` reject — which the socket documents as
+			// impossible, relies on for `getClient()`'s error message, and does
+			// not always await, so it could surface as an unhandled rejection.
+			if (state.phase === 'closing' || state.phase === 'closed') {
+				await state.done.catch(() => {})
+				return
+			}
 			if (state.phase !== 'running') return
 
 			const { client } = state

--- a/src/Socket/bridge-client-owner.ts
+++ b/src/Socket/bridge-client-owner.ts
@@ -4,77 +4,95 @@
  * The socket's startup is async and its teardown can start at any point during
  * it — a `sock.end()` right after `makeWASocket()`, an `await using` scope
  * exiting, or a terminal disconnect the dispatcher reports while `init()` is
- * still building the client. That window used to be managed by hand across
- * six closure variables and a scattering of `if (ended) return` checks, which
- * is where every teardown bug in this file came from: startup dereferencing a
+ * still building the client. That window used to be managed by hand across six
+ * closure variables and a scattering of `if (ended) return` checks, which is
+ * where every teardown bug in this file came from: startup dereferencing a
  * handle teardown had already nulled, a client built after teardown with
- * nobody left to free it, and an `end()` that resolved for its second caller
- * while the first was still flushing the auth store.
+ * nobody left to free it, an `end()` that resolved for its second caller while
+ * the first was still flushing, and a re-entrant close releasing the same wasm
+ * handle twice.
  *
- * This gathers that into three operations with names:
+ * All of those are one question — *what phase is this client in?* — so it is
+ * one discriminated union rather than a set of booleans that can disagree:
  *
- *  - `adopt(client)` — startup hands the client over. Returns `false` when
- *    teardown already ran, having freed the client itself, so startup knows to
- *    stop.
- *  - `isClosing()` — the guard startup checks between awaits.
- *  - `close(error)` — runs once, and every later caller awaits that same run
- *    rather than resolving early.
+ * ```
+ *   starting ──adopt()──► running ──close()──► closing ──► closed
+ *      │                     │                    ▲
+ *      └──────close()────────┴──discard()─────────┘
+ * ```
  *
- * Everything the socket owns beyond the client (transport, store flushes, end
- * handlers) goes in the `teardown` hook, which runs exactly once whether or
- * not a client was ever adopted.
+ * Two rules make the whole thing safe, and both are properties of the union
+ * rather than of any individual method:
+ *
+ *  - **The transition is synchronous and happens first.** `close()` publishes
+ *    `closing` — carrying the promise callers await — before any teardown work
+ *    starts, so re-entering it finds an in-flight close instead of starting a
+ *    second one. That is why the work is deferred by a microtask rather than
+ *    started inline: an async body would otherwise run eagerly to its first
+ *    `await`, i.e. before the state was stored.
+ *  - **`closing` still carries the client.** The socket's transport close
+ *    reads it back through `peek()` (`ws.close()` is `getClient()?.disconnect()`),
+ *    so dropping the handle at the start of teardown silently turns that into
+ *    a no-op and moves the disconnect after the auth-store flush. `isClosing()`
+ *    — not `peek()` — is the "should I still be doing work" signal.
  */
 
 import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
 import type { ILogger } from '../Utils/logger.ts'
 
+/**
+ * `closing` keeps the client so teardown can still reach the bridge; `closed`
+ * has handed it back. Both carry the same promise, so a late caller awaits the
+ * real teardown either way.
+ */
+type OwnerState =
+	| { readonly phase: 'starting' }
+	| { readonly phase: 'running'; readonly client: WasmWhatsAppClient }
+	| { readonly phase: 'closing'; readonly client: WasmWhatsAppClient | undefined; readonly done: Promise<void> }
+	| { readonly phase: 'closed'; readonly done: Promise<void> }
+
 export interface BridgeClientOwnerOptions {
 	logger: ILogger
 	/**
 	 * The socket's own shutdown work. Receives the adopted client, if there is
-	 * one, *before* it is released — so it can still talk to the bridge — and
-	 * the error the teardown was started with.
+	 * one, while it is still usable, and the error teardown was started with.
 	 *
-	 * Runs once. Throwing propagates to `close()`'s callers, but the client is
+	 * Runs once. Throwing propagates to `close()`'s callers; the client is
 	 * released either way.
 	 */
 	teardown: (client: WasmWhatsAppClient | undefined, error: Error | undefined) => Promise<void>
 	/**
-	 * Release the adopted client. Separate from `teardown` because ordering
-	 * matters and the two have different failure semantics: this one is
-	 * best-effort and never throws out.
+	 * Hand the client back to the bridge. Separate from `teardown` because
+	 * ordering matters and the two have different failure semantics: this one
+	 * is best-effort and never throws out.
 	 */
 	release: (client: WasmWhatsAppClient) => Promise<void>
 }
 
 export interface BridgeClientOwner {
-	/** The adopted client, or undefined before startup finishes / after close. */
+	/** The client while `running` or `closing`; undefined before and after. */
 	peek: () => WasmWhatsAppClient | undefined
 	/**
 	 * Publish a freshly built client. Returns `false` when teardown has already
-	 * started — the client is released here and the caller must stop; nothing
-	 * else will ever own it.
+	 * started — the client is released here and the caller must stop, because
+	 * nothing else will ever own it.
 	 */
 	adopt: (client: WasmWhatsAppClient) => boolean
-	/** True once `close()` has been requested. Startup checks this between awaits. */
+	/** True from the moment `close()` is called. Startup checks it between awaits. */
 	isClosing: () => boolean
-	/**
-	 * Idempotent teardown. The first call runs it; later callers await that
-	 * same run instead of resolving while it is still going.
-	 */
+	/** Runs teardown once; later callers await that same run. */
 	close: (error: Error | undefined) => Promise<void>
 	/**
-	 * Drop the adopted client without tearing the socket down — for a startup
-	 * that failed after adopting, where the client exists but its read loop
-	 * never started.
+	 * Drop the client without tearing the socket down — for a startup that
+	 * failed after adopting, where the client exists but its read loop never
+	 * started. Joins an in-flight close rather than releasing a client that
+	 * close already owns.
 	 */
 	discard: () => Promise<void>
 	/**
 	 * Resolves once every release this owner started has finished, including
 	 * the one a refused `adopt()` kicks off. Startup awaits it on the way out
-	 * so its own promise does not settle with a release still in flight —
-	 * otherwise `await using` could return while the discarded client is still
-	 * writing to a store the caller is about to delete.
+	 * so its own promise does not settle with a release still in flight.
 	 */
 	settled: () => Promise<void>
 }
@@ -82,9 +100,7 @@ export interface BridgeClientOwner {
 export const makeBridgeClientOwner = (opts: BridgeClientOwnerOptions): BridgeClientOwner => {
 	const { logger, teardown, release } = opts
 
-	let client: WasmWhatsAppClient | undefined
-	let closing = false
-	let closePromise: Promise<void> | undefined
+	let state: OwnerState = { phase: 'starting' }
 	/** Releases started outside `close()`, so `settled()` can join them. */
 	const pendingReleases = new Set<Promise<void>>()
 
@@ -103,66 +119,62 @@ export const makeBridgeClientOwner = (opts: BridgeClientOwnerOptions): BridgeCli
 		return running
 	}
 
-	const runClose = async (error: Error | undefined) => {
-		// Set before the first await so `isClosing()` and `adopt()` see it the
-		// moment `close()` is called, not a tick later.
-		closing = true
-		const adopted = client
-
+	const runClose = async (client: WasmWhatsAppClient | undefined, error: Error | undefined, done: Promise<void>) => {
 		try {
-			// `client` stays published for the whole of `teardown`. The socket's
-			// transport close reads it back through `peek()` — `ws.close()` is
-			// `getClient()?.disconnect()` — and clearing it first silently turned
-			// that into a no-op, moving the disconnect after the auth-store
-			// flush and dropping the closing-session ratchet write it emits.
-			//
-			// So teardown sees a live client and `isClosing()`, not `peek()`, is
-			// the guard for "should I still be doing work".
-			await teardown(adopted, error)
+			await teardown(client, error)
 		} finally {
-			client = undefined
-			if (adopted) await releaseQuietly(adopted)
+			state = { phase: 'closed', done }
+			if (client) await releaseQuietly(client)
 		}
 	}
 
 	return {
-		peek: () => client,
+		peek: () => (state.phase === 'running' || state.phase === 'closing' ? state.client : undefined),
 
 		adopt: candidate => {
-			if (closing) {
+			if (state.phase !== 'starting') {
 				// Teardown has already been through here and found nothing, so
 				// this client would have no owner: nothing would free it and its
-				// read loop would reconnect forever against a socket the caller
-				// already disposed.
+				// read loop would reconnect forever against a disposed socket.
 				void trackRelease(candidate)
 				return false
 			}
-			client = candidate
+			state = { phase: 'running', client: candidate }
 			return true
 		},
 
-		isClosing: () => closing,
+		isClosing: () => state.phase === 'closing' || state.phase === 'closed',
 
 		close: error => {
-			if (closePromise) {
+			if (state.phase === 'closing' || state.phase === 'closed') {
 				logger.trace({ trace: error?.stack }, 'already closing; awaiting the in-flight teardown')
-				return closePromise
+				return state.done
 			}
-			closePromise = runClose(error)
-			return closePromise
+
+			const client = state.phase === 'running' ? state.client : undefined
+			// Deferred by a microtask so the `closing` state below is stored
+			// before any teardown work runs. Calling `runClose` inline would
+			// execute its body eagerly up to the first `await` — teardown starts
+			// by closing the transport — and anything reached synchronously that
+			// calls back into `close()` would find no in-flight close and start
+			// a second teardown, releasing the same wasm handle twice.
+			const done: Promise<void> = Promise.resolve().then(() => runClose(client, error, done))
+			state = { phase: 'closing', client, done }
+			return done
 		},
 
 		discard: async () => {
-			// `close()` keeps the client published for the whole of `teardown`,
-			// so a discard landing in that window would take the very handle
-			// `runClose` already captured and release it a second time — two
-			// disconnect/free sequences on one wasm client, which is the heap
-			// corruption this owner exists to avoid. `close()` owns it from the
-			// moment it starts; joining is the correct answer, not releasing.
-			if (closing) return closePromise
-			const adopted = client
-			client = undefined
-			if (adopted) await trackRelease(adopted)
+			// `close()` owns the client from the moment it starts, and keeps it
+			// published for the whole of teardown — releasing it here as well
+			// would be two disconnect/free sequences on one handle. Join instead.
+			if (state.phase === 'closing' || state.phase === 'closed') return state.done
+			if (state.phase !== 'running') return
+
+			const { client } = state
+			// Back to `starting`, not `closed`: a later `close()` must still run
+			// teardown for everything the socket owns beyond the client.
+			state = { phase: 'starting' }
+			await trackRelease(client)
 		},
 
 		settled: async () => {

--- a/src/Socket/bridge-client-owner.ts
+++ b/src/Socket/bridge-client-owner.ts
@@ -1,0 +1,167 @@
+/**
+ * Owns the bridge client's lifetime.
+ *
+ * The socket's startup is async and its teardown can start at any point during
+ * it — a `sock.end()` right after `makeWASocket()`, an `await using` scope
+ * exiting, or a terminal disconnect the dispatcher reports while `init()` is
+ * still building the client. That window used to be managed by hand across
+ * six closure variables and a scattering of `if (ended) return` checks, which
+ * is where every teardown bug in this file came from: startup dereferencing a
+ * handle teardown had already nulled, a client built after teardown with
+ * nobody left to free it, and an `end()` that resolved for its second caller
+ * while the first was still flushing the auth store.
+ *
+ * This gathers that into three operations with names:
+ *
+ *  - `adopt(client)` — startup hands the client over. Returns `false` when
+ *    teardown already ran, having freed the client itself, so startup knows to
+ *    stop.
+ *  - `isClosing()` — the guard startup checks between awaits.
+ *  - `close(error)` — runs once, and every later caller awaits that same run
+ *    rather than resolving early.
+ *
+ * Everything the socket owns beyond the client (transport, store flushes, end
+ * handlers) goes in the `teardown` hook, which runs exactly once whether or
+ * not a client was ever adopted.
+ */
+
+import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+import type { ILogger } from '../Utils/logger.ts'
+
+export interface BridgeClientOwnerOptions {
+	logger: ILogger
+	/**
+	 * The socket's own shutdown work. Receives the adopted client, if there is
+	 * one, *before* it is released — so it can still talk to the bridge — and
+	 * the error the teardown was started with.
+	 *
+	 * Runs once. Throwing propagates to `close()`'s callers, but the client is
+	 * released either way.
+	 */
+	teardown: (client: WasmWhatsAppClient | undefined, error: Error | undefined) => Promise<void>
+	/**
+	 * Release the adopted client. Separate from `teardown` because ordering
+	 * matters and the two have different failure semantics: this one is
+	 * best-effort and never throws out.
+	 */
+	release: (client: WasmWhatsAppClient) => Promise<void>
+}
+
+export interface BridgeClientOwner {
+	/** The adopted client, or undefined before startup finishes / after close. */
+	peek: () => WasmWhatsAppClient | undefined
+	/**
+	 * Publish a freshly built client. Returns `false` when teardown has already
+	 * started — the client is released here and the caller must stop; nothing
+	 * else will ever own it.
+	 */
+	adopt: (client: WasmWhatsAppClient) => boolean
+	/** True once `close()` has been requested. Startup checks this between awaits. */
+	isClosing: () => boolean
+	/**
+	 * Idempotent teardown. The first call runs it; later callers await that
+	 * same run instead of resolving while it is still going.
+	 */
+	close: (error: Error | undefined) => Promise<void>
+	/**
+	 * Drop the adopted client without tearing the socket down — for a startup
+	 * that failed after adopting, where the client exists but its read loop
+	 * never started.
+	 */
+	discard: () => Promise<void>
+	/**
+	 * Resolves once every release this owner started has finished, including
+	 * the one a refused `adopt()` kicks off. Startup awaits it on the way out
+	 * so its own promise does not settle with a release still in flight —
+	 * otherwise `await using` could return while the discarded client is still
+	 * writing to a store the caller is about to delete.
+	 */
+	settled: () => Promise<void>
+}
+
+export const makeBridgeClientOwner = (opts: BridgeClientOwnerOptions): BridgeClientOwner => {
+	const { logger, teardown, release } = opts
+
+	let client: WasmWhatsAppClient | undefined
+	let closing = false
+	let closePromise: Promise<void> | undefined
+	/** Releases started outside `close()`, so `settled()` can join them. */
+	const pendingReleases = new Set<Promise<void>>()
+
+	const releaseQuietly = async (target: WasmWhatsAppClient) => {
+		try {
+			await release(target)
+		} catch (err) {
+			logger.error({ err }, 'failed to release the bridge client')
+		}
+	}
+
+	/** `releaseQuietly`, but joinable through `settled()`. */
+	const trackRelease = (target: WasmWhatsAppClient) => {
+		const running = releaseQuietly(target).finally(() => pendingReleases.delete(running))
+		pendingReleases.add(running)
+		return running
+	}
+
+	const runClose = async (error: Error | undefined) => {
+		// Set before the first await so `isClosing()` and `adopt()` see it the
+		// moment `close()` is called, not a tick later.
+		closing = true
+		const adopted = client
+
+		try {
+			// `client` stays published for the whole of `teardown`. The socket's
+			// transport close reads it back through `peek()` — `ws.close()` is
+			// `getClient()?.disconnect()` — and clearing it first silently turned
+			// that into a no-op, moving the disconnect after the auth-store
+			// flush and dropping the closing-session ratchet write it emits.
+			//
+			// So teardown sees a live client and `isClosing()`, not `peek()`, is
+			// the guard for "should I still be doing work".
+			await teardown(adopted, error)
+		} finally {
+			client = undefined
+			if (adopted) await releaseQuietly(adopted)
+		}
+	}
+
+	return {
+		peek: () => client,
+
+		adopt: candidate => {
+			if (closing) {
+				// Teardown has already been through here and found nothing, so
+				// this client would have no owner: nothing would free it and its
+				// read loop would reconnect forever against a socket the caller
+				// already disposed.
+				void trackRelease(candidate)
+				return false
+			}
+			client = candidate
+			return true
+		},
+
+		isClosing: () => closing,
+
+		close: error => {
+			if (closePromise) {
+				logger.trace({ trace: error?.stack }, 'already closing; awaiting the in-flight teardown')
+				return closePromise
+			}
+			closePromise = runClose(error)
+			return closePromise
+		},
+
+		discard: async () => {
+			const adopted = client
+			client = undefined
+			if (adopted) await trackRelease(adopted)
+		},
+
+		settled: async () => {
+			// A release can outlive the set it started in, so drain rather than
+			// awaiting one snapshot.
+			while (pendingReleases.size) await Promise.all(pendingReleases)
+		}
+	}
+}

--- a/src/Socket/bridge-client-owner.ts
+++ b/src/Socket/bridge-client-owner.ts
@@ -93,6 +93,9 @@ export interface BridgeClientOwner {
 	 * Resolves once every release this owner started has finished, including
 	 * the one a refused `adopt()` kicks off. Startup awaits it on the way out
 	 * so its own promise does not settle with a release still in flight.
+	 *
+	 * A release can outlive the set it started in, so this drains rather than
+	 * awaiting one snapshot.
 	 */
 	settled: () => Promise<void>
 }
@@ -119,12 +122,23 @@ export const makeBridgeClientOwner = (opts: BridgeClientOwnerOptions): BridgeCli
 		return running
 	}
 
+	/** Drain releases started outside this close — see `runClose`. */
+	const drainReleases = async () => {
+		while (pendingReleases.size) await Promise.all(pendingReleases)
+	}
+
 	const runClose = async (client: WasmWhatsAppClient | undefined, error: Error | undefined, done: Promise<void>) => {
 		try {
 			await teardown(client, error)
 		} finally {
 			state = { phase: 'closed', done }
 			if (client) await releaseQuietly(client)
+			// A `discard()` in flight when this close started put the client
+			// back in `starting`, so the capture above found none and teardown
+			// ran without it. Its release is still going: joining here keeps
+			// `close()` from settling while a client is being disconnected and
+			// freed, which is what the caller is told it can rely on.
+			await drainReleases()
 		}
 	}
 
@@ -187,10 +201,6 @@ export const makeBridgeClientOwner = (opts: BridgeClientOwnerOptions): BridgeCli
 			await trackRelease(client)
 		},
 
-		settled: async () => {
-			// A release can outlive the set it started in, so drain rather than
-			// awaiting one snapshot.
-			while (pendingReleases.size) await Promise.all(pendingReleases)
-		}
+		settled: drainReleases
 	}
 }

--- a/src/Socket/bridge-client-owner.ts
+++ b/src/Socket/bridge-client-owner.ts
@@ -153,6 +153,13 @@ export const makeBridgeClientOwner = (opts: BridgeClientOwnerOptions): BridgeCli
 		},
 
 		discard: async () => {
+			// `close()` keeps the client published for the whole of `teardown`,
+			// so a discard landing in that window would take the very handle
+			// `runClose` already captured and release it a second time — two
+			// disconnect/free sequences on one wasm client, which is the heap
+			// corruption this owner exists to avoid. `close()` owns it from the
+			// moment it starts; joining is the correct answer, not releasing.
+			if (closing) return closePromise
 			const adopted = client
 			client = undefined
 			if (adopted) await trackRelease(adopted)

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -341,11 +341,16 @@ const DISPATCHERS: DispatcherMap = {
 	// reporting `connecting` forever, with the wasm client never freed and the
 	// consumer's reconnect handler never firing.
 	disconnected: (_, dispatchCtx) => {
-		clearHistorySyncPausedTimeout(dispatchCtx.historySync)
 		if (dispatchCtx.callbacks?.isAutoReconnectEnabled?.() === false) {
+			clearHistorySyncPausedTimeout(dispatchCtx.historySync)
 			emitClose(dispatchCtx, 'Connection closed', DisconnectReason.connectionClosed)
 			return
 		}
+		// The pause timer survives a retrying drop. It is the only pending
+		// transition to `messaging-history.status: paused`, and this socket
+		// lives on — clearing it left a RECENT sync that had reported progress
+		// below 100 with neither `paused` nor `complete` if the reconnect
+		// produced no further chunk, hanging consumers waiting on hydration.
 		emitRetrying(dispatchCtx.ctx)
 	},
 	qr: (evt, { ctx }) => emitConnectionUpdate(ctx, { qr: evt.code }),

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -55,6 +55,7 @@ import {
 import { emitMessageUpsert, type MessageUpsertMetadata } from '../Compatibility/message-upsert.ts'
 import { extractMessageCappingPayload } from './message-capping.ts'
 import { mapReachoutTimelock } from './reachout.ts'
+import { isReconnectableConnectFailure } from './terminal-close.ts'
 import type { SocketContext } from './types.ts'
 
 const CANONICAL_MESSAGE_EVENT = 'message'
@@ -146,6 +147,21 @@ interface EventCallbacks {
 	onPairSuccess?: (data: { platform?: string; businessName?: string }) => void | Promise<void>
 	onIncomingCall?: (event: Extract<CanonicalEvent, { type: 'incomingCall' }>) => void
 	onDirtyState?: (event: Extract<CanonicalEvent, { type: 'dirtyState' }>) => void
+	/**
+	 * The engine has stopped reconnecting: this client is dead weight only
+	 * `free()` can reclaim. Fired immediately before the `close` that reports
+	 * it, so the socket is already shutting down by the time the consumer's
+	 * handler runs and builds a replacement.
+	 */
+	onTerminalClose?: (error: Error) => void
+	/**
+	 * Whether `sock.setAutoReconnect(true)` is in effect. A plain drop is only
+	 * transient while the engine still intends to retry: with auto-reconnect
+	 * off, the run loop dispatches `Disconnected` and then breaks for good
+	 * (`client/lifecycle.rs` tests the flag *after* the dispatch), so the same
+	 * event becomes terminal. Absent callback means the default, enabled.
+	 */
+	isAutoReconnectEnabled?: () => boolean
 }
 
 interface DispatchCtx {
@@ -178,17 +194,71 @@ type DispatcherFn<T extends CanonicalEvent['type']> = (evt: CanonicalByType<T>, 
  */
 type DispatcherMap = { [K in CanonicalEvent['type']]: DispatcherFn<K> }
 
-const emitClose = (ctx: SocketContext, reason: string, statusCode: number, data?: Record<string, unknown>) =>
+/**
+ * Report a disconnect the engine will NOT recover from.
+ *
+ * `connection: 'close'` carries one meaning on this socket, the same one it
+ * carries in upstream Baileys: the socket is finished and the consumer has to
+ * build a new one. Disconnects the engine is still retrying never come through
+ * here — see `emitRetrying` and `terminal-close.ts`.
+ *
+ * `onTerminalClose` runs first so the socket starts tearing itself down before
+ * the consumer sees the event: `end()` flips its `ended` flag synchronously,
+ * so by the time a handler calls `makeWASocket()` again the old socket is
+ * already spent rather than racing the new one.
+ */
+const emitClose = (
+	{ ctx, callbacks }: DispatchCtx,
+	reason: string,
+	statusCode: number,
+	data?: Record<string, unknown>
+) => {
+	const error = new Boom(reason, { statusCode, data })
+	callbacks?.onTerminalClose?.(error)
 	ctx.ev.emit('connection.update', {
 		connection: 'close',
-		lastDisconnect: { error: new Boom(reason, { statusCode, data }), date: new Date() }
+		lastDisconnect: { error, date: new Date() }
 	} as Partial<ConnectionState>)
+}
+
+/**
+ * Report a disconnect the engine is retrying on its own.
+ *
+ * Emitted as `connecting` rather than `close` on purpose. The canonical
+ * upstream handler is `if (connection === 'close') reconnect()`, and upstream
+ * has no auto-reconnect — so surfacing a transient drop as `close` makes that
+ * handler build a second socket while the engine is already backing off to
+ * restore the first. Two live sockets for one connection. `connecting` is the
+ * state upstream itself uses while a connection is being (re)established, so
+ * consumers read this as `open → connecting → open` and stay out of the way.
+ */
+const emitRetrying = (ctx: SocketContext) =>
+	ctx.ev.emit('connection.update', {
+		connection: 'connecting',
+		// Same shape upstream's own `connecting` always carries. Without the
+		// explicit clear, a consumer merging partial state keeps rendering the
+		// QR from before the drop — one the server has already rotated away.
+		qr: undefined,
+		receivedPendingNotifications: false
+	} as Partial<ConnectionState>)
+
+/**
+ * `<failure reason="405">` — the wire code, kept as-is rather than folded into
+ * `DisconnectReason`, which has no member for it. See the `clientOutdated`
+ * dispatcher for why `badSession` was the wrong home.
+ */
+const CLIENT_OUTDATED_STATUS = 405
 
 /**
  * Map bridge `ConnectFailureReason` wire codes (per the bridge's
  * `.d.ts` annotation) onto upstream Baileys' `DisconnectReason`.
  * Unknown codes fall through to `connectionClosed` so existing
  * reconnect heuristics keep working.
+ *
+ * Several cases here are belt-and-braces: the engine dispatches its own event
+ * for `is_logged_out()` reasons (401/403/406) and for 405, so those never
+ * reach `connectFailure` in practice. Kept because they cost nothing and the
+ * engine's routing is not ours to depend on.
  */
 const mapConnectFailureToDisconnect = (reason: number | undefined): number => {
 	switch (reason) {
@@ -199,7 +269,7 @@ const mapConnectFailureToDisconnect = (reason: number | undefined): number => {
 		case 402: // TempBanned
 			return DisconnectReason.forbidden
 		case 405: // ClientOutdated
-			return DisconnectReason.badSession
+			return CLIENT_OUTDATED_STATUS
 		case 411: // MultideviceMismatch (legacy alias)
 			return DisconnectReason.multideviceMismatch
 		case 503: // ServiceUnavailable
@@ -249,9 +319,22 @@ const DISPATCHERS: DispatcherMap = {
 		emitConnectionUpdate(ctx, {
 			receivedPendingNotifications: true
 		}),
-	disconnected: (_, { ctx, historySync }) => {
-		clearHistorySyncPausedTimeout(historySync)
-		emitClose(ctx, 'Connection closed', DisconnectReason.connectionClosed)
+	// The engine dispatches `Disconnected` only for an *unexpected* loop exit,
+	// and every terminal path marks `expected_disconnect` first — so this is
+	// normally "the Fibonacci backoff is already running".
+	//
+	// The exception is `sock.setAutoReconnect(false)`: `client/lifecycle.rs`
+	// dispatches `Disconnected` and only *then* tests the flag and breaks out
+	// of the run loop. Treating that as transient would leave the socket
+	// reporting `connecting` forever, with the wasm client never freed and the
+	// consumer's reconnect handler never firing.
+	disconnected: (_, dispatchCtx) => {
+		clearHistorySyncPausedTimeout(dispatchCtx.historySync)
+		if (dispatchCtx.callbacks?.isAutoReconnectEnabled?.() === false) {
+			emitClose(dispatchCtx, 'Connection closed', DisconnectReason.connectionClosed)
+			return
+		}
+		emitRetrying(dispatchCtx.ctx)
 	},
 	qr: (evt, { ctx }) => emitConnectionUpdate(ctx, { qr: evt.code }),
 	pairSuccess: (evt, { ctx, callbacks }) => {
@@ -264,50 +347,59 @@ const DISPATCHERS: DispatcherMap = {
 		// a compat hook for upstream's lifecycle.
 		ctx.ev.emit('creds.update', { registered: true, me: { id, lid, name: businessName }, platform })
 	},
-	pairError: (evt, { ctx }) => emitClose(ctx, 'Pairing failed: ' + evt.error, DisconnectReason.connectionClosed),
-	loggedOut: (evt, { ctx }) =>
-		emitClose(ctx, evt.reason ? `Logged out: ${evt.reason}` : 'Logged out', DisconnectReason.loggedOut),
-	connectFailure: (evt, { ctx }) => {
+	// Pairing failed, but the engine keeps its loop and re-emits a QR — nothing
+	// about the client is dead, so this must not read as `close`. It still
+	// belongs on the bus: the QR the user was shown is spent, and `connecting`
+	// clears it while telling the consumer a fresh one is coming.
+	pairError: (evt, { ctx }) => {
+		ctx.logger.error({ err: evt.error }, 'pairing failed; the engine will retry')
+		emitRetrying(ctx)
+	},
+	loggedOut: (evt, dispatchCtx) =>
+		emitClose(dispatchCtx, evt.reason ? `Logged out: ${evt.reason}` : 'Logged out', DisconnectReason.loggedOut),
+	connectFailure: (evt, dispatchCtx) => {
 		// Map bridge `ConnectFailureReason` wire codes onto Baileys'
 		// DisconnectReason. Defaults to connectionClosed for unknown codes.
 		// LoggedOut paths (401/403/406) drive bots' "should I re-pair?"
 		// branch — folding them into connectionClosed kept that broken.
+		if (isReconnectableConnectFailure(evt.reason)) {
+			dispatchCtx.ctx.logger.warn(
+				{ reason: evt.reason, message: evt.message },
+				'connect failure; the engine will retry'
+			)
+			emitRetrying(dispatchCtx.ctx)
+			return
+		}
+
 		const status = mapConnectFailureToDisconnect(evt.reason)
-		emitClose(ctx, evt.message ?? 'Connection failure', status)
+		emitClose(dispatchCtx, evt.message ?? 'Connection failure', status)
 	},
-	// Preserve the wire code on `boom.data.streamErrorCode` so consumers can
-	// branch on the actual `<stream:error code="...">` (e.g. 500 vs an
-	// unknown code) without losing the canonical DisconnectReason.badSession.
-	streamError: (evt, { ctx }) =>
-		emitClose(ctx, 'Stream error: ' + evt.code, DisconnectReason.badSession, {
-			streamErrorCode: evt.code
-		}),
-	streamReplaced: (_, { ctx }) =>
-		emitConnectionUpdate(ctx, {
-			connection: 'close',
-			lastDisconnect: {
-				error: new Boom('Connection replaced', { statusCode: DisconnectReason.connectionReplaced }),
-				date: new Date()
-			}
-		}),
-	clientOutdated: (_, { ctx }) => emitClose(ctx, 'Client outdated', DisconnectReason.badSession),
-	temporaryBan: (evt, { ctx }) => {
+	// NOT a close. The engine dispatches `StreamError` only from its catch-all
+	// `<stream:error>` branch — an unknown code, an `<ack/>` it still owes the
+	// server, or `<xml-not-well-formed>` — and it keeps or deliberately recycles
+	// the connection in every one of those. This used to report
+	// `DisconnectReason.badSession`, the code bots use to wipe credentials and
+	// re-pair, so a routine stream recycle could destroy a working session. The
+	// coded stream errors (401/409/515/516) never arrive here; they dispatch
+	// `loggedOut` / `streamReplaced` of their own.
+	streamError: (evt, { ctx }) => ctx.logger.warn({ code: evt.code }, 'stream error; the connection is preserved'),
+	streamReplaced: (_, dispatchCtx) =>
+		emitClose(dispatchCtx, 'Connection replaced', DisconnectReason.connectionReplaced),
+	// Carries the wire code (405), not `DisconnectReason.badSession`. Upstream
+	// does the same for stream errors — `+node.attrs.code` first, `badSession`
+	// only as the no-code fallback (`Utils/generics.ts` `getErrorCodeFromStreamError`).
+	// badSession is 500, the code bots use to wipe credentials and re-pair; an
+	// outdated build is the one failure where wiping a perfectly good session
+	// helps nobody, and the next connect fails identically.
+	clientOutdated: (_, dispatchCtx) => emitClose(dispatchCtx, 'Client outdated', CLIENT_OUTDATED_STATUS),
+	temporaryBan: (evt, dispatchCtx) => {
 		// Surface the wire code + expire on the Boom so consumers reading
 		// `lastDisconnect.error.data` can act on the specific reason.
 		const reason = describeTempBan(evt.code)
 		const message = evt.expire
 			? `Temporary ban (${reason}); expires at ${new Date(evt.expire * 1000).toISOString()}`
 			: `Temporary ban (${reason})`
-		ctx.ev.emit('connection.update', {
-			connection: 'close',
-			lastDisconnect: {
-				error: new Boom(message, {
-					statusCode: DisconnectReason.forbidden,
-					data: { code: evt.code, expire: evt.expire }
-				}),
-				date: new Date()
-			}
-		} as Partial<ConnectionState>)
+		emitClose(dispatchCtx, message, DisconnectReason.forbidden, { code: evt.code, expire: evt.expire })
 	},
 	qrScannedWithoutMultidevice: (_, { ctx }) => ctx.logger.warn('QR scanned but multi-device not enabled on phone'),
 

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -160,6 +160,17 @@ interface EventCallbacks {
 	 */
 	onTerminalClose?: (error: Error, publish: () => void) => void
 	/**
+	 * Hand back a cleanup for anything the dispatcher armed that outlives a
+	 * single event — today the history-sync pause timer. The socket registers
+	 * it as an end handler, so a plain `sock.end()` or an `await using` scope
+	 * exiting cancels it too: only the terminal-close path goes through
+	 * `emitClose`, and a timer surviving disposal fires
+	 * `messaging-history.status: paused` from a socket that is already gone.
+	 *
+	 * Called once, during `makeEventHandlers`.
+	 */
+	onCleanup?: (cleanup: () => void) => void
+	/**
 	 * Whether `sock.setAutoReconnect(true)` is in effect. A plain drop is only
 	 * transient while the engine still intends to retry: with auto-reconnect
 	 * off, the run loop dispatches `Disconnected` and then breaks for good
@@ -1018,6 +1029,8 @@ export const makeEventHandlers = (ctx: SocketContext, callbacks?: EventCallbacks
 		callbacks,
 		historySync: { initialBootstrapComplete: false, recentSyncComplete: false }
 	}
+
+	callbacks?.onCleanup?.(() => clearHistorySyncPausedTimeout(dispatchCtx.historySync))
 
 	const onEvent = (event: WhatsAppEvent) => {
 		const canonical = adaptBridgeEvent(event, ctx.logger)

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -214,11 +214,17 @@ type DispatcherMap = { [K in CanonicalEvent['type']]: DispatcherFn<K> }
  * goes out immediately.
  */
 const emitClose = (
-	{ ctx, callbacks }: DispatchCtx,
+	{ ctx, callbacks, historySync }: DispatchCtx,
 	reason: string,
 	statusCode: number,
 	data?: Record<string, unknown>
 ) => {
+	// Every terminal path cancels the history-sync pause timer, not just the
+	// one in `disconnected`. A transient drop deliberately keeps it armed, so
+	// without this a drop followed by a terminal close leaves it to fire a
+	// `messaging-history.status: paused` from a socket that has already ended.
+	clearHistorySyncPausedTimeout(historySync)
+
 	const error = new Boom(reason, { statusCode, data })
 	const publish = () =>
 		ctx.ev.emit('connection.update', {
@@ -342,7 +348,6 @@ const DISPATCHERS: DispatcherMap = {
 	// consumer's reconnect handler never firing.
 	disconnected: (_, dispatchCtx) => {
 		if (dispatchCtx.callbacks?.isAutoReconnectEnabled?.() === false) {
-			clearHistorySyncPausedTimeout(dispatchCtx.historySync)
 			emitClose(dispatchCtx, 'Connection closed', DisconnectReason.connectionClosed)
 			return
 		}

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -149,11 +149,16 @@ interface EventCallbacks {
 	onDirtyState?: (event: Extract<CanonicalEvent, { type: 'dirtyState' }>) => void
 	/**
 	 * The engine has stopped reconnecting: this client is dead weight only
-	 * `free()` can reclaim. Fired immediately before the `close` that reports
-	 * it, so the socket is already shutting down by the time the consumer's
-	 * handler runs and builds a replacement.
+	 * `free()` can reclaim.
+	 *
+	 * Owns publishing the `close` too — `publish()` must be called, and the
+	 * point of handing it over is that the socket can finish tearing down
+	 * first. Upstream does the same, emitting its close only after `ws.close()`
+	 * and the end handlers (`Socket/socket.ts`). A consumer answering `close`
+	 * with a replacement socket on the same auth folder would otherwise race
+	 * the old one's store flush and `free()`.
 	 */
-	onTerminalClose?: (error: Error) => void
+	onTerminalClose?: (error: Error, publish: () => void) => void
 	/**
 	 * Whether `sock.setAutoReconnect(true)` is in effect. A plain drop is only
 	 * transient while the engine still intends to retry: with auto-reconnect
@@ -202,10 +207,11 @@ type DispatcherMap = { [K in CanonicalEvent['type']]: DispatcherFn<K> }
  * build a new one. Disconnects the engine is still retrying never come through
  * here — see `emitRetrying` and `terminal-close.ts`.
  *
- * `onTerminalClose` runs first so the socket starts tearing itself down before
- * the consumer sees the event: `end()` flips its `ended` flag synchronously,
- * so by the time a handler calls `makeWASocket()` again the old socket is
- * already spent rather than racing the new one.
+ * `onTerminalClose` owns both the teardown and the publish, so the socket can
+ * be fully torn down before the consumer sees the event — the order upstream
+ * uses, and what keeps a replacement socket from overlapping the old one's
+ * store flush. Without that callback (a bare `makeEventHandler`), the close
+ * goes out immediately.
  */
 const emitClose = (
 	{ ctx, callbacks }: DispatchCtx,
@@ -214,11 +220,17 @@ const emitClose = (
 	data?: Record<string, unknown>
 ) => {
 	const error = new Boom(reason, { statusCode, data })
-	callbacks?.onTerminalClose?.(error)
-	ctx.ev.emit('connection.update', {
-		connection: 'close',
-		lastDisconnect: { error, date: new Date() }
-	} as Partial<ConnectionState>)
+	const publish = () =>
+		ctx.ev.emit('connection.update', {
+			connection: 'close',
+			lastDisconnect: { error, date: new Date() }
+		} as Partial<ConnectionState>)
+
+	if (callbacks?.onTerminalClose) {
+		callbacks.onTerminalClose(error, publish)
+		return
+	}
+	publish()
 }
 
 /**
@@ -362,7 +374,11 @@ const DISPATCHERS: DispatcherMap = {
 		// DisconnectReason. Defaults to connectionClosed for unknown codes.
 		// LoggedOut paths (401/403/406) drive bots' "should I re-pair?"
 		// branch — folding them into connectionClosed kept that broken.
-		if (isReconnectableConnectFailure(evt.reason)) {
+		// "Reconnectable" is only true while the engine is allowed to reconnect.
+		// With `setAutoReconnect(false)` the run loop breaks on the next pass,
+		// so reporting `connecting` for a 500/503 would leave the socket stuck
+		// in that state with nothing left to restore it.
+		if (isReconnectableConnectFailure(evt.reason) && dispatchCtx.callbacks?.isAutoReconnectEnabled?.() !== false) {
 			dispatchCtx.ctx.logger.warn(
 				{ reason: evt.reason, message: evt.message },
 				'connect failure; the engine will retry'

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -583,7 +583,21 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		initialized = true
 	}
 
-	const end = (error: Error | undefined): Promise<void> => owner.close(error)
+	/**
+	 * Joins startup too, not just the teardown.
+	 *
+	 * `owner.close()` covers the client it can see. A close landing while
+	 * `createWhatsAppClient()` is still pending sees none — the client arrives
+	 * afterwards, `adopt()` refuses it, and the release runs detached. Without
+	 * waiting for `init()` to finish, `await sock.end()` therefore returns while
+	 * that client is still disconnecting and being freed, and the replacement
+	 * socket the consumer builds next overlaps it on the same auth folder.
+	 *
+	 * `initPromise` is declared below and swallows its own failures, so this
+	 * neither hits its TDZ (nothing can call `end` during the synchronous
+	 * construction below) nor masks the teardown error.
+	 */
+	const end = (error: Error | undefined): Promise<void> => owner.close(error).finally(() => initPromise)
 
 	let initError: Error | undefined
 	// Started only once `end` exists. `init()`'s synchronous prefix reaches
@@ -623,6 +637,13 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// either way. Counting rather than flagging, because a terminal close
 		// may already have happened earlier in this socket's life.
 		const closesBefore = terminalCloseCount
+		// A socket that has already gone through a terminal close reported one
+		// then. `logout()` called from that very handler finds no live client to
+		// dispatch a second `LoggedOut`, so the count cannot move — and
+		// synthesizing a close on that basis gives every listener two terminal
+		// notifications for one socket, and a handler that logs out on close an
+		// asynchronous close/logout loop.
+		const alreadyClosed = owner.isClosing()
 		const live = owner.peek()
 		if (live) {
 			try {
@@ -635,7 +656,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// Nothing dispatched: no client at all, or `logout()` threw before the
 		// bridge got to it. Upstream always reports exactly one close for a
 		// logout, so emitting none would be worse than emitting one too many.
-		const announceLogout = terminalCloseCount === closesBefore
+		const announceLogout = !alreadyClosed && terminalCloseCount === closesBefore
 
 		try {
 			await end(logoutError)
@@ -649,13 +670,21 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			// path listeners would otherwise see no terminal close at all for a
 			// socket that has definitely ended. The rejection still propagates.
 			if (announceLogout) {
-				ev.emit('connection.update', {
-					connection: 'close',
-					lastDisconnect: {
-						error: logoutError,
-						date: new Date()
-					}
-				} as Partial<ConnectionState>)
+				try {
+					ev.emit('connection.update', {
+						connection: 'close',
+						lastDisconnect: {
+							error: logoutError,
+							date: new Date()
+						}
+					} as Partial<ConnectionState>)
+				} catch (err) {
+					// Emitted from a `finally`, so a throwing consumer listener
+					// would otherwise replace the auth-store flush failure `end()`
+					// is rethrowing — hiding the real teardown error behind one
+					// from the handler reacting to it.
+					logger.error({ err }, 'connection.update listener threw on the logout close')
+				}
 			}
 		}
 		// The dispatcher publishes its close on a chain one hop further out than

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -118,6 +118,30 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	const socketEndHandlers: Array<(error: Error | undefined) => void | Promise<void>> = []
 
 	/**
+	 * Drain both auth stores, returning the FIRST failure rather than throwing
+	 * so the caller can finish the rest of its work and still report it.
+	 *
+	 * Called through their owners on purpose: collecting the two methods into
+	 * an array and invoking them bare drops the receiver, so a consumer store
+	 * whose `flush()` touches `this` throws on `undefined` and the teardown
+	 * publishes a close with the auth writes unpersisted.
+	 */
+	const flushStores = async (): Promise<unknown> => {
+		let firstError: unknown
+		try {
+			await auth.store?.flush?.()
+		} catch (e) {
+			firstError ??= e
+		}
+		try {
+			await autoWrappedStore?.flush?.()
+		} catch (e) {
+			firstError ??= e
+		}
+		return firstError
+	}
+
+	/**
 	 * Single home for the bridge client's lifetime. `ws` below reads the current
 	 * client from it, and this teardown closes `ws` — the cycle is fine because
 	 * both directions only run once the socket is live.
@@ -159,27 +183,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 				await new Promise(resolve => setImmediate(resolve))
 			}
 
-			// Capture the FIRST flush failure so a corrupt-on-shutdown auth
-			// state reaches the caller, but finish the rest of the teardown
-			// regardless — the client is released either way.
-			//
-			// Called through their owners on purpose. Collecting the two methods
-			// into an array and invoking them bare drops the receiver, so a
-			// consumer store whose `flush()` touches `this` throws on
-			// `undefined` — the teardown then records a flush failure, releases
-			// the client and publishes the close with the auth writes still
-			// unpersisted.
-			let firstFlushError: unknown
-			try {
-				await auth.store?.flush?.()
-			} catch (e) {
-				firstFlushError ??= e
-			}
-			try {
-				await autoWrappedStore?.flush?.()
-			} catch (e) {
-				firstFlushError ??= e
-			}
+			const firstFlushError = await flushStores()
 
 			// End handlers run before the flush error is rethrown: they are the
 			// consumer's teardown hook, and a corrupt-on-shutdown auth store is
@@ -225,10 +229,21 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			// already set: that path does NOT await the disconnect it skipped, so
 			// `void sock.ws.close(); await sock.end()` could otherwise reach
 			// `free()` with the first disconnect still running.
+			let disconnected = true
 			try {
 				await client.disconnect()
 			} catch {
-				/* ignore */
+				disconnected = false
+			}
+
+			// Teardown already flushed, but only after its own disconnect
+			// attempts. If those all failed and this one succeeded, the
+			// closing-session ratchet writes it enqueues arrived after that
+			// flush — with nothing left to persist them. Cheap enough to just
+			// drain again.
+			if (disconnected) {
+				const lateFlushError = await flushStores()
+				if (lateFlushError) logger.error({ err: lateFlushError }, 'failed to flush after the final disconnect')
 			}
 
 			// Unregister before freeing: `free()` is swallowed, so ordering it
@@ -403,7 +418,12 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			// teardown is waiting on this.
 			terminalClose.reportAfter(() => owner.close(error).finally(() => initPromise), publish)
 		},
-		isAutoReconnectEnabled: () => autoReconnectEnabled
+		isAutoReconnectEnabled: () => autoReconnectEnabled,
+		// Timers the dispatcher armed outlive the events that armed them, and
+		// only the terminal-close path clears them. Ending the socket any other
+		// way — `sock.end()`, an `await using` scope exiting — has to as well,
+		// or one fires from a socket whose client is already freed.
+		onCleanup: cleanup => socketEndHandlers.push(cleanup)
 	})
 
 	const init = async () => {
@@ -665,7 +685,12 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// The close is published on a chain one hop further out than the
 		// teardown both paths await, so without this `await sock.logout()`
 		// returns just before the event it caused.
-		await terminalClose.published()
+		//
+		// Skipped when re-entered from an end handler, for the same reason
+		// `end()` short-circuits there: the publish waits for the teardown, the
+		// teardown waits for the handler, and the handler would be waiting here
+		// — stalled until the watchdog fires.
+		if (!runningEndHandlers) await terminalClose.published()
 	}
 
 	const registerSocketEndHandler = (handler: (error: Error | undefined) => void | Promise<void>) => {

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -284,7 +284,18 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			user = u
 		},
 		getClient: () => {
-			// Deliberately gated on `initialized`, not merely on the client
+			// `peek()` keeps returning the client through `closing` so teardown
+			// can still close the transport with it — but that is teardown's
+			// client, not everyone's. Handing it to an ordinary call racing
+			// shutdown, or made from an end handler, starts a bridge operation
+			// while the client is being disconnected and freed, which is the
+			// heap-corruption hazard the whole teardown ordering exists to
+			// avoid. Refuse from the moment `close()` is called.
+			if (owner.isClosing()) {
+				return Promise.reject(new Boom('Connection Closed', { statusCode: DisconnectReason.connectionClosed }))
+			}
+
+			// Otherwise gated on `initialized`, not merely on the client
 			// existing. `adopt()` publishes it several awaits before
 			// `setDeviceProps`, the account lookups and `run()`, so keying off
 			// `peek()` alone would hand ordinary calls like `sendMessage()` a
@@ -306,6 +317,10 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			})
 		},
 		getClientSync: () => {
+			// Same rule as `getClient` — see there.
+			if (owner.isClosing()) {
+				throw new Boom('Connection Closed', { statusCode: DisconnectReason.connectionClosed })
+			}
 			const built = owner.peek()
 			if (!built) throw new Boom('Client not initialized', { statusCode: 500 })
 			return built
@@ -365,7 +380,15 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		 * on the same auth folder.
 		 */
 		onTerminalClose: (error, publish) => {
-			terminalClose.reportAfter(() => end(error), publish)
+			// `owner.close()`, not `end()`. `end()` short-circuits when called
+			// from inside an end handler — it has to, or the handler awaits the
+			// teardown waiting for it — and a terminal event raised from one of
+			// those would then publish against an already-resolved promise,
+			// letting a close listener build a replacement while the old client
+			// is still owned. This waits for the real teardown, and cannot
+			// deadlock because `reportAfter` runs it detached; nothing in the
+			// teardown is waiting on this.
+			terminalClose.reportAfter(() => owner.close(error).finally(() => initPromise), publish)
 		},
 		isAutoReconnectEnabled: () => autoReconnectEnabled
 	})
@@ -599,7 +622,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// Keyed on a close having been *reported*, not on the socket closing —
 		// a plain `end()` reports nothing, so keying off that would let a logout
 		// racing one finish with no close at all.
-		const announceLogout = !reportedBefore && !terminalClose.hasReported()
+		const mayNeedFallback = !reportedBefore && !terminalClose.hasReported()
 
 		try {
 			await end(logoutError)
@@ -610,7 +633,10 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			// rethrows the first flush failure and the owner releases the client
 			// regardless — on that path listeners would otherwise see no
 			// terminal close at all for a socket that has definitely ended.
-			if (announceLogout) {
+			// Rechecked here, not just before the await: a dispatcher close
+			// arriving while `end()` ran would otherwise be followed by this
+			// stale decision, giving consumers two closes for one logout.
+			if (mayNeedFallback && !terminalClose.hasReported()) {
 				terminalClose.reportNow(() =>
 					ev.emit('connection.update', {
 						connection: 'close',

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -384,6 +384,15 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		onTerminalClose: (error, publish) => {
 			terminalCloseCount++
 
+			// Settles when the close is *reported*, not when teardown settles.
+			// The watchdog below exists precisely for a teardown that never
+			// settles, so tying this to `end()` would leave `logout()` — which
+			// awaits it — hanging past a close the consumer already received.
+			let markPublished!: () => void
+			terminalClosePublished = new Promise<void>(resolve => {
+				markPublished = resolve
+			})
+
 			let published = false
 			const publishOnce = (reason?: unknown) => {
 				if (published) return
@@ -398,6 +407,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 					// default handler.
 					logger.error({ err }, 'connection.update listener threw on the terminal close')
 				}
+				markPublished()
 			}
 
 			const watchdog = setTimeout(() => {
@@ -409,7 +419,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			}, TERMINAL_CLOSE_PUBLISH_TIMEOUT_MS)
 			watchdog.unref?.()
 
-			terminalClosePublished = end(error).then(
+			void end(error).then(
 				() => {
 					clearTimeout(watchdog)
 					publishOnce()
@@ -419,7 +429,6 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 					publishOnce(err)
 				}
 			)
-			void terminalClosePublished
 		},
 		isAutoReconnectEnabled: () => autoReconnectEnabled
 	})
@@ -574,7 +583,16 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		initialized = true
 	}
 
+	const end = (error: Error | undefined): Promise<void> => owner.close(error)
+
 	let initError: Error | undefined
+	// Started only once `end` exists. `init()`'s synchronous prefix reaches
+	// `await createWhatsAppClient(...)` before the bridge can dispatch anything,
+	// so today nothing can call `onTerminalClose` — and therefore `end` — that
+	// early. But that is an argument about the current shape of `init()`, not a
+	// rule the code enforces: dispatch a terminal close any sooner and line 401
+	// becomes a `ReferenceError` inside a bridge callback, where no `try/catch`
+	// of ours can reach it. Ordering it here makes the dependency structural.
 	const initPromise = init().catch(err => {
 		initError = err instanceof Error ? err : new Error(String(err))
 		logger.error({ err }, 'failed to initialize bridge client')
@@ -593,7 +611,6 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	 * `close` → `await sock.end()` → `makeWASocket()` into two writers on one
 	 * auth folder.
 	 */
-	const end = (error: Error | undefined): Promise<void> => owner.close(error)
 
 	const logout = async (msg?: string) => {
 		user = undefined

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -40,7 +40,7 @@ import type Long from 'long'
 import { DisconnectReason } from '../Types/index.ts'
 import { Boom } from '../Utils/boom.ts'
 import { makeEventBuffer } from '../Utils/event-buffer.ts'
-import { _registerActiveBridgeClient, downloadMediaMessage } from '../Utils/messages.ts'
+import { _registerActiveBridgeClient, _unregisterActiveBridgeClient, downloadMediaMessage } from '../Utils/messages.ts'
 import { makeNativeCryptoProvider } from '../Utils/native-crypto-provider.ts'
 import type { MediaDownloadOptions } from '../Utils/messages-media.ts'
 import { wrapLegacyStore } from '../Utils/wrap-legacy-store.ts'
@@ -125,6 +125,13 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	// `end()` to drain the debounced `saveCreds` timer — `auth.store?.flush?.()`
 	// covers the explicit-store path but not this one.
 	let autoWrappedStore: { flush?: () => Promise<void> } | undefined
+	// Mirrors the engine's `enable_auto_reconnect`, which defaults to on. Only
+	// `sock.setAutoReconnect()` moves it, and the dispatcher reads it to tell a
+	// transient drop from a terminal one.
+	let autoReconnectEnabled = true
+	// How many terminal closes the dispatcher has reported. `logout()` reads it
+	// to tell whether the bridge already announced the logout.
+	let terminalCloseCount = 0
 
 	const ctx: SocketContext = {
 		ev,
@@ -198,7 +205,24 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 				activeCallContexts.set(callId, { peer: event.from, callCreator })
 			}
 		},
-		onDirtyState: event => refreshParticipating(event.dirtyType)
+		onDirtyState: event => refreshParticipating(event.dirtyType),
+		/**
+		 * The engine has stopped reconnecting, so this client is dead weight
+		 * that only `free()` reclaims — `run()` returns `void`, so its loop
+		 * exiting is otherwise invisible from here.
+		 *
+		 * Detached rather than awaited: the dispatcher is synchronous and the
+		 * `close` must reach the consumer in this tick. `end()` sets its `ended`
+		 * flag synchronously, so a handler that responds by calling
+		 * `makeWASocket()` never races a socket that is still winding down.
+		 */
+		onTerminalClose: error => {
+			terminalCloseCount++
+			void end(error).catch(err => {
+				logger.error({ err }, 'failed to end the socket after a terminal disconnect')
+			})
+		},
+		isAutoReconnectEnabled: () => autoReconnectEnabled
 	})
 
 	const init = async () => {
@@ -253,7 +277,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		}
 		if (useNativeMemory) logger.debug('auth: using socket-local native memory backend')
 
-		client = await createWhatsAppClient(
+		const created = await createWhatsAppClient(
 			makeTransport(fullConfig),
 			makeHttpClient(fullConfig),
 			eventHandlers,
@@ -262,12 +286,38 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			fullConfig.version,
 			fullConfig.wantedPreKeyCount ?? null
 		)
+		// `end()` can land while the bridge client is still being built — a
+		// `sock.end()` / `await using` right after `makeWASocket()` does exactly
+		// that. It saw `client === undefined` and freed nothing, so without this
+		// guard the client we just created has no owner: nothing frees it, and
+		// `run()` below would reconnect it forever against a socket the caller
+		// already disposed.
+		if (ended) {
+			try {
+				created.free()
+			} catch {
+				/* ignore */
+			}
+			return
+		}
+		client = created
+		// Make this client the fallback for standalone helpers like
+		// downloadContentFromMessage that have no socket reference. Registered
+		// from `created`, not `client`, and before the first await below: an
+		// `end()` landing mid-init nulls `client`, and passing that `undefined`
+		// through would clear the pointer a *different*, live socket had
+		// claimed in a multi-account host.
+		_registerActiveBridgeClient(created, logger)
+
+		// Replay a preference set before the client existed. `setAutoReconnect`
+		// forwards through `client?.`, so `makeWASocket(cfg).setAutoReconnect(false)`
+		// — the idiomatic first line — used to move only the JS mirror and leave
+		// the engine retrying.
+		if (!autoReconnectEnabled) created.setAutoReconnect(false)
+
 		if (fullConfig.pushName) {
 			await client.setInitialPushName(fullConfig.pushName)
 		}
-		// Make this client the fallback for standalone helpers like
-		// downloadContentFromMessage that have no socket reference.
-		_registerActiveBridgeClient(client, logger)
 
 		const [osName, browserName] = fullConfig.browser
 
@@ -302,30 +352,28 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			client.setRawNodeForwarding(true)
 		}
 
-		// `run()` is fire-and-forget by design (the bridge runs the read
-		// loop until disconnect/free) but typed `Promise<void>`. A late
-		// rejection (lost connection during cleanup, etc) without a
-		// `.catch` would escape to `process.on('unhandledRejection')`.
-		// Funnel into the connection.update channel so consumers' regular
-		// reconnect/diagnostic plumbing handles it like any other close.
-		const runPromise = client.run() as unknown as Promise<void> | undefined
-		if (runPromise && typeof runPromise.catch === 'function') {
-			runPromise.catch(err => {
-				logger.error({ err }, 'bridge client.run() rejected')
-				ev.emit('connection.update', {
-					connection: 'close',
-					lastDisconnect: {
-						// restartRequired (515) signals "Rust read loop crashed
-						// unrecoverably, restart the sock". Previously mapped to
-						// 500, which collided with the server-side <stream:error
-						// code="500"> path and made it impossible for consumers
-						// to tell the two apart.
-						error: err instanceof Error ? err : new Boom(String(err), { statusCode: DisconnectReason.restartRequired }),
-						date: new Date()
-					}
-				} as Partial<ConnectionState>)
-			})
-		}
+		// Same race as above, but for an `end()` that landed mid-init: it
+		// already freed the client, so starting the read loop now would run
+		// against a dangling handle.
+		if (ended) return
+
+		// `run()` spawns the connect/handshake/read/reconnect loop as a
+		// background task and returns `void` — it deliberately is not `async`,
+		// so that it does not hold a wasm-bindgen borrow on `self` that would
+		// block `disconnect()`.
+		//
+		// Consequence: the loop's exit is not observable from here. The engine
+		// clears `enable_auto_reconnect` and breaks out on every terminal
+		// disconnect (conflict/401/409/516, and any `<failure>` whose reason is
+		// not 500/503), and when it does, the `WasmWhatsAppClient` is dead
+		// weight that only `sock.end()` can free — nothing else can, because
+		// the bridge holds the JS event callbacks as wasm-bindgen externrefs,
+		// those close over `ctx`, and `ctx` closes over `client`, so the cycle
+		// crosses the JS/wasm boundary and no `FinalizationRegistry` fires.
+		// Freeing that automatically needs the bridge to expose loop completion
+		// (a terminal callback or an awaitable handle); until it does, the
+		// consumer has to call `sock.end()` on a terminal close.
+		client.run()
 	}
 
 	let initError: Error | undefined
@@ -342,22 +390,26 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	const socketEndHandlers: Array<(error: Error | undefined) => void | Promise<void>> = [
 		() => activeCallContexts.clear()
 	]
-	const end = async (error: Error | undefined) => {
-		if (ended) {
-			logger.trace({ trace: error?.stack }, 'connection already closed')
-			return
-		}
+	const endImpl = async (error: Error | undefined) => {
+		// Synchronous relative to the call: an async function body runs up to
+		// its first `await` eagerly, so `init()`'s two `ended` guards still see
+		// the flag the moment `end()` is invoked.
 		ended = true
 		const c = client
-		if (c) {
-			try {
-				await ws.close()
-			} catch {
-				/* ignore */
-			}
-			client = undefined
-			readyClient = undefined
+		// Closing the transport and draining the auth store are NOT conditional
+		// on a client existing. `end()` called mid-init — `await using`, or a
+		// bot that gives up during `makeWASocket()` — used to skip both, leaving
+		// `ws.readyState` stuck at CONNECTING on a socket the caller had
+		// disposed and dropping whatever the store had buffered.
+		try {
+			await ws.close()
+		} catch {
+			/* ignore */
+		}
+		client = undefined
+		readyClient = undefined
 
+		if (c) {
 			// Barrier: bridge cleanup paths fired during `disconnect()` may
 			// emit `set()` calls that are still queued as microtasks /
 			// `setImmediate` callbacks at this point. Two yields to the
@@ -368,32 +420,72 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			// (typically the closing-session ratchet step).
 			await new Promise(resolve => setImmediate(resolve))
 			await new Promise(resolve => setImmediate(resolve))
+		}
 
-			// Capture the FIRST flush failure so a corrupt-on-shutdown auth
-			// state surfaces to the caller. Always finish the rest of
-			// cleanup; rethrow at the end so c.free() still runs.
-			let firstFlushError: unknown
+		// Capture the FIRST flush failure so a corrupt-on-shutdown auth
+		// state surfaces to the caller. Always finish the rest of
+		// cleanup; rethrow at the end so c.free() still runs.
+		let firstFlushError: unknown
+		try {
+			await auth.store?.flush?.()
+		} catch (e) {
+			firstFlushError ??= e
+		}
+
+		try {
+			await autoWrappedStore?.flush?.()
+		} catch (e) {
+			firstFlushError ??= e
+		}
+
+		if (c) {
+			// Defence in depth ahead of `free()`, not a fix for a reproduced
+			// bug on this path — be precise about which.
+			//
+			// The hazard is real and reproducible at the bridge: freeing a
+			// client with any call still pending corrupts the wasm heap —
+			// dlmalloc trips `assertion failed: psize <= size + max_overhead`
+			// and the process dies on `RuntimeError: unreachable`, from a
+			// microtask no try/catch here can reach (`free()` itself returns
+			// normally). `logout()`, `disconnect()` and a plain
+			// `fetchBlocklist()` all reproduce it. See
+			// `__tests__/bridge-free-safety.test.ts`.
+			//
+			// What keeps `end()` off that path today is the `await ws.close()`
+			// above, which is itself a `client.disconnect()`
+			// (`Compatibility/websocket-client.ts`). This call is the belt to
+			// that braces, and the gap it closes is `WebSocketClient.close()`'s
+			// early return when `closing`/`closed` is already set: that path
+			// does NOT await the disconnect it skipped, so a caller who does
+			// `void sock.ws.close(); await sock.end()` could reach `free()` with
+			// the first disconnect still running.
+			//
+			// Both the plain and the early-return orderings were exercised
+			// against a live server with several calls outstanding, with and
+			// without this line, and neither corrupted anything — so it is
+			// insurance, not a verified failure being closed. Kept because the
+			// downside is unmeasurable latency and the upside is not having to
+			// re-derive that `ws.close()` happens to disconnect first.
 			try {
-				await auth.store?.flush?.()
-			} catch (e) {
-				firstFlushError ??= e
+				await c.disconnect()
+			} catch {
+				/* ignore */
 			}
 
-			try {
-				await autoWrappedStore?.flush?.()
-			} catch (e) {
-				firstFlushError ??= e
-			}
-
+			// Unregister before freeing: `free()` is swallowed, so ordering it
+			// last would leave the module-level pointer aimed at a client that
+			// is already gone if anything between them threw.
+			_unregisterActiveBridgeClient(c)
 			try {
 				c.free()
 			} catch {
 				/* ignore */
 			}
-
-			if (firstFlushError) throw firstFlushError
 		}
 
+		// End handlers run before the flush error is rethrown: they are the
+		// consumer's teardown hook, and a corrupt-on-shutdown auth store is
+		// exactly when they most need to run.
 		for (const handler of socketEndHandlers) {
 			try {
 				await handler(error)
@@ -401,10 +493,48 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 				logger.error({ err: handlerError }, 'error in socket end handler')
 			}
 		}
+
+		if (firstFlushError) throw firstFlushError
+	}
+
+	/**
+	 * Idempotent shutdown that later callers can actually await.
+	 *
+	 * Memoizing the promise rather than returning early on a flag is what makes
+	 * that true, and it became load-bearing the moment the socket started
+	 * ending *itself*: the terminal-close path fires `void end(error)` from a
+	 * synchronous dispatcher, so by the time the consumer's own
+	 * `await sock.end()` / `await sock.logout()` runs, `ended` is already set.
+	 * With an early return those awaits resolved instantly while the real
+	 * teardown — store flush, `client.disconnect()`, `free()`, end handlers —
+	 * was still running detached.
+	 *
+	 * That is a corruption path on the exact flow this design encourages:
+	 * `close` → `await sock.end()` → `makeWASocket()` on the same auth folder
+	 * gives two writers on one store. Same for `await sock.end()` followed by
+	 * deleting the folder, or by `process.exit()`.
+	 */
+	let endPromise: Promise<void> | undefined
+	const end = (error: Error | undefined): Promise<void> => {
+		if (endPromise) {
+			logger.trace({ trace: error?.stack }, 'connection already closing; awaiting the in-flight teardown')
+			return endPromise
+		}
+		endPromise = endImpl(error)
+		return endPromise
 	}
 
 	const logout = async (msg?: string) => {
 		user = undefined
+		const logoutError = new Boom(msg || 'Logged out', { statusCode: DisconnectReason.loggedOut })
+
+		// `Client::logout()` dispatches `LoggedOut` itself, which the dispatcher
+		// turns into the terminal close. Reporting our own on top of that gave
+		// consumers two `close` events for one logout, and upstream guarantees
+		// at most one — so watch for the dispatcher's instead of assuming
+		// either way. Counting rather than flagging, because a terminal close
+		// may already have happened earlier in this socket's life.
+		const closesBefore = terminalCloseCount
 		if (client) {
 			try {
 				await client.logout()
@@ -413,14 +543,19 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			}
 		}
 
-		const logoutError = new Boom(msg || 'Logged out', { statusCode: DisconnectReason.loggedOut })
-		ev.emit('connection.update', {
-			connection: 'close',
-			lastDisconnect: {
-				error: logoutError,
-				date: new Date()
-			}
-		} as Partial<ConnectionState>)
+		// Nothing dispatched: no client at all, or `logout()` threw before the
+		// bridge got to it. Upstream always reports exactly one close for a
+		// logout, so emitting none would be worse than emitting one too many.
+		if (terminalCloseCount === closesBefore) {
+			ev.emit('connection.update', {
+				connection: 'close',
+				lastDisconnect: {
+					error: logoutError,
+					date: new Date()
+				}
+			} as Partial<ConnectionState>)
+		}
+
 		await end(logoutError)
 	}
 
@@ -493,6 +628,38 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		logger,
 		ws,
 		type: 'md' as const,
+		/**
+		 * `await using sock = makeWASocket(config)` — frees the wasm client on
+		 * scope exit. Nothing else can: the bridge holds the JS event callbacks
+		 * as wasm-bindgen externrefs and those callbacks reach back to this
+		 * closure, so the reference cycle crosses the JS/wasm boundary and no
+		 * `FinalizationRegistry` will ever fire for the client.
+		 *
+		 * Delegates to `end()`, so it flushes the auth store and is idempotent.
+		 *
+		 * Then awaits `initPromise`, because `end()` alone does not satisfy the
+		 * async-disposal contract: called before `createWhatsAppClient()`
+		 * settles, it sees `client === undefined`, frees nothing, and resolves
+		 * while initialization is still running. What actually disposes that
+		 * client is the `ended` guard inside `init()` — so code after the
+		 * `await using` scope would otherwise overlap with bridge construction,
+		 * event callbacks, and store access. `end()` runs first because it sets
+		 * `ended` synchronously, which is what makes `init()` bail out early.
+		 *
+		 * The `finally` is load-bearing: `end()` rethrows the first auth-store
+		 * flush failure, and letting that propagate directly would skip the wait
+		 * and resolve the disposer with `init()` still in flight — losing the
+		 * one guarantee it exists to provide, in exactly the situation where
+		 * cleanup already went wrong. `initPromise` swallows its own failures,
+		 * so awaiting it here cannot mask the flush error.
+		 */
+		async [Symbol.asyncDispose]() {
+			try {
+				await end(undefined)
+			} finally {
+				await initPromise
+			}
+		},
 		// Upstream `socket.ts:1106-1108` returns `authState.creds.me`, which
 		// carries `{ id, lid, name, verifiedName, ... }` — full Contact
 		// shape. Returning the bare `{id, lid}` like before broke
@@ -564,6 +731,9 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		registerSocketEndHandler,
 		waitForConnectionUpdate,
 		setAutoReconnect: (enabled: boolean) => {
+			// Mirrored locally because the dispatcher has to know: with this off,
+			// a plain drop is terminal rather than the start of a backoff.
+			autoReconnectEnabled = enabled
 			client?.setAutoReconnect(enabled)
 		},
 		/**

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -50,6 +50,7 @@ import { makeChatActionMethods } from './chat-actions.ts'
 import { makeContactMethods } from './contacts.ts'
 import { makeCommunityMethods } from './communities.ts'
 import { makeBridgeClientOwner } from './bridge-client-owner.ts'
+import { makeTerminalCloseReporter } from './terminal-close-reporter.ts'
 import { makeEventHandlers } from './events.ts'
 import { makeGroupMethods } from './groups.ts'
 import { makeMessageMethods } from './messages.ts'
@@ -63,25 +64,6 @@ import type { SocketContext } from './types.ts'
 import { makeUSyncMethods } from './usync.ts'
 
 let wasmInitialized = false
-
-/**
- * How long a terminal-close teardown may run before the socket reports the
- * close anyway.
- *
- * This is a deliberate trade of one guarantee for another, so it is worth
- * being plain about which. Normally the close is published only after teardown
- * finishes, precisely so a consumer answering it with a replacement socket
- * cannot overlap this one's auth-store flush. Past this deadline that no
- * longer holds — but the alternative is losing the event entirely, which is
- * the bug this whole change exists to fix: a bot offline with nothing in its
- * logs.
- *
- * Teardown takes milliseconds in practice; reaching this means a consumer end
- * handler or a store flush never settled, and the error logged alongside says
- * so. Generous rather than tight, because firing early is the harmful
- * direction here.
- */
-const TERMINAL_CLOSE_PUBLISH_TIMEOUT_MS = 60_000
 
 /**
  * Default mapping for the legacy `browser[1]` slot — preserved so users on the
@@ -125,6 +107,8 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	let user: { id?: string; lid?: string } | undefined
 	/** True once `init()` has finished wiring the client and started its read loop. */
 	let initialized = false
+	/** True while the socket's end handlers run — see `end`. */
+	let runningEndHandlers = false
 
 	/**
 	 * Consumer teardown hooks, plus the socket's own. Declared here rather than
@@ -200,12 +184,23 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			// End handlers run before the flush error is rethrown: they are the
 			// consumer's teardown hook, and a corrupt-on-shutdown auth store is
 			// exactly when they most need to run.
-			for (const handler of socketEndHandlers) {
-				try {
-					await handler(error)
-				} catch (handlerError) {
-					logger.error({ err: handlerError }, 'error in socket end handler')
+			//
+			// The flag makes a re-entrant `end()` from inside one of them a
+			// no-op instead of a deadlock: shared cleanup used both directly and
+			// as an end hook would otherwise be handed the very promise that is
+			// waiting for it to return, and nothing would ever settle — no
+			// release, and no terminal close until the watchdog.
+			runningEndHandlers = true
+			try {
+				for (const handler of socketEndHandlers) {
+					try {
+						await handler(error)
+					} catch (handlerError) {
+						logger.error({ err: handlerError }, 'error in socket end handler')
+					}
 				}
+			} finally {
+				runningEndHandlers = false
 			}
 
 			if (firstFlushError) throw firstFlushError
@@ -270,13 +265,8 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	// `sock.setAutoReconnect()` moves it, and the dispatcher reads it to tell a
 	// transient drop from a terminal one.
 	let autoReconnectEnabled = true
-	// How many terminal closes the dispatcher has reported, and the settle of
-	// the most recent one's publish. `logout()` reads both: the count to tell
-	// whether the bridge already announced the logout, and the promise so
-	// `await sock.logout()` does not return one microtask before the `close`
-	// event it caused.
-	let terminalCloseCount = 0
-	let terminalClosePublished: Promise<void> | undefined
+	/** Owns reporting the terminal close: once, after teardown, never not at all. */
+	const terminalClose = makeTerminalCloseReporter({ logger })
 
 	const ctx: SocketContext = {
 		ev,
@@ -369,66 +359,13 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		 * that only `free()` reclaims — `run()` returns `void`, so its loop
 		 * exiting is otherwise invisible from here.
 		 *
-		 * `publish` runs after the teardown, so a consumer answering `close`
-		 * with a replacement socket on the same auth folder cannot overlap this
-		 * one's store flush and `free()`. Upstream orders it the same way:
-		 * `ws.close()` and the end handlers, then the close.
-		 *
-		 * But it has to run *unconditionally*. The close used to be emitted
-		 * synchronously and could not be lost; hanging it off a teardown makes
-		 * it conditional on that teardown settling, and a `close` that never
-		 * arrives is the original bug all over again — a bot offline with
-		 * nothing in its logs. Hence both settle paths, a swallowed publish,
-		 * and a watchdog for a teardown that never finishes at all.
+		 * Tearing down and reporting are both handed to the reporter: the close
+		 * has to reach the consumer exactly once and only after this socket has
+		 * released what it owns, or a replacement built in response overlaps it
+		 * on the same auth folder.
 		 */
 		onTerminalClose: (error, publish) => {
-			terminalCloseCount++
-
-			// Settles when the close is *reported*, not when teardown settles.
-			// The watchdog below exists precisely for a teardown that never
-			// settles, so tying this to `end()` would leave `logout()` — which
-			// awaits it — hanging past a close the consumer already received.
-			let markPublished!: () => void
-			terminalClosePublished = new Promise<void>(resolve => {
-				markPublished = resolve
-			})
-
-			let published = false
-			const publishOnce = (reason?: unknown) => {
-				if (published) return
-				published = true
-				if (reason) logger.error({ err: reason }, 'socket teardown failed after a terminal disconnect')
-				try {
-					publish()
-				} catch (err) {
-					// `publish` is `ev.emit`, so this is a throwing consumer
-					// listener. Letting it escape would surface as an unhandled
-					// rejection on a detached chain — process exit under Node's
-					// default handler.
-					logger.error({ err }, 'connection.update listener threw on the terminal close')
-				}
-				markPublished()
-			}
-
-			const watchdog = setTimeout(() => {
-				logger.error(
-					{ afterMs: TERMINAL_CLOSE_PUBLISH_TIMEOUT_MS },
-					'socket teardown is still running; reporting the terminal close anyway'
-				)
-				publishOnce()
-			}, TERMINAL_CLOSE_PUBLISH_TIMEOUT_MS)
-			watchdog.unref?.()
-
-			void end(error).then(
-				() => {
-					clearTimeout(watchdog)
-					publishOnce()
-				},
-				err => {
-					clearTimeout(watchdog)
-					publishOnce(err)
-				}
-			)
+			terminalClose.reportAfter(() => end(error), publish)
 		},
 		isAutoReconnectEnabled: () => autoReconnectEnabled
 	})
@@ -597,7 +534,13 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	 * neither hits its TDZ (nothing can call `end` during the synchronous
 	 * construction below) nor masks the teardown error.
 	 */
-	const end = (error: Error | undefined): Promise<void> => owner.close(error).finally(() => initPromise)
+	const end = (error: Error | undefined): Promise<void> => {
+		// Called from inside an end handler, the teardown is already running and
+		// is waiting for that handler to return. Handing back its promise would
+		// have the handler await itself.
+		if (runningEndHandlers) return Promise.resolve()
+		return owner.close(error).finally(() => initPromise)
+	}
 
 	let initError: Error | undefined
 	// Started only once `end` exists. `init()`'s synchronous prefix reaches
@@ -636,14 +579,11 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// at most one — so watch for the dispatcher's instead of assuming
 		// either way. Counting rather than flagging, because a terminal close
 		// may already have happened earlier in this socket's life.
-		const closesBefore = terminalCloseCount
-		// A socket that has already gone through a terminal close reported one
-		// then. `logout()` called from that very handler finds no live client to
-		// dispatch a second `LoggedOut`, so the count cannot move — and
-		// synthesizing a close on that basis gives every listener two terminal
-		// notifications for one socket, and a handler that logs out on close an
-		// asynchronous close/logout loop.
-		const alreadyClosed = owner.isClosing()
+		// `Client::logout()` dispatches `LoggedOut` itself, which the dispatcher
+		// turns into the terminal close. Reporting our own on top of that gave
+		// consumers two closes for one logout, and upstream guarantees at most
+		// one — so watch for the dispatcher's instead of assuming either way.
+		const reportedBefore = terminalClose.hasReported()
 		const live = owner.peek()
 		if (live) {
 			try {
@@ -653,24 +593,25 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			}
 		}
 
-		// Nothing dispatched: no client at all, or `logout()` threw before the
+		// Nothing announced it: no client at all, or `logout()` threw before the
 		// bridge got to it. Upstream always reports exactly one close for a
 		// logout, so emitting none would be worse than emitting one too many.
-		const announceLogout = !alreadyClosed && terminalCloseCount === closesBefore
+		// Keyed on a close having been *reported*, not on the socket closing —
+		// a plain `end()` reports nothing, so keying off that would let a logout
+		// racing one finish with no close at all.
+		const announceLogout = !reportedBefore && !terminalClose.hasReported()
 
 		try {
 			await end(logoutError)
 		} finally {
-			// Published after the teardown, like the dispatcher's own close.
-			// Doing it before would hand a logged-out handler a socket still
-			// flushing the auth folder it is about to delete.
-			//
-			// In a `finally` because `end()` rethrows the first auth-store flush
-			// failure, and the owner releases the client regardless — so on that
-			// path listeners would otherwise see no terminal close at all for a
-			// socket that has definitely ended. The rejection still propagates.
+			// After the teardown, like the dispatcher's own close: doing it
+			// before would hand a logged-out handler a socket still flushing the
+			// auth folder it is about to delete. In a `finally` because `end()`
+			// rethrows the first flush failure and the owner releases the client
+			// regardless — on that path listeners would otherwise see no
+			// terminal close at all for a socket that has definitely ended.
 			if (announceLogout) {
-				try {
+				terminalClose.reportNow(() =>
 					ev.emit('connection.update', {
 						connection: 'close',
 						lastDisconnect: {
@@ -678,19 +619,14 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 							date: new Date()
 						}
 					} as Partial<ConnectionState>)
-				} catch (err) {
-					// Emitted from a `finally`, so a throwing consumer listener
-					// would otherwise replace the auth-store flush failure `end()`
-					// is rethrowing — hiding the real teardown error behind one
-					// from the handler reacting to it.
-					logger.error({ err }, 'connection.update listener threw on the logout close')
-				}
+				)
 			}
 		}
-		// The dispatcher publishes its close on a chain one hop further out than
-		// the teardown both paths await, so without this `await sock.logout()`
+
+		// The close is published on a chain one hop further out than the
+		// teardown both paths await, so without this `await sock.logout()`
 		// returns just before the event it caused.
-		await terminalClosePublished
+		await terminalClose.published()
 	}
 
 	const registerSocketEndHandler = (handler: (error: Error | undefined) => void | Promise<void>) => {

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -112,6 +112,8 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	// rather than the pre-pair placeholder.
 	ev.on('creds.update', update => Object.assign(auth.creds, update))
 	let user: { id?: string; lid?: string } | undefined
+	/** True once `init()` has finished wiring the client and started its read loop. */
+	let initialized = false
 
 	/**
 	 * Consumer teardown hooks, plus the socket's own. Declared here rather than
@@ -137,7 +139,16 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			try {
 				await ws.close()
 			} catch {
-				/* ignore */
+				// The transport refused to close cleanly. Go straight at the
+				// client so the disconnect still happens *before* the barrier
+				// and flush below: `release` retries it, but that runs after the
+				// flush, and the closing-session ratchet writes a disconnect
+				// enqueues would then have nothing left to persist them.
+				try {
+					await client?.disconnect()
+				} catch {
+					/* ignore */
+				}
 			}
 
 			if (client) {
@@ -272,8 +283,16 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			user = u
 		},
 		getClient: () => {
-			const ready = owner.peek()
-			if (ready) return Promise.resolve(ready)
+			// Deliberately gated on `initialized`, not merely on the client
+			// existing. `adopt()` publishes it several awaits before
+			// `setDeviceProps`, the account lookups and `run()`, so keying off
+			// `peek()` alone would hand ordinary calls like `sendMessage()` a
+			// half-built client whose read loop has not started — and skip the
+			// `initError` check when startup later fails.
+			if (initialized) {
+				const ready = owner.peek()
+				if (ready) return Promise.resolve(ready)
+			}
 
 			return initPromise.then(() => {
 				if (initError) {
@@ -541,6 +560,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// (a terminal callback or an awaitable handle); until it does, the
 		// consumer has to call `sock.end()` on a terminal close.
 		created.run()
+		initialized = true
 	}
 
 	let initError: Error | undefined
@@ -589,20 +609,26 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// logout, so emitting none would be worse than emitting one too many.
 		const announceLogout = terminalCloseCount === closesBefore
 
-		await end(logoutError)
-
-		// Published after the teardown, like the dispatcher's own close. Doing
-		// it before would hand a logged-out handler a socket that is still
-		// flushing the auth folder it is about to delete — the one guarantee
-		// this whole change is selling.
-		if (announceLogout) {
-			ev.emit('connection.update', {
-				connection: 'close',
-				lastDisconnect: {
-					error: logoutError,
-					date: new Date()
-				}
-			} as Partial<ConnectionState>)
+		try {
+			await end(logoutError)
+		} finally {
+			// Published after the teardown, like the dispatcher's own close.
+			// Doing it before would hand a logged-out handler a socket still
+			// flushing the auth folder it is about to delete.
+			//
+			// In a `finally` because `end()` rethrows the first auth-store flush
+			// failure, and the owner releases the client regardless — so on that
+			// path listeners would otherwise see no terminal close at all for a
+			// socket that has definitely ended. The rejection still propagates.
+			if (announceLogout) {
+				ev.emit('connection.update', {
+					connection: 'close',
+					lastDisconnect: {
+						error: logoutError,
+						date: new Date()
+					}
+				} as Partial<ConnectionState>)
+			}
 		}
 		// The dispatcher publishes its close on a chain one hop further out than
 		// the teardown both paths await, so without this `await sock.logout()`

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -66,11 +66,22 @@ let wasmInitialized = false
 
 /**
  * How long a terminal-close teardown may run before the socket reports the
- * close anyway. Teardown normally takes milliseconds; this only fires when a
- * consumer end handler or an auth-store flush never settles, and losing the
- * event entirely is worse than reporting it early.
+ * close anyway.
+ *
+ * This is a deliberate trade of one guarantee for another, so it is worth
+ * being plain about which. Normally the close is published only after teardown
+ * finishes, precisely so a consumer answering it with a replacement socket
+ * cannot overlap this one's auth-store flush. Past this deadline that no
+ * longer holds — but the alternative is losing the event entirely, which is
+ * the bug this whole change exists to fix: a bot offline with nothing in its
+ * logs.
+ *
+ * Teardown takes milliseconds in practice; reaching this means a consumer end
+ * handler or a store flush never settled, and the error logged alongside says
+ * so. Generous rather than tight, because firing early is the harmful
+ * direction here.
  */
-const TERMINAL_CLOSE_PUBLISH_TIMEOUT_MS = 10_000
+const TERMINAL_CLOSE_PUBLISH_TIMEOUT_MS = 60_000
 
 /**
  * Default mapping for the legacy `browser[1]` slot — preserved so users on the

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -156,13 +156,23 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			// Capture the FIRST flush failure so a corrupt-on-shutdown auth
 			// state reaches the caller, but finish the rest of the teardown
 			// regardless — the client is released either way.
+			//
+			// Called through their owners on purpose. Collecting the two methods
+			// into an array and invoking them bare drops the receiver, so a
+			// consumer store whose `flush()` touches `this` throws on
+			// `undefined` — the teardown then records a flush failure, releases
+			// the client and publishes the close with the auth writes still
+			// unpersisted.
 			let firstFlushError: unknown
-			for (const flush of [auth.store?.flush, autoWrappedStore?.flush]) {
-				try {
-					await flush?.()
-				} catch (e) {
-					firstFlushError ??= e
-				}
+			try {
+				await auth.store?.flush?.()
+			} catch (e) {
+				firstFlushError ??= e
+			}
+			try {
+				await autoWrappedStore?.flush?.()
+			} catch (e) {
+				firstFlushError ??= e
 			}
 
 			// End handlers run before the flush error is rethrown: they are the
@@ -577,7 +587,15 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// Nothing dispatched: no client at all, or `logout()` threw before the
 		// bridge got to it. Upstream always reports exactly one close for a
 		// logout, so emitting none would be worse than emitting one too many.
-		if (terminalCloseCount === closesBefore) {
+		const announceLogout = terminalCloseCount === closesBefore
+
+		await end(logoutError)
+
+		// Published after the teardown, like the dispatcher's own close. Doing
+		// it before would hand a logged-out handler a socket that is still
+		// flushing the auth folder it is about to delete — the one guarantee
+		// this whole change is selling.
+		if (announceLogout) {
 			ev.emit('connection.update', {
 				connection: 'close',
 				lastDisconnect: {
@@ -586,8 +604,6 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 				}
 			} as Partial<ConnectionState>)
 		}
-
-		await end(logoutError)
 		// The dispatcher publishes its close on a chain one hop further out than
 		// the teardown both paths await, so without this `await sock.logout()`
 		// returns just before the event it caused.

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -307,6 +307,19 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			}
 
 			return initPromise.then(() => {
+				// Rechecked after the await: a close landing while startup was
+				// still running would otherwise be handed the client anyway.
+				//
+				// The window between handing a client back and the call reaching
+				// wasm cannot be closed here — that needs in-flight call
+				// tracking. What covers it is `release`, which awaits
+				// `client.disconnect()` before `free()`; the corruption comes
+				// from freeing with a call pending, and the disconnect drains
+				// those first (`__tests__/bridge-free-safety.test.ts`).
+				if (owner.isClosing()) {
+					throw new Boom('Connection Closed', { statusCode: DisconnectReason.connectionClosed })
+				}
+
 				if (initError) {
 					throw new Boom('Bridge client failed to initialize: ' + initError.message, { statusCode: 500 })
 				}

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -5,8 +5,7 @@ import {
 	type DevicePlatformType,
 	encodeProto,
 	initWasmEngine,
-	type UploadMediaResult,
-	type WasmWhatsAppClient
+	type UploadMediaResult
 } from '@oxidezap/whatsapp-rust-bridge'
 import { normalizeSocketAuthenticationState } from '../Compatibility/internal/auth-state.ts'
 import { makeMutex } from '../Compatibility/internal/make-mutex.ts'
@@ -50,6 +49,7 @@ import { makeBlockingMethods } from './blocking.ts'
 import { makeChatActionMethods } from './chat-actions.ts'
 import { makeContactMethods } from './contacts.ts'
 import { makeCommunityMethods } from './communities.ts'
+import { makeBridgeClientOwner } from './bridge-client-owner.ts'
 import { makeEventHandlers } from './events.ts'
 import { makeGroupMethods } from './groups.ts'
 import { makeMessageMethods } from './messages.ts'
@@ -63,6 +63,14 @@ import type { SocketContext } from './types.ts'
 import { makeUSyncMethods } from './usync.ts'
 
 let wasmInitialized = false
+
+/**
+ * How long a terminal-close teardown may run before the socket reports the
+ * close anyway. Teardown normally takes milliseconds; this only fires when a
+ * consumer end handler or an auth-store flush never settles, and losing the
+ * event entirely is worse than reporting it early.
+ */
+const TERMINAL_CLOSE_PUBLISH_TIMEOUT_MS = 10_000
 
 /**
  * Default mapping for the legacy `browser[1]` slot — preserved so users on the
@@ -103,11 +111,112 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	// this first so `ev.on('creds.update', saveCreds)` persists the merged state
 	// rather than the pre-pair placeholder.
 	ev.on('creds.update', update => Object.assign(auth.creds, update))
-	let client: WasmWhatsAppClient | undefined
-	let readyClient: Promise<WasmWhatsAppClient> | undefined
 	let user: { id?: string; lid?: string } | undefined
 
-	const ws = new WebSocketClient(fullConfig.waWebSocketUrl, fullConfig, () => client)
+	/**
+	 * Consumer teardown hooks, plus the socket's own. Declared here rather than
+	 * beside their registrations so the owner below can close over the list
+	 * before anything fills it.
+	 */
+	const socketEndHandlers: Array<(error: Error | undefined) => void | Promise<void>> = []
+
+	/**
+	 * Single home for the bridge client's lifetime. `ws` below reads the current
+	 * client from it, and this teardown closes `ws` — the cycle is fine because
+	 * both directions only run once the socket is live.
+	 */
+	const owner = makeBridgeClientOwner({
+		logger,
+		/**
+		 * Everything the socket owns beyond the client itself. Runs once, with
+		 * the client still usable, whether or not one was ever adopted — a
+		 * teardown that landed mid-init still has a transport to close and a
+		 * store to drain.
+		 */
+		teardown: async (client, error) => {
+			try {
+				await ws.close()
+			} catch {
+				/* ignore */
+			}
+
+			if (client) {
+				// Barrier: bridge cleanup paths fired during `disconnect()` may
+				// emit `set()` calls that are still queued as microtasks /
+				// `setImmediate` callbacks at this point. Two yields to the
+				// event loop drain (1) the microtask queue and (2) the next
+				// macrotask tick where wasm-bindgen async callbacks land.
+				// Without this barrier the flushes below run before the bridge
+				// has finished writing — a race that loses the last few sets
+				// (typically the closing-session ratchet step).
+				await new Promise(resolve => setImmediate(resolve))
+				await new Promise(resolve => setImmediate(resolve))
+			}
+
+			// Capture the FIRST flush failure so a corrupt-on-shutdown auth
+			// state reaches the caller, but finish the rest of the teardown
+			// regardless — the client is released either way.
+			let firstFlushError: unknown
+			for (const flush of [auth.store?.flush, autoWrappedStore?.flush]) {
+				try {
+					await flush?.()
+				} catch (e) {
+					firstFlushError ??= e
+				}
+			}
+
+			// End handlers run before the flush error is rethrown: they are the
+			// consumer's teardown hook, and a corrupt-on-shutdown auth store is
+			// exactly when they most need to run.
+			for (const handler of socketEndHandlers) {
+				try {
+					await handler(error)
+				} catch (handlerError) {
+					logger.error({ err: handlerError }, 'error in socket end handler')
+				}
+			}
+
+			if (firstFlushError) throw firstFlushError
+		},
+
+		release: async client => {
+			// `disconnect()` before `free()` is defence in depth, not a fix for a
+			// reproduced bug on this path.
+			//
+			// The hazard is real and reproducible at the bridge: freeing a client
+			// with any call still pending corrupts the wasm heap — dlmalloc trips
+			// `assertion failed: psize <= size + max_overhead` and the process
+			// dies on `RuntimeError: unreachable`, from a microtask no try/catch
+			// here can reach, since `free()` itself returns normally.
+			// `logout()`, `disconnect()` and a plain `fetchBlocklist()` all
+			// reproduce it — see `__tests__/bridge-free-safety.test.ts`.
+			//
+			// What keeps teardown off that path is the `ws.close()` above, which
+			// is itself a `client.disconnect()` (`Compatibility/websocket-client.ts`).
+			// This is the belt to that braces, and the gap it closes is
+			// `WebSocketClient.close()`'s early return when `closing`/`closed` is
+			// already set: that path does NOT await the disconnect it skipped, so
+			// `void sock.ws.close(); await sock.end()` could otherwise reach
+			// `free()` with the first disconnect still running.
+			try {
+				await client.disconnect()
+			} catch {
+				/* ignore */
+			}
+
+			// Unregister before freeing: `free()` is swallowed, so ordering it
+			// last would leave the module-level pointer aimed at a client that is
+			// already gone if anything between them threw.
+			_unregisterActiveBridgeClient(client)
+			try {
+				client.free()
+			} catch {
+				/* ignore */
+			}
+		}
+	})
+
+	const ws = new WebSocketClient(fullConfig.waWebSocketUrl, fullConfig, () => owner.peek())
 
 	let tagEpoch = 0
 	// Per-socket random prefix avoids collisions between sockets created
@@ -129,9 +238,13 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	// `sock.setAutoReconnect()` moves it, and the dispatcher reads it to tell a
 	// transient drop from a terminal one.
 	let autoReconnectEnabled = true
-	// How many terminal closes the dispatcher has reported. `logout()` reads it
-	// to tell whether the bridge already announced the logout.
+	// How many terminal closes the dispatcher has reported, and the settle of
+	// the most recent one's publish. `logout()` reads both: the count to tell
+	// whether the bridge already announced the logout, and the promise so
+	// `await sock.logout()` does not return one microtask before the `close`
+	// event it caused.
 	let terminalCloseCount = 0
+	let terminalClosePublished: Promise<void> | undefined
 
 	const ctx: SocketContext = {
 		ev,
@@ -149,20 +262,23 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			user = u
 		},
 		getClient: () => {
-			if (readyClient) return readyClient
+			const ready = owner.peek()
+			if (ready) return Promise.resolve(ready)
 
 			return initPromise.then(() => {
 				if (initError) {
 					throw new Boom('Bridge client failed to initialize: ' + initError.message, { statusCode: 500 })
 				}
 
-				if (!client) throw new Boom('Client not initialized', { statusCode: 500 })
-				return client
+				const built = owner.peek()
+				if (!built) throw new Boom('Client not initialized', { statusCode: 500 })
+				return built
 			})
 		},
 		getClientSync: () => {
-			if (!client) throw new Boom('Client not initialized', { statusCode: 500 })
-			return client
+			const built = owner.peek()
+			if (!built) throw new Boom('Client not initialized', { statusCode: 500 })
+			return built
 		}
 	}
 	// The native repository delegates Signal state directly to the core and does
@@ -180,6 +296,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	const appStatePatchMutex = makeMutex()
 	const notificationMutex = makeMutex()
 	const activeCallContexts = new Map<string, { peer: string; callCreator: string }>()
+	socketEndHandlers.push(() => activeCallContexts.clear())
 	const groupMethods = makeGroupMethods(ctx)
 	const communityMethods = makeCommunityMethods(ctx, groupMethods)
 	const refreshParticipating = makeParticipatingRefreshHandler(ctx, {
@@ -190,7 +307,8 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	const eventHandlers = makeEventHandlers(ctx, {
 		onPairSuccess: data => {
 			pairedAccount = data
-			client
+			owner
+				.peek()
 				?.getAccount?.()
 				.then((acc: proto.IADVSignedDeviceIdentity | undefined) => {
 					cachedAccount = acc ?? undefined
@@ -211,16 +329,57 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		 * that only `free()` reclaims — `run()` returns `void`, so its loop
 		 * exiting is otherwise invisible from here.
 		 *
-		 * Detached rather than awaited: the dispatcher is synchronous and the
-		 * `close` must reach the consumer in this tick. `end()` sets its `ended`
-		 * flag synchronously, so a handler that responds by calling
-		 * `makeWASocket()` never races a socket that is still winding down.
+		 * `publish` runs after the teardown, so a consumer answering `close`
+		 * with a replacement socket on the same auth folder cannot overlap this
+		 * one's store flush and `free()`. Upstream orders it the same way:
+		 * `ws.close()` and the end handlers, then the close.
+		 *
+		 * But it has to run *unconditionally*. The close used to be emitted
+		 * synchronously and could not be lost; hanging it off a teardown makes
+		 * it conditional on that teardown settling, and a `close` that never
+		 * arrives is the original bug all over again — a bot offline with
+		 * nothing in its logs. Hence both settle paths, a swallowed publish,
+		 * and a watchdog for a teardown that never finishes at all.
 		 */
-		onTerminalClose: error => {
+		onTerminalClose: (error, publish) => {
 			terminalCloseCount++
-			void end(error).catch(err => {
-				logger.error({ err }, 'failed to end the socket after a terminal disconnect')
-			})
+
+			let published = false
+			const publishOnce = (reason?: unknown) => {
+				if (published) return
+				published = true
+				if (reason) logger.error({ err: reason }, 'socket teardown failed after a terminal disconnect')
+				try {
+					publish()
+				} catch (err) {
+					// `publish` is `ev.emit`, so this is a throwing consumer
+					// listener. Letting it escape would surface as an unhandled
+					// rejection on a detached chain — process exit under Node's
+					// default handler.
+					logger.error({ err }, 'connection.update listener threw on the terminal close')
+				}
+			}
+
+			const watchdog = setTimeout(() => {
+				logger.error(
+					{ afterMs: TERMINAL_CLOSE_PUBLISH_TIMEOUT_MS },
+					'socket teardown is still running; reporting the terminal close anyway'
+				)
+				publishOnce()
+			}, TERMINAL_CLOSE_PUBLISH_TIMEOUT_MS)
+			watchdog.unref?.()
+
+			terminalClosePublished = end(error).then(
+				() => {
+					clearTimeout(watchdog)
+					publishOnce()
+				},
+				err => {
+					clearTimeout(watchdog)
+					publishOnce(err)
+				}
+			)
+			void terminalClosePublished
 		},
 		isAutoReconnectEnabled: () => autoReconnectEnabled
 	})
@@ -286,27 +445,17 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			fullConfig.version,
 			fullConfig.wantedPreKeyCount ?? null
 		)
-		// `end()` can land while the bridge client is still being built — a
-		// `sock.end()` / `await using` right after `makeWASocket()` does exactly
-		// that. It saw `client === undefined` and freed nothing, so without this
-		// guard the client we just created has no owner: nothing frees it, and
-		// `run()` below would reconnect it forever against a socket the caller
-		// already disposed.
-		if (ended) {
-			try {
-				created.free()
-			} catch {
-				/* ignore */
-			}
-			return
-		}
-		client = created
-		// Make this client the fallback for standalone helpers like
-		// downloadContentFromMessage that have no socket reference. Registered
-		// from `created`, not `client`, and before the first await below: an
-		// `end()` landing mid-init nulls `client`, and passing that `undefined`
-		// through would clear the pointer a *different*, live socket had
-		// claimed in a multi-account host.
+		// `end()` can land while the client is still being built — a `sock.end()`
+		// or `await using` right after `makeWASocket()` does exactly that. When
+		// it has, `adopt` frees this client and tells us to stop: nothing else
+		// would ever own it, and `run()` below would reconnect it forever
+		// against a socket the caller already disposed.
+		// `adopt` starts releasing the refused client; joining it here keeps
+		// that work inside `initPromise`, which `Symbol.asyncDispose` awaits.
+		if (!owner.adopt(created)) return owner.settled()
+
+		// Fallback for standalone helpers like `downloadContentFromMessage`
+		// that carry no socket reference.
 		_registerActiveBridgeClient(created, logger)
 
 		// Replay a preference set before the client existed. `setAutoReconnect`
@@ -315,24 +464,32 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// the engine retrying.
 		if (!autoReconnectEnabled) created.setAutoReconnect(false)
 
+		// Everything below talks to `created`, which stays valid for the whole
+		// body, and re-checks `isClosing()` between awaits: once teardown has
+		// started it owns this client, and issuing more bridge calls against it
+		// races the release.
 		if (fullConfig.pushName) {
-			await client.setInitialPushName(fullConfig.pushName)
+			await created.setInitialPushName(fullConfig.pushName)
 		}
+		if (owner.isClosing()) return
 
 		const [osName, browserName] = fullConfig.browser
 
 		const deviceOs = browserName === 'Android' ? 'Android' : osName
-		await client.setDeviceProps({
+		await created.setDeviceProps({
 			os: deviceOs,
 			platformType: browserToPlatformType(browserName),
 			...fullConfig.deviceProps
 		})
+		if (owner.isClosing()) return
 
 		const [jid, lid, account] = await Promise.all([
-			client.getJid(),
-			client.getLid(),
-			client.getAccount().catch(() => undefined)
+			created.getJid(),
+			created.getLid(),
+			created.getAccount().catch(() => undefined)
 		])
+		if (owner.isClosing()) return
+
 		if (jid) {
 			user = { id: jid, lid: lid ?? undefined }
 		}
@@ -345,17 +502,17 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// `UserAgent.platform = ANDROID` (no `web_info`), mirroring upstream
 		// Baileys PR #2201. Required for the server to deliver view_once payloads.
 		if (browserName === 'Android') {
-			await client.setClientProfile({ preset: 'android', osVersion: osName })
+			await created.setClientProfile({ preset: 'android', osVersion: osName })
+			if (owner.isClosing()) return
 		}
 
 		if (isRawNodeForwardingEnabled(ws)) {
-			client.setRawNodeForwarding(true)
+			created.setRawNodeForwarding(true)
 		}
 
-		// Same race as above, but for an `end()` that landed mid-init: it
-		// already freed the client, so starting the read loop now would run
-		// against a dangling handle.
-		if (ended) return
+		// Same race as above: teardown already owns and releases this client, so
+		// starting the read loop now would run against a handle about to go.
+		if (owner.isClosing()) return
 
 		// `run()` spawns the connect/handshake/read/reconnect loop as a
 		// background task and returns `void` — it deliberately is not `async`,
@@ -373,156 +530,29 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// Freeing that automatically needs the bridge to expose loop completion
 		// (a terminal callback or an awaitable handle); until it does, the
 		// consumer has to call `sock.end()` on a terminal close.
-		client.run()
+		created.run()
 	}
 
 	let initError: Error | undefined
-	const initPromise = init()
-		.then(() => {
-			if (client) readyClient = Promise.resolve(client)
-		})
-		.catch(err => {
-			initError = err instanceof Error ? err : new Error(String(err))
-			logger.error({ err }, 'failed to initialize bridge client')
-		})
+	const initPromise = init().catch(err => {
+		initError = err instanceof Error ? err : new Error(String(err))
+		logger.error({ err }, 'failed to initialize bridge client')
 
-	let ended = false
-	const socketEndHandlers: Array<(error: Error | undefined) => void | Promise<void>> = [
-		() => activeCallContexts.clear()
-	]
-	const endImpl = async (error: Error | undefined) => {
-		// Synchronous relative to the call: an async function body runs up to
-		// its first `await` eagerly, so `init()`'s two `ended` guards still see
-		// the flag the moment `end()` is invoked.
-		ended = true
-		const c = client
-		// Closing the transport and draining the auth store are NOT conditional
-		// on a client existing. `end()` called mid-init — `await using`, or a
-		// bot that gives up during `makeWASocket()` — used to skip both, leaving
-		// `ws.readyState` stuck at CONNECTING on a socket the caller had
-		// disposed and dropping whatever the store had buffered.
-		try {
-			await ws.close()
-		} catch {
-			/* ignore */
-		}
-		client = undefined
-		readyClient = undefined
-
-		if (c) {
-			// Barrier: bridge cleanup paths fired during `disconnect()` may
-			// emit `set()` calls that are still queued as microtasks /
-			// `setImmediate` callbacks at this point. Two yields to the
-			// event loop drain (1) microtask queue and (2) the next
-			// macrotask tick where wasm-bindgen async callbacks land.
-			// Without this barrier, the flushes below run before the bridge
-			// has finished writing — a race that loses the last few sets
-			// (typically the closing-session ratchet step).
-			await new Promise(resolve => setImmediate(resolve))
-			await new Promise(resolve => setImmediate(resolve))
-		}
-
-		// Capture the FIRST flush failure so a corrupt-on-shutdown auth
-		// state surfaces to the caller. Always finish the rest of
-		// cleanup; rethrow at the end so c.free() still runs.
-		let firstFlushError: unknown
-		try {
-			await auth.store?.flush?.()
-		} catch (e) {
-			firstFlushError ??= e
-		}
-
-		try {
-			await autoWrappedStore?.flush?.()
-		} catch (e) {
-			firstFlushError ??= e
-		}
-
-		if (c) {
-			// Defence in depth ahead of `free()`, not a fix for a reproduced
-			// bug on this path — be precise about which.
-			//
-			// The hazard is real and reproducible at the bridge: freeing a
-			// client with any call still pending corrupts the wasm heap —
-			// dlmalloc trips `assertion failed: psize <= size + max_overhead`
-			// and the process dies on `RuntimeError: unreachable`, from a
-			// microtask no try/catch here can reach (`free()` itself returns
-			// normally). `logout()`, `disconnect()` and a plain
-			// `fetchBlocklist()` all reproduce it. See
-			// `__tests__/bridge-free-safety.test.ts`.
-			//
-			// What keeps `end()` off that path today is the `await ws.close()`
-			// above, which is itself a `client.disconnect()`
-			// (`Compatibility/websocket-client.ts`). This call is the belt to
-			// that braces, and the gap it closes is `WebSocketClient.close()`'s
-			// early return when `closing`/`closed` is already set: that path
-			// does NOT await the disconnect it skipped, so a caller who does
-			// `void sock.ws.close(); await sock.end()` could reach `free()` with
-			// the first disconnect still running.
-			//
-			// Both the plain and the early-return orderings were exercised
-			// against a live server with several calls outstanding, with and
-			// without this line, and neither corrupted anything — so it is
-			// insurance, not a verified failure being closed. Kept because the
-			// downside is unmeasurable latency and the upside is not having to
-			// re-derive that `ws.close()` happens to disconnect first.
-			try {
-				await c.disconnect()
-			} catch {
-				/* ignore */
-			}
-
-			// Unregister before freeing: `free()` is swallowed, so ordering it
-			// last would leave the module-level pointer aimed at a client that
-			// is already gone if anything between them threw.
-			_unregisterActiveBridgeClient(c)
-			try {
-				c.free()
-			} catch {
-				/* ignore */
-			}
-		}
-
-		// End handlers run before the flush error is rethrown: they are the
-		// consumer's teardown hook, and a corrupt-on-shutdown auth store is
-		// exactly when they most need to run.
-		for (const handler of socketEndHandlers) {
-			try {
-				await handler(error)
-			} catch (handlerError) {
-				logger.error({ err: handlerError }, 'error in socket end handler')
-			}
-		}
-
-		if (firstFlushError) throw firstFlushError
-	}
+		// A client adopted before the failure outlives a read loop that never
+		// started: `getClient()` correctly rejects, but the standalone
+		// helpers bypass it and would keep reaching the half-built client.
+		return owner.discard()
+	})
 
 	/**
-	 * Idempotent shutdown that later callers can actually await.
-	 *
-	 * Memoizing the promise rather than returning early on a flag is what makes
-	 * that true, and it became load-bearing the moment the socket started
-	 * ending *itself*: the terminal-close path fires `void end(error)` from a
-	 * synchronous dispatcher, so by the time the consumer's own
-	 * `await sock.end()` / `await sock.logout()` runs, `ended` is already set.
-	 * With an early return those awaits resolved instantly while the real
-	 * teardown — store flush, `client.disconnect()`, `free()`, end handlers —
-	 * was still running detached.
-	 *
-	 * That is a corruption path on the exact flow this design encourages:
-	 * `close` → `await sock.end()` → `makeWASocket()` on the same auth folder
-	 * gives two writers on one store. Same for `await sock.end()` followed by
-	 * deleting the folder, or by `process.exit()`.
+	 * Idempotent shutdown that later callers can actually await — the socket
+	 * now ends *itself* on a terminal disconnect, so a consumer's
+	 * `await sock.end()` is usually the second call. Resolving it early while
+	 * the first was still flushing turned
+	 * `close` → `await sock.end()` → `makeWASocket()` into two writers on one
+	 * auth folder.
 	 */
-	let endPromise: Promise<void> | undefined
-	const end = (error: Error | undefined): Promise<void> => {
-		if (endPromise) {
-			logger.trace({ trace: error?.stack }, 'connection already closing; awaiting the in-flight teardown')
-			return endPromise
-		}
-		endPromise = endImpl(error)
-		return endPromise
-	}
+	const end = (error: Error | undefined): Promise<void> => owner.close(error)
 
 	const logout = async (msg?: string) => {
 		user = undefined
@@ -535,9 +565,10 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// either way. Counting rather than flagging, because a terminal close
 		// may already have happened earlier in this socket's life.
 		const closesBefore = terminalCloseCount
-		if (client) {
+		const live = owner.peek()
+		if (live) {
 			try {
-				await client.logout()
+				await live.logout()
 			} catch {
 				/* ignore */
 			}
@@ -557,6 +588,10 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		}
 
 		await end(logoutError)
+		// The dispatcher publishes its close on a chain one hop further out than
+		// the teardown both paths await, so without this `await sock.logout()`
+		// returns just before the event it caused.
+		await terminalClosePublished
 	}
 
 	const registerSocketEndHandler = (handler: (error: Error | undefined) => void | Promise<void>) => {
@@ -677,13 +712,13 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			}
 		},
 		get waClient() {
-			return client
+			return owner.peek()
 		},
 		get isConnected() {
-			return client?.isConnected() ?? false
+			return owner.peek()?.isConnected() ?? false
 		},
 		get isLoggedIn() {
-			return client?.isLoggedIn() ?? false
+			return owner.peek()?.isLoggedIn() ?? false
 		},
 		get authState(): { creds: AuthenticationCreds; keys: SignalKeyStoreWithTransaction } {
 			return {
@@ -734,7 +769,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			// Mirrored locally because the dispatcher has to know: with this off,
 			// a plain drop is terminal rather than the start of a backoff.
 			autoReconnectEnabled = enabled
-			client?.setAutoReconnect(enabled)
+			owner.peek()?.setAutoReconnect(enabled)
 		},
 		/**
 		 * Update presence either globally (`available`/`unavailable`) or per-chat

--- a/src/Socket/terminal-close-reporter.ts
+++ b/src/Socket/terminal-close-reporter.ts
@@ -1,0 +1,149 @@
+/**
+ * Reports the terminal `connection.update { close }` — exactly once, after
+ * teardown, and never silently not at all.
+ *
+ * That sentence is the whole contract this branch sells, and getting it wrong
+ * has two opposite failure modes, both bad:
+ *
+ *  - **Not reported.** The consumer's handler never runs, so it never builds a
+ *    replacement socket. A bot offline with nothing in its logs — the original
+ *    bug this branch exists to fix.
+ *  - **Reported early, or twice.** The replacement socket overlaps the old
+ *    one's auth-store flush and `free()`, or every listener sees two terminal
+ *    notifications for one socket and a handler that cleans up on close loops.
+ *
+ * Keeping both away used to be inline logic split across the dispatcher hook
+ * and `logout()`, sharing a counter and a promise. Nine separate bugs came out
+ * of that in review — a publish that could never run, a throwing listener
+ * taking the process down, `logout()` resolving before the close it caused,
+ * the watchdog not releasing its waiters, a suppression check that also
+ * matched non-terminal teardown, a fallback that did not count itself. Every
+ * one was a different way of answering the same question, so it is one object
+ * now, with the answer in one place.
+ */
+
+import type { ILogger } from '../Utils/logger.ts'
+
+/**
+ * How long teardown may run before the close is reported anyway.
+ *
+ * A deliberate trade of one guarantee for the other: past this point the close
+ * goes out with teardown still running, because losing the event entirely is
+ * the worse of the two failures. Teardown takes milliseconds in practice, so
+ * reaching this means a consumer end handler or a store flush never settled —
+ * and the error logged alongside says exactly that. Generous rather than
+ * tight, since firing early is the harmful direction.
+ */
+export const TERMINAL_CLOSE_PUBLISH_TIMEOUT_MS = 60_000
+
+export interface TerminalCloseReporter {
+	/**
+	 * Run `teardown`, then publish. Used by the dispatcher, which learns about
+	 * the close first and hands over the publishing so the socket can finish
+	 * releasing its resources before a consumer can react.
+	 *
+	 * Never rejects and never leaves `publish` uncalled: teardown failures are
+	 * logged, a throwing listener is contained, and a teardown that hangs is
+	 * cut short by the watchdog.
+	 */
+	reportAfter: (teardown: () => Promise<void>, publish: () => void) => void
+	/**
+	 * Publish immediately, for a close nothing else will announce — a `logout()`
+	 * with no live client, or one whose `logout()` threw before the bridge
+	 * dispatched anything.
+	 */
+	reportNow: (publish: () => void) => void
+	/**
+	 * Whether a terminal close has been *claimed* — reported, or reported-and-
+	 * still-tearing-down. Not "published": `reportAfter` publishes only once
+	 * teardown finishes, so a check keyed on delivery would see `false` right
+	 * after the bridge announced the logout and let `logout()` add a second
+	 * close of its own.
+	 *
+	 * `logout()` uses this rather than "is the socket closing", which is also
+	 * true for a plain `end()` — and those report nothing, so keying off them
+	 * would let a logout racing one finish with no close at all.
+	 */
+	hasReported: () => boolean
+	/**
+	 * Settles once the most recent report has been published — the moment the
+	 * consumer sees it, not the moment teardown finishes, so a waiter is not
+	 * left hanging when the watchdog is what released the event.
+	 *
+	 * Resolves immediately when nothing has been reported.
+	 */
+	published: () => Promise<void>
+}
+
+export const makeTerminalCloseReporter = (opts: {
+	logger: ILogger
+	/** Overridable for tests; production uses the constant above. */
+	publishTimeoutMs?: number
+}): TerminalCloseReporter => {
+	const { logger } = opts
+	const publishTimeoutMs = opts.publishTimeoutMs ?? TERMINAL_CLOSE_PUBLISH_TIMEOUT_MS
+
+	/** Claims, not deliveries — see `hasReported`. */
+	let claimed = 0
+	let publishedPromise: Promise<void> | undefined
+
+	/** One publish per claim, whatever gets there first, and never throwing. */
+	const makeOnce = (publish: () => void, settle: () => void) => {
+		let done = false
+		return () => {
+			if (done) return
+			done = true
+			try {
+				publish()
+			} catch (err) {
+				// `publish` emits on the consumer's bus. Letting this escape
+				// would surface as an unhandled rejection on a detached chain —
+				// process exit under Node's default handler.
+				logger.error({ err }, 'connection.update listener threw on the terminal close')
+			}
+			settle()
+		}
+	}
+
+	return {
+		reportAfter: (teardown, publish) => {
+			claimed++
+			let settle!: () => void
+			publishedPromise = new Promise<void>(resolve => {
+				settle = resolve
+			})
+			const publishOnce = makeOnce(publish, settle)
+
+			// Deliberately referenced: a pending promise does not keep Node's
+			// event loop alive, so an unref'd timer lets a minimal bot exit
+			// before it can publish — and the close handler that would have
+			// built the replacement never runs, which is what this guards.
+			// Cleared the moment teardown settles, so it holds the loop only
+			// while one is in flight.
+			const watchdog = setTimeout(() => {
+				logger.error({ afterMs: publishTimeoutMs }, 'socket teardown is still running; reporting the close anyway')
+				publishOnce()
+			}, publishTimeoutMs)
+
+			const finish = (err?: unknown) => {
+				clearTimeout(watchdog)
+				if (err) logger.error({ err }, 'socket teardown failed after a terminal disconnect')
+				publishOnce()
+			}
+			void teardown().then(() => finish(), finish)
+		},
+
+		reportNow: publish => {
+			claimed++
+			let settle!: () => void
+			publishedPromise = new Promise<void>(resolve => {
+				settle = resolve
+			})
+			makeOnce(publish, settle)()
+		},
+
+		hasReported: () => claimed > 0,
+
+		published: () => publishedPromise ?? Promise.resolve()
+	}
+}

--- a/src/Socket/terminal-close-reporter.ts
+++ b/src/Socket/terminal-close-reporter.ts
@@ -130,7 +130,16 @@ export const makeTerminalCloseReporter = (opts: {
 				if (err) logger.error({ err }, 'socket teardown failed after a terminal disconnect')
 				publishOnce()
 			}
-			void teardown().then(() => finish(), finish)
+			// `teardown()` is called inside the try because it can throw
+			// *synchronously*, before returning a promise — `.then` would never
+			// run and the close would stay unpublished until the watchdog, or
+			// forever if the timer were ever removed. The no-silent-failure
+			// promise has to hold for that path too.
+			try {
+				void teardown().then(() => finish(), finish)
+			} catch (err) {
+				finish(err)
+			}
 		},
 
 		reportNow: publish => {

--- a/src/Socket/terminal-close.ts
+++ b/src/Socket/terminal-close.ts
@@ -21,8 +21,12 @@
  * Events deliberately absent from the terminal set, and why:
  *  - `disconnected` — the engine only dispatches `Event::Disconnected` for an
  *    *unexpected* loop exit, and every terminal path sets `expected_disconnect`
- *    first, which suppresses it (`client/lifecycle.rs`). So this one is by
- *    construction the "engine is retrying" signal.
+ *    first, which suppresses it (`client/lifecycle.rs`). So this one is the
+ *    "engine is retrying" signal — with one exception the dispatcher handles:
+ *    under `setAutoReconnect(false)` the run loop dispatches `Disconnected`
+ *    and only *then* tests the flag and breaks out, which makes the very same
+ *    event terminal. Absence from this list means "not terminal on its own",
+ *    not "never terminal".
  *  - `streamError` — reaches JS only from the engine's catch-all `<stream:error>`
  *    branch (unknown code, `<ack/>`, `<xml-not-well-formed>`); the coded ones
  *    (401/409/515/516/429/503) dispatch their own events instead. Every case

--- a/src/Socket/terminal-close.ts
+++ b/src/Socket/terminal-close.ts
@@ -1,0 +1,49 @@
+/**
+ * Which bridge disconnects end the socket for good.
+ *
+ * This mirrors one decision that lives in the Rust engine, so keep it honest:
+ * `whatsapp-rust` clears `enable_auto_reconnect` and breaks out of its run loop
+ * on exactly these, and retries everything else on the WA Web Fibonacci backoff
+ * (`client/lifecycle.rs`).
+ *
+ * The socket layer needs the answer because `WasmWhatsAppClient.run()` returns
+ * `void` — it spawns the loop as a background task, so the loop's exit is not
+ * observable from JS (`whatsapp_rust_bridge.d.ts`, `run(): void`). Until the
+ * bridge exposes loop completion, this table is how the socket knows a client
+ * has become dead weight that only `free()` can reclaim.
+ *
+ * The upstream Baileys contract this buys us: `connection.update { close }`
+ * means "this socket is finished, build a new one" — which is what every
+ * consumer written against upstream already assumes, because upstream has no
+ * auto-reconnect at all. Transient drops therefore never surface as `close`;
+ * they surface as `connecting`.
+ *
+ * Events deliberately absent from the terminal set, and why:
+ *  - `disconnected` — the engine only dispatches `Event::Disconnected` for an
+ *    *unexpected* loop exit, and every terminal path sets `expected_disconnect`
+ *    first, which suppresses it (`client/lifecycle.rs`). So this one is by
+ *    construction the "engine is retrying" signal.
+ *  - `streamError` — reaches JS only from the engine's catch-all `<stream:error>`
+ *    branch (unknown code, `<ack/>`, `<xml-not-well-formed>`); the coded ones
+ *    (401/409/515/516/429/503) dispatch their own events instead. Every case
+ *    that gets here keeps the connection or recycles it deliberately.
+ *  - `pairError` — pairing failed, but the engine keeps its loop and re-emits a
+ *    QR; nothing about the client is dead.
+ */
+
+/**
+ * `ConnectFailureReason` wire codes the engine retries — the JS mirror of
+ * `ConnectFailureReason::should_reconnect()`, which matches only
+ * `InternalServerError | ServiceUnavailable`.
+ *
+ * A `<failure>` with no reason at all is NOT retried: the engine parses it as
+ * `Unknown(0)`, which fails `should_reconnect()`.
+ */
+const RECONNECTABLE_CONNECT_FAILURE_REASONS: ReadonlySet<number> = new Set([
+	500, // InternalServerError
+	503 // ServiceUnavailable
+])
+
+/** True when the engine will keep retrying after this `<failure>`. */
+export const isReconnectableConnectFailure = (reason: number | undefined): boolean =>
+	reason !== undefined && RECONNECTABLE_CONNECT_FAILURE_REASONS.has(reason)

--- a/src/Utils/event-buffer.ts
+++ b/src/Utils/event-buffer.ts
@@ -399,7 +399,14 @@ export const makeEventBuffer = (logger: ILogger): BaileysBufferableEventEmitter 
 				// the bot would stay offline. This is the lifecycle channel;
 				// losing delivery here is the failure mode the socket's whole
 				// close contract exists to prevent.
-				for (const listener of ev.listeners(event)) {
+				// `rawListeners`, not `listeners`: the latter unwraps `once()`
+				// handlers to the function underneath, so calling that would
+				// never run the wrapper that unregisters them and the listener
+				// would stay subscribed for every later update. `once` is not on
+				// `BaileysEventEmitter` today, so this is unreachable rather than
+				// broken — but the two differ only in this respect and the raw
+				// one is the correct primitive for calling listeners by hand.
+				for (const listener of ev.rawListeners(event)) {
 					try {
 						// `.call(ev, …)` so `this` is still the emitter, as it
 						// would be under `emit()`. A listener declared as a

--- a/src/Utils/event-buffer.ts
+++ b/src/Utils/event-buffer.ts
@@ -401,7 +401,12 @@ export const makeEventBuffer = (logger: ILogger): BaileysBufferableEventEmitter 
 				// close contract exists to prevent.
 				for (const listener of ev.listeners(event)) {
 					try {
-						;(listener as (data: unknown) => void)(events[event])
+						// `.call(ev, …)` so `this` is still the emitter, as it
+						// would be under `emit()`. A listener declared as a
+						// normal function that does `this.off('connection.update', …)`
+						// — a common self-removing pattern — would otherwise
+						// throw on `undefined` and be swallowed by the catch.
+						;(listener as (this: unknown, data: unknown) => void).call(ev, events[event])
 					} catch (err) {
 						logger.error({ err, event }, 'connection.update listener threw; continuing with the rest')
 					}

--- a/src/Utils/event-buffer.ts
+++ b/src/Utils/event-buffer.ts
@@ -391,6 +391,23 @@ export const makeEventBuffer = (logger: ILogger): BaileysBufferableEventEmitter 
 
 	ev.on('event', (events: BaileysEventData) => {
 		for (const event of Object.keys(events) as BaileysEvent[]) {
+			if (event === 'connection.update') {
+				// Delivered listener by listener, unlike every other event.
+				// `EventEmitter.emit()` stops at the first listener that throws,
+				// so one bad handler would keep the rest — including the app's
+				// reconnect handler — from ever seeing a terminal `close`, and
+				// the bot would stay offline. This is the lifecycle channel;
+				// losing delivery here is the failure mode the socket's whole
+				// close contract exists to prevent.
+				for (const listener of ev.listeners(event)) {
+					try {
+						;(listener as (data: unknown) => void)(events[event])
+					} catch (err) {
+						logger.error({ err, event }, 'connection.update listener threw; continuing with the rest')
+					}
+				}
+				continue
+			}
 			ev.emit(event, events[event])
 		}
 	})

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -900,6 +900,22 @@ export const _registerActiveBridgeClient = (client: WasmWhatsAppClient, logger?:
 	activeBridgeLogger = logger
 }
 
+/**
+ * Drop the module-level pointer when `sock.end()` frees the client it points
+ * at. Without this the global keeps a strong reference to a freed
+ * `WasmWhatsAppClient`, so the next standalone `downloadContentFromMessage()`
+ * call reaches into a null wasm pointer and fails with an opaque
+ * wasm-bindgen error instead of the actionable "no bridge client" Boom.
+ *
+ * Identity-checked on purpose: a multi-account host that ends socket A after
+ * creating socket B must not clear B's registration.
+ */
+export const _unregisterActiveBridgeClient = (client: WasmWhatsAppClient) => {
+	if (activeBridgeClient !== client) return
+	activeBridgeClient = undefined
+	activeBridgeLogger = undefined
+}
+
 const noopLogger: ILogger = {
 	level: 'silent',
 	child: () => noopLogger,

--- a/src/__tests__/active-bridge-client-unregister.test.ts
+++ b/src/__tests__/active-bridge-client-unregister.test.ts
@@ -1,0 +1,97 @@
+/**
+ * `_registerActiveBridgeClient` is a module-level pointer to the most-recently
+ * created bridge client, used by the standalone helpers
+ * (`downloadContentFromMessage`, `downloadHistory`) that carry no socket.
+ *
+ * `sock.end()` calls `c.free()`. While the global still pointed at the freed
+ * client, the next standalone call reached through a null wasm pointer and
+ * failed with an opaque wasm-bindgen error instead of the actionable Boom —
+ * and the global kept a strong reference to a client the socket had dropped.
+ */
+
+import { describe, it } from 'node:test'
+
+import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+import { _registerActiveBridgeClient, _unregisterActiveBridgeClient } from '../Utils/messages.ts'
+import { downloadHistory } from '../Utils/process-history-message.ts'
+import { expect } from './expect.ts'
+
+const mediaNotification = {
+	directPath: '/v/history',
+	mediaKey: new Uint8Array(32),
+	fileSha256: new Uint8Array(32),
+	fileEncSha256: new Uint8Array(32),
+	fileLength: 1
+}
+
+/** A client whose `downloadMediaStream` fails the way wasm-bindgen does after `free()`. */
+const freedClient = (): WasmWhatsAppClient =>
+	({
+		downloadMediaStream: () => {
+			throw new Error('null pointer passed to rust')
+		}
+	}) as unknown as WasmWhatsAppClient
+
+const liveClient = (): WasmWhatsAppClient =>
+	({
+		downloadMediaStream: () =>
+			new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.close()
+				}
+			})
+	}) as unknown as WasmWhatsAppClient
+
+/** Message of the error the standalone helper produces for the notification above. */
+const downloadError = async (): Promise<string> => {
+	try {
+		await downloadHistory(mediaNotification, {})
+		return '<no error>'
+	} catch (err) {
+		return err instanceof Error ? err.message : String(err)
+	}
+}
+
+describe('_unregisterActiveBridgeClient', () => {
+	it('leaves the standalone helper reporting "no bridge client" instead of reaching a freed pointer', async () => {
+		const client = freedClient()
+		_registerActiveBridgeClient(client)
+
+		// Before: the global still points at the freed client.
+		expect(await downloadError()).toContain('null pointer passed to rust')
+
+		// After: `sock.end()` unregisters, so the helper fails with the
+		// actionable message rather than the wasm-bindgen one.
+		_unregisterActiveBridgeClient(client)
+		const message = await downloadError()
+		expect(message).toContain('no bridge client available')
+		expect(message.includes('null pointer passed to rust')).toBe(false)
+	})
+
+	it('is identity-checked: ending socket A must not unregister socket B', async () => {
+		const a = freedClient()
+		const b = liveClient()
+
+		_registerActiveBridgeClient(a)
+		_registerActiveBridgeClient(b) // a second socket takes over the pointer
+
+		_unregisterActiveBridgeClient(a) // the old socket's `end()`
+
+		// B is still registered, so the download runs against it and fails
+		// further downstream (empty payload) — not with "no bridge client".
+		const message = await downloadError()
+		expect(message.includes('no bridge client available')).toBe(false)
+	})
+
+	it('is idempotent: a repeated unregister must not clear the next registration', async () => {
+		const a = freedClient()
+		_registerActiveBridgeClient(a)
+		_unregisterActiveBridgeClient(a)
+		_unregisterActiveBridgeClient(a)
+
+		const b = liveClient()
+		_registerActiveBridgeClient(b)
+		const message = await downloadError()
+		expect(message.includes('no bridge client available')).toBe(false)
+	})
+})

--- a/src/__tests__/active-bridge-client-unregister.test.ts
+++ b/src/__tests__/active-bridge-client-unregister.test.ts
@@ -9,7 +9,7 @@
  * and the global kept a strong reference to a client the socket had dropped.
  */
 
-import { describe, it } from 'node:test'
+import { afterEach, describe, it } from 'node:test'
 
 import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
 import { _registerActiveBridgeClient, _unregisterActiveBridgeClient } from '../Utils/messages.ts'
@@ -53,9 +53,21 @@ const downloadError = async (): Promise<string> => {
 }
 
 describe('_unregisterActiveBridgeClient', () => {
-	it('leaves the standalone helper reporting "no bridge client" instead of reaching a freed pointer', async () => {
-		const client = freedClient()
+	// The pointer is module-global, so a test that leaves one registered makes
+	// the next one order-dependent. Track what each test claimed and release it.
+	const registered: WasmWhatsAppClient[] = []
+	const register = (client: WasmWhatsAppClient) => {
+		registered.push(client)
 		_registerActiveBridgeClient(client)
+		return client
+	}
+
+	afterEach(() => {
+		for (const client of registered.splice(0)) _unregisterActiveBridgeClient(client)
+	})
+
+	it('leaves the standalone helper reporting "no bridge client" instead of reaching a freed pointer', async () => {
+		const client = register(freedClient())
 
 		// Before: the global still points at the freed client.
 		expect(await downloadError()).toContain('null pointer passed to rust')
@@ -69,29 +81,31 @@ describe('_unregisterActiveBridgeClient', () => {
 	})
 
 	it('is identity-checked: ending socket A must not unregister socket B', async () => {
-		const a = freedClient()
-		const b = liveClient()
-
-		_registerActiveBridgeClient(a)
-		_registerActiveBridgeClient(b) // a second socket takes over the pointer
+		const a = register(freedClient())
+		const b = register(liveClient()) // a second socket takes over the pointer
 
 		_unregisterActiveBridgeClient(a) // the old socket's `end()`
 
 		// B is still registered, so the download runs against it and fails
 		// further downstream (empty payload) — not with "no bridge client".
-		const message = await downloadError()
-		expect(message.includes('no bridge client available')).toBe(false)
+		expect((await downloadError()).includes('no bridge client available')).toBe(false)
+
+		// And B really is why: clearing it flips the failure back, which a bare
+		// negative assertion would not have proven — it also passes when the
+		// download simply succeeds.
+		_unregisterActiveBridgeClient(b)
+		expect(await downloadError()).toContain('no bridge client available')
 	})
 
 	it('is idempotent: a repeated unregister must not clear the next registration', async () => {
-		const a = freedClient()
-		_registerActiveBridgeClient(a)
+		const a = register(freedClient())
 		_unregisterActiveBridgeClient(a)
 		_unregisterActiveBridgeClient(a)
 
-		const b = liveClient()
-		_registerActiveBridgeClient(b)
-		const message = await downloadError()
-		expect(message.includes('no bridge client available')).toBe(false)
+		const b = register(liveClient())
+		expect((await downloadError()).includes('no bridge client available')).toBe(false)
+
+		_unregisterActiveBridgeClient(b)
+		expect(await downloadError()).toContain('no bridge client available')
 	})
 })

--- a/src/__tests__/auto-reconnect-terminal-close.test.ts
+++ b/src/__tests__/auto-reconnect-terminal-close.test.ts
@@ -82,9 +82,12 @@ const dispatch = (bridgeEvent: BridgeEvent, opts: { autoReconnect?: boolean } = 
 	})
 
 	makeEventHandlers(ctx, {
-		onTerminalClose: error => {
+		onTerminalClose: (error, publish) => {
 			terminalCloses.push(error)
 			trace.push('end')
+			// The socket wires this to `end(...).finally(publish)`; the test
+			// stands in for a teardown that has already finished.
+			publish()
 		},
 		isAutoReconnectEnabled: () => opts.autoReconnect ?? true
 	}).onEvent?.(bridgeEvent as never)
@@ -291,6 +294,28 @@ describe('setAutoReconnect(false) turns a plain drop terminal', () => {
 		expect(close).toBe(undefined)
 		expect(trace).toEqual(['connecting'])
 	})
+
+	// 500/503 are only "retryable" while the engine is allowed to retry. With
+	// the flag off the run loop breaks on the next pass, so reporting
+	// `connecting` would strand the socket in that state with nothing left to
+	// restore it and the wasm client never freed.
+	// 503 has a DisconnectReason of its own; 500 falls through to the generic
+	// connectionClosed, same as it would in `mapConnectFailureToDisconnect`.
+	for (const { reason, expected } of [
+		{ reason: 503, expected: DisconnectReason.unavailableService },
+		{ reason: 500, expected: DisconnectReason.connectionClosed }
+	]) {
+		it(`connect failure ${reason} is terminal too when auto-reconnect is off`, () => {
+			const { close, statusCode, trace } = dispatch(
+				{ type: 'connect_failure', data: { reason, message: 'x' } },
+				{ autoReconnect: false }
+			)
+
+			expect(close?.connection).toBe('close')
+			expect(statusCode).toBe(expected)
+			expect(trace).toEqual(['end', 'close'])
+		})
+	}
 })
 
 describe('a retrying update clears the spent QR', () => {

--- a/src/__tests__/auto-reconnect-terminal-close.test.ts
+++ b/src/__tests__/auto-reconnect-terminal-close.test.ts
@@ -1,0 +1,321 @@
+/**
+ * `connection.update { close }` means one thing on this socket, the same thing
+ * it means in upstream Baileys: this socket is finished, build a new one.
+ *
+ * That equivalence is what makes the canonical upstream handler safe here:
+ *
+ * ```ts
+ * if (connection === 'close') {
+ *   const shouldReconnect = statusCode !== DisconnectReason.loggedOut
+ *   if (shouldReconnect) connectToWhatsApp()
+ * }
+ * ```
+ *
+ * Upstream has no auto-reconnect, so that handler assumes every `close` is
+ * final. baileyrs runs an engine that reconnects on a Fibonacci backoff, so if
+ * a transient drop surfaced as `close` the handler would build a second socket
+ * while the engine was already restoring the first — two live sockets for one
+ * connection. Transient drops therefore surface as `connecting`.
+ *
+ * The split mirrors `whatsapp-rust`: it clears `enable_auto_reconnect` and
+ * exits its run loop on the terminal set below, and retries everything else.
+ */
+
+import { EventEmitter } from 'node:events'
+import { describe, it } from 'node:test'
+
+import { makeEventHandler, makeEventHandlers } from '../Socket/events.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import type { ConnectionState } from '../Types/index.ts'
+import { DisconnectReason } from '../Types/index.ts'
+import type { Boom } from '../Utils/boom.ts'
+import { expect } from './expect.ts'
+
+const noopLogger = {
+	trace() {},
+	debug() {},
+	info() {},
+	warn() {},
+	error() {},
+	child() {
+		return noopLogger
+	}
+}
+
+const makeCtx = () => {
+	const ev = new EventEmitter()
+	const ws = new EventEmitter()
+	const ctx: SocketContext = {
+		ev: ev as unknown as SocketContext['ev'],
+		logger: noopLogger as never,
+		fullConfig: {} as never,
+		ws,
+		getUser: () => undefined,
+		getMe: () => undefined,
+		setUser: () => {},
+		getClient: () => Promise.reject(new Error('not used')),
+		getClientSync: () => {
+			throw new Error('not used')
+		}
+	}
+	return { ctx, ev }
+}
+
+type BridgeEvent = { type: string; data?: unknown }
+
+/**
+ * Run a bridge event through the dispatcher and collect what it published.
+ *
+ * `trace` records `onTerminalClose` and each `connection.update` in the order
+ * they actually happened — the ordering is the invariant the whole design
+ * rests on, so it has to be observed, not assumed.
+ */
+const dispatch = (bridgeEvent: BridgeEvent, opts: { autoReconnect?: boolean } = {}) => {
+	const { ctx, ev } = makeCtx()
+	const updates: Partial<ConnectionState>[] = []
+	const terminalCloses: Error[] = []
+	const trace: string[] = []
+
+	ev.on('connection.update', (update: Partial<ConnectionState>) => {
+		updates.push(update)
+		trace.push(update.connection ?? 'update')
+	})
+
+	makeEventHandlers(ctx, {
+		onTerminalClose: error => {
+			terminalCloses.push(error)
+			trace.push('end')
+		},
+		isAutoReconnectEnabled: () => opts.autoReconnect ?? true
+	}).onEvent?.(bridgeEvent as never)
+
+	const close = updates.find(update => update.connection === 'close')
+	return {
+		updates,
+		close,
+		terminalCloses,
+		trace,
+		statusCode: (close?.lastDisconnect?.error as Boom | undefined)?.output?.statusCode
+	}
+}
+
+/**
+ * Disconnects where `whatsapp-rust` stores `enable_auto_reconnect = false` and
+ * exits its run loop. None recover without a new socket.
+ */
+const TERMINAL: Array<{ label: string; event: BridgeEvent; expected: number }> = [
+	{
+		label: 'logged out',
+		event: { type: 'logged_out', data: { reason: 'LoggedOut' } },
+		expected: DisconnectReason.loggedOut
+	},
+	{
+		// `<stream:error conflict="replaced">` / code 409
+		label: 'stream replaced: another session took the device',
+		event: { type: 'stream_replaced' },
+		expected: DisconnectReason.connectionReplaced
+	},
+	{
+		// `<failure reason="405">`
+		// The wire code, not `badSession` (500) — see the dispatcher.
+		label: 'client outdated: the server rejected this build',
+		event: { type: 'client_outdated' },
+		expected: 405
+	},
+	{
+		// `<failure reason="402">`
+		label: 'temporary ban',
+		event: { type: 'temporary_ban', data: { code: 101, expire: 1893456000 } },
+		expected: DisconnectReason.forbidden
+	},
+	{
+		// `should_reconnect()` is false for every reason below.
+		label: 'connect failure 400 (Generic)',
+		event: { type: 'connect_failure', data: { reason: 400, message: 'Generic' } },
+		expected: DisconnectReason.connectionClosed
+	},
+	{
+		label: 'connect failure 409 (BadUserAgent)',
+		event: { type: 'connect_failure', data: { reason: 409, message: 'BadUserAgent' } },
+		expected: DisconnectReason.connectionClosed
+	},
+	{
+		label: 'connect failure 413 (CatExpired)',
+		event: { type: 'connect_failure', data: { reason: 413, message: 'CatExpired' } },
+		expected: DisconnectReason.connectionClosed
+	},
+	{
+		// No reason at all: the engine reads it as `Unknown(0)`, which fails
+		// `should_reconnect()`.
+		label: 'connect failure with no reason',
+		event: { type: 'connect_failure', data: {} },
+		expected: DisconnectReason.connectionClosed
+	}
+]
+
+/** Disconnects the engine recovers from on its own. */
+const RETRYING: Array<{ label: string; event: BridgeEvent }> = [
+	{
+		// The engine dispatches `Disconnected` only for an unexpected loop exit;
+		// terminal paths set `expected_disconnect`, which suppresses it.
+		label: 'transport drop',
+		event: { type: 'disconnected' }
+	},
+	{
+		// `should_reconnect()` matches ServiceUnavailable…
+		label: 'connect failure 503 (ServiceUnavailable)',
+		event: { type: 'connect_failure', data: { reason: 503, message: 'ServiceUnavailable' } }
+	},
+	{
+		// …and InternalServerError.
+		label: 'connect failure 500 (InternalServerError)',
+		event: { type: 'connect_failure', data: { reason: 500, message: 'InternalServerError' } }
+	},
+	{
+		// Pairing failed; the engine keeps its loop and re-emits a QR. The
+		// `connecting` update is what clears the spent QR from consumer state.
+		label: 'pair error',
+		event: { type: 'pair_error', data: { error: 'bad signature' } }
+	}
+]
+
+/** Events that must not touch `connection.update` at all. */
+const SILENT: Array<{ label: string; event: BridgeEvent }> = [
+	{
+		// Reaches JS only from the engine's catch-all `<stream:error>` branch —
+		// unknown code, `<ack/>`, `<xml-not-well-formed>` — every one of which
+		// keeps or deliberately recycles the connection. This used to report
+		// `badSession`, the code bots use to wipe credentials and re-pair.
+		label: 'stream error (connection preserved)',
+		event: { type: 'stream_error', data: { code: 'unknown' } }
+	}
+]
+
+describe('connection.update: terminal disconnects', () => {
+	for (const { label, event, expected } of TERMINAL) {
+		it(`${label} → close ${expected}, and the socket ends itself`, () => {
+			const result = dispatch(event)
+
+			expect(result.close?.connection).toBe('close')
+			expect(result.statusCode).toBe(expected)
+			// `onTerminalClose` is what frees the wasm client: `run()` returns
+			// void, so the engine's loop exit is invisible from JS.
+			expect(result.terminalCloses.length).toBe(1)
+		})
+	}
+})
+
+describe('connection.update: disconnects the engine retries', () => {
+	for (const { label, event } of RETRYING) {
+		it(`${label} → 'connecting', never 'close'`, () => {
+			const result = dispatch(event)
+
+			expect(result.close).toBe(undefined)
+			expect(result.updates.map(update => update.connection)).toEqual(['connecting'])
+			// Ending here would kill a socket the engine is busy restoring.
+			expect(result.terminalCloses.length).toBe(0)
+		})
+	}
+})
+
+describe('connection.update: events that must stay off the channel', () => {
+	for (const { label, event } of SILENT) {
+		it(`${label} → no connection.update`, () => {
+			const result = dispatch(event)
+
+			expect(result.updates.length).toBe(0)
+			expect(result.terminalCloses.length).toBe(0)
+		})
+	}
+})
+
+describe('the upstream Baileys reconnect handler is safe against every disconnect', () => {
+	/** README §"Connecting" — the canonical consumer handler, verbatim in spirit. */
+	const upstreamHandler = (update: Partial<ConnectionState>): 'reconnect' | 'stay-logged-out' | 'ignore' => {
+		if (update.connection !== 'close') return 'ignore'
+		const statusCode = (update.lastDisconnect?.error as Boom | undefined)?.output?.statusCode
+		return statusCode === DisconnectReason.loggedOut ? 'stay-logged-out' : 'reconnect'
+	}
+
+	it('never builds a second socket while the engine is still retrying', () => {
+		// This is the whole point. Every retrying disconnect must leave the
+		// upstream handler idle, or the consumer's new socket races the one the
+		// engine is restoring.
+		for (const { label, event } of [...RETRYING, ...SILENT]) {
+			const { updates } = dispatch(event)
+			const actions = updates.map(upstreamHandler)
+			expect(actions.every(action => action === 'ignore')).toBe(true)
+			expect(label.length > 0).toBe(true)
+		}
+	})
+
+	it('does act on every terminal disconnect, which is the only time a new socket is right', () => {
+		for (const { event } of TERMINAL) {
+			const { close } = dispatch(event)
+			if (!close) throw new Error('expected a terminal close')
+			const action = upstreamHandler(close)
+			expect(action === 'reconnect' || action === 'stay-logged-out').toBe(true)
+		}
+	})
+
+	it('and by then the old socket has already ended, so the two never overlap', () => {
+		// Ordering, not just occurrence. `end()` sets its `ended` flag
+		// synchronously, so it has to run BEFORE the consumer sees the close —
+		// otherwise a handler that answers with `makeWASocket()` races a socket
+		// that has not started tearing down. Asserting only that
+		// `onTerminalClose` fired would pass with the two swapped.
+		for (const { label, event } of TERMINAL) {
+			const { trace } = dispatch(event)
+			expect(trace).toEqual(['end', 'close'])
+			expect(label.length > 0).toBe(true)
+		}
+	})
+})
+
+describe('setAutoReconnect(false) turns a plain drop terminal', () => {
+	// `client/lifecycle.rs` dispatches `Disconnected` and only THEN tests the
+	// flag and breaks out of the run loop. Reporting `connecting` there would
+	// leave the socket in that state forever: the engine is gone, nothing frees
+	// the wasm client, and the consumer's reconnect handler never fires.
+	it('reports close and ends the socket when auto-reconnect is off', () => {
+		const { close, statusCode, trace } = dispatch({ type: 'disconnected' }, { autoReconnect: false })
+
+		expect(close?.connection).toBe('close')
+		expect(statusCode).toBe(DisconnectReason.connectionClosed)
+		expect(trace).toEqual(['end', 'close'])
+	})
+
+	it('still reports connecting while auto-reconnect is on', () => {
+		const { close, trace } = dispatch({ type: 'disconnected' }, { autoReconnect: true })
+
+		expect(close).toBe(undefined)
+		expect(trace).toEqual(['connecting'])
+	})
+})
+
+describe('a retrying update clears the spent QR', () => {
+	// Upstream's own `connecting` always carries these. Without the explicit
+	// clear, a consumer merging partial state keeps rendering a QR the server
+	// has already rotated away.
+	it('carries qr: undefined and receivedPendingNotifications: false', () => {
+		const { updates } = dispatch({ type: 'disconnected' })
+
+		expect(updates.length).toBe(1)
+		expect('qr' in updates[0]!).toBe(true)
+		expect(updates[0]?.qr).toBe(undefined)
+		expect(updates[0]?.receivedPendingNotifications).toBe(false)
+	})
+})
+
+describe('makeEventHandler stays usable without callbacks', () => {
+	it('a terminal event with no onTerminalClose wired still emits its close', () => {
+		const { ctx, ev } = makeCtx()
+		const updates: Partial<ConnectionState>[] = []
+		ev.on('connection.update', (update: Partial<ConnectionState>) => updates.push(update))
+
+		makeEventHandler(ctx)({ type: 'stream_replaced' } as never)
+
+		expect(updates.length).toBe(1)
+		expect(updates[0]?.connection).toBe('close')
+	})
+})

--- a/src/__tests__/auto-reconnect-terminal-close.test.ts
+++ b/src/__tests__/auto-reconnect-terminal-close.test.ts
@@ -194,6 +194,25 @@ const SILENT: Array<{ label: string; event: BridgeEvent }> = [
 	}
 ]
 
+describe('dispatcher cleanup', () => {
+	it('hands back a cleanup the socket can run on any teardown', () => {
+		// The history-sync pause timer outlives the event that armed it, and
+		// only `emitClose` clears it — so `sock.end()` or an `await using` scope
+		// exiting would leave it to fire `messaging-history.status: paused` from
+		// a socket whose client is already freed. The socket registers this as
+		// an end handler.
+		const { ctx } = makeCtx()
+		const cleanups: Array<() => void> = []
+
+		makeEventHandlers(ctx, { onCleanup: cleanup => cleanups.push(cleanup) })
+
+		expect(cleanups.length).toBe(1)
+		// Idempotent and safe with nothing armed.
+		cleanups[0]!()
+		cleanups[0]!()
+	})
+})
+
 describe('connection.update: terminal disconnects', () => {
 	for (const { label, event, expected } of TERMINAL) {
 		it(`${label} → close ${expected}, and the socket ends itself`, () => {

--- a/src/__tests__/bridge-client-owner.test.ts
+++ b/src/__tests__/bridge-client-owner.test.ts
@@ -271,6 +271,32 @@ describe('bridge client owner: settled', () => {
 		expect(releaseFinished).toBe(true)
 	})
 
+	it('does not adopt the failure of a close it joined', async () => {
+		// `discard()` is best-effort cleanup called from `init()`'s catch, and
+		// `close()` rejects when teardown rethrows the first auth-store flush
+		// error. Propagating that would make `initPromise` reject — which the
+		// socket documents as impossible, relies on for `getClient()`'s error
+		// message, and does not always await, so it could surface as an
+		// unhandled rejection.
+		const h = makeHarness({
+			teardown: async () => {
+				throw new Error('flush exploded')
+			}
+		})
+		h.owner.adopt(h.client())
+
+		const closing = h.owner.close(undefined)
+		// Resolving is the assertion.
+		await h.owner.discard()
+
+		// …and the close itself still reports the failure to its own callers.
+		let thrown: unknown
+		await closing.catch(err => {
+			thrown = err
+		})
+		expect((thrown as Error | undefined)?.message).toBe('flush exploded')
+	})
+
 	it('resolves immediately when nothing is in flight', async () => {
 		const h = makeHarness()
 		await h.owner.settled()

--- a/src/__tests__/bridge-client-owner.test.ts
+++ b/src/__tests__/bridge-client-owner.test.ts
@@ -297,6 +297,28 @@ describe('bridge client owner: settled', () => {
 		expect((thrown as Error | undefined)?.message).toBe('flush exploded')
 	})
 
+	it('close() waits for a release a concurrent discard() started', async () => {
+		// `discard()` puts the client back in `starting` before awaiting its
+		// release, so a `close()` landing in that window captures no client and
+		// runs teardown without it. The release is still going — settling
+		// `close()` there lets the caller start a replacement socket, or delete
+		// the auth folder, while a client is mid-disconnect.
+		let releaseFinished = false
+		const h = makeHarness({
+			release: async () => {
+				await wait(150)
+				releaseFinished = true
+			}
+		})
+		h.owner.adopt(h.client())
+
+		const discarding = h.owner.discard()
+		await h.owner.close(undefined)
+
+		expect(releaseFinished).toBe(true)
+		await discarding
+	})
+
 	it('resolves immediately when nothing is in flight', async () => {
 		const h = makeHarness()
 		await h.owner.settled()

--- a/src/__tests__/bridge-client-owner.test.ts
+++ b/src/__tests__/bridge-client-owner.test.ts
@@ -1,0 +1,274 @@
+/**
+ * The bridge client's lifetime, tested without a bridge.
+ *
+ * These races used to need a real wasm client to reach, which meant child
+ * processes, loopback listeners and a cuttable TCP proxy — and even then some
+ * of them could not be forced deterministically. Owning the lifetime behind a
+ * small interface makes the same cases plain unit tests: a fake "client" is
+ * only ever adopted, disconnected and freed.
+ */
+
+import { describe, it } from 'node:test'
+
+import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+import { type BridgeClientOwner, makeBridgeClientOwner } from '../Socket/bridge-client-owner.ts'
+import { expect } from './expect.ts'
+
+const noopLogger = {
+	trace() {},
+	debug() {},
+	info() {},
+	warn() {},
+	error() {},
+	child() {
+		return noopLogger
+	}
+}
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+interface Harness {
+	owner: BridgeClientOwner
+	/** Ordered log of every lifecycle effect, for asserting sequence not just occurrence. */
+	trace: string[]
+	client: (name?: string) => WasmWhatsAppClient
+	teardownCalls: Array<{ client: WasmWhatsAppClient | undefined; error: Error | undefined }>
+}
+
+const makeHarness = (
+	overrides: {
+		teardown?: (client: WasmWhatsAppClient | undefined, error: Error | undefined) => Promise<void>
+		release?: (client: WasmWhatsAppClient) => Promise<void>
+	} = {}
+): Harness => {
+	const trace: string[] = []
+	const teardownCalls: Array<{ client: WasmWhatsAppClient | undefined; error: Error | undefined }> = []
+
+	const client = (name = 'client') => ({ name }) as unknown as WasmWhatsAppClient
+
+	const owner = makeBridgeClientOwner({
+		logger: noopLogger as never,
+		teardown: async (adopted, error) => {
+			teardownCalls.push({ client: adopted, error })
+			trace.push(adopted ? 'teardown(with-client)' : 'teardown(no-client)')
+			if (overrides.teardown) await overrides.teardown(adopted, error)
+		},
+		release: async adopted => {
+			trace.push(`release(${(adopted as unknown as { name: string }).name})`)
+			if (overrides.release) await overrides.release(adopted)
+		}
+	})
+
+	return { owner, trace, client, teardownCalls }
+}
+
+describe('bridge client owner: adoption', () => {
+	it('publishes the client so the socket can reach it', () => {
+		const h = makeHarness()
+		const c = h.client()
+
+		expect(h.owner.adopt(c)).toBe(true)
+		expect(h.owner.peek()).toBe(c)
+	})
+
+	it('refuses and releases a client adopted after close started', async () => {
+		// The mid-init teardown window: startup finished building a client that
+		// nothing would otherwise own — no owner means nothing frees it and its
+		// read loop reconnects forever against a disposed socket.
+		const h = makeHarness()
+		const closed = h.owner.close(undefined)
+
+		const late = h.client('late')
+		expect(h.owner.adopt(late)).toBe(false)
+		expect(h.owner.peek()).toBe(undefined)
+
+		await closed
+		await wait(10)
+		expect(h.trace).toContain('release(late)')
+	})
+
+	it('reports isClosing() synchronously, before close() has awaited anything', () => {
+		// Startup checks this between awaits; a flag that only flipped a tick
+		// later would let it keep issuing calls against a client being released.
+		const h = makeHarness()
+		expect(h.owner.isClosing()).toBe(false)
+
+		void h.owner.close(undefined)
+		expect(h.owner.isClosing()).toBe(true)
+	})
+})
+
+describe('bridge client owner: close', () => {
+	it('tears down with the client still usable, then releases it', async () => {
+		// Ordering, not just occurrence: teardown needs the live client to close
+		// the transport and drain the store before anything frees it.
+		const h = makeHarness()
+		const c = h.client()
+		h.owner.adopt(c)
+
+		await h.owner.close(undefined)
+
+		expect(h.trace).toEqual(['teardown(with-client)', 'release(client)'])
+		expect(h.owner.peek()).toBe(undefined)
+	})
+
+	it('still tears down when no client was ever adopted', async () => {
+		// A socket disposed mid-init still has a transport to close and a store
+		// to drain; skipping that left `ws.readyState` stuck at CONNECTING.
+		const h = makeHarness()
+
+		await h.owner.close(undefined)
+
+		expect(h.trace).toEqual(['teardown(no-client)'])
+	})
+
+	it('passes the error through to teardown', async () => {
+		const h = makeHarness()
+		const boom = new Error('terminal')
+
+		await h.owner.close(boom)
+
+		expect(h.teardownCalls[0]?.error).toBe(boom)
+	})
+
+	it('runs once, and later callers await that same run', async () => {
+		// The socket ends itself on a terminal close, so a consumer's own
+		// `await sock.end()` is usually the second call. Resolving it early
+		// while the first was still flushing is how `close` → `end()` →
+		// `makeWASocket()` ended up with two writers on one auth folder.
+		let teardownFinished = false
+		const h = makeHarness({
+			teardown: async () => {
+				await wait(150)
+				teardownFinished = true
+			}
+		})
+		h.owner.adopt(h.client())
+
+		void h.owner.close(undefined)
+		await h.owner.close(undefined)
+
+		expect(teardownFinished).toBe(true)
+		expect(h.teardownCalls.length).toBe(1)
+	})
+
+	it('releases the client even when teardown throws', async () => {
+		// `teardown` rethrows the first auth-store flush failure. Leaking the
+		// wasm client on that path would make a bad shutdown worse.
+		const h = makeHarness({
+			teardown: async () => {
+				throw new Error('flush exploded')
+			}
+		})
+		h.owner.adopt(h.client())
+
+		let thrown: unknown
+		await h.owner.close(undefined).catch(err => {
+			thrown = err
+		})
+
+		expect((thrown as Error | undefined)?.message).toBe('flush exploded')
+		expect(h.trace).toContain('release(client)')
+	})
+
+	it('does not let a failing release mask the teardown, or throw on its own', async () => {
+		const h = makeHarness({
+			release: async () => {
+				throw new Error('free exploded')
+			}
+		})
+		h.owner.adopt(h.client())
+
+		// Resolving is the assertion: release failures are logged, not surfaced.
+		await h.owner.close(undefined)
+	})
+})
+
+describe('bridge client owner: teardown sees a live client', () => {
+	it('keeps peek() published for the whole teardown', async () => {
+		// The socket's transport close reads the client back through `peek()` —
+		// `ws.close()` is `getClient()?.disconnect()`. Clearing the handle before
+		// `teardown` turned that into a silent no-op, which moved the disconnect
+		// after the auth-store flush and dropped the closing-session ratchet
+		// write it emits. Nothing else in the suite could see that: the owner
+		// looked correct in isolation and the damage lived in the wiring.
+		const seen: Array<unknown> = []
+		const h = makeHarness({
+			teardown: async () => {
+				seen.push(h.owner.peek())
+			}
+		})
+		const c = h.client()
+		h.owner.adopt(c)
+
+		await h.owner.close(undefined)
+
+		expect(seen[0]).toBe(c)
+		// …and gone once teardown is done.
+		expect(h.owner.peek()).toBe(undefined)
+	})
+
+	it('reports isClosing() during teardown, so work can still be gated', () => {
+		// `peek()` staying live means it is no longer the "are we shutting down"
+		// signal. `isClosing()` is.
+		const h = makeHarness()
+		h.owner.adopt(h.client())
+
+		void h.owner.close(undefined)
+
+		expect(h.owner.isClosing()).toBe(true)
+		expect(h.owner.peek() !== undefined).toBe(true)
+	})
+})
+
+describe('bridge client owner: settled', () => {
+	it('joins the release a refused adopt started', async () => {
+		// `adopt` refuses and releases detached so startup can bail on a plain
+		// `return`. Startup joins it here, keeping that work inside
+		// `initPromise` — otherwise `await using` returns while the discarded
+		// client is still disconnecting, possibly writing to a store the caller
+		// is about to delete.
+		let releaseFinished = false
+		const h = makeHarness({
+			release: async () => {
+				await wait(120)
+				releaseFinished = true
+			}
+		})
+		void h.owner.close(undefined)
+
+		expect(h.owner.adopt(h.client('late'))).toBe(false)
+		await h.owner.settled()
+
+		expect(releaseFinished).toBe(true)
+	})
+
+	it('resolves immediately when nothing is in flight', async () => {
+		const h = makeHarness()
+		await h.owner.settled()
+	})
+})
+
+describe('bridge client owner: discard', () => {
+	it('releases an adopted client without running teardown', async () => {
+		// Startup that failed after adopting: the client exists but its read
+		// loop never started, so the socket has nothing to tear down — while
+		// the standalone helpers would happily keep reaching the half-built one.
+		const h = makeHarness()
+		h.owner.adopt(h.client('half-built'))
+
+		await h.owner.discard()
+
+		expect(h.trace).toEqual(['release(half-built)'])
+		expect(h.owner.peek()).toBe(undefined)
+		expect(h.teardownCalls.length).toBe(0)
+	})
+
+	it('is a no-op when nothing was adopted', async () => {
+		const h = makeHarness()
+
+		await h.owner.discard()
+
+		expect(h.trace).toEqual([])
+	})
+})

--- a/src/__tests__/bridge-client-owner.test.ts
+++ b/src/__tests__/bridge-client-owner.test.ts
@@ -152,6 +152,34 @@ describe('bridge client owner: close', () => {
 		expect(h.teardownCalls.length).toBe(1)
 	})
 
+	it('is safe against a teardown that re-enters close()', async () => {
+		// `close()` reserves its promise before invoking `runClose`, because an
+		// async body runs eagerly to its first `await`: teardown starts by
+		// closing the transport, and anything it reaches synchronously that
+		// calls back into `close()` would otherwise see no in-flight close and
+		// start a second teardown — releasing the same wasm client twice.
+		const h = makeHarness()
+		let reentered: Promise<void> | undefined
+		const owner = makeBridgeClientOwner({
+			logger: noopLogger as never,
+			teardown: async () => {
+				h.trace.push('teardown')
+				// Synchronous re-entry, before this body's first await.
+				reentered = owner.close(undefined)
+				await wait(20)
+			},
+			release: async () => {
+				h.trace.push('release')
+			}
+		})
+		owner.adopt(h.client())
+
+		await owner.close(undefined)
+		await reentered
+
+		expect(h.trace).toEqual(['teardown', 'release'])
+	})
+
 	it('releases the client even when teardown throws', async () => {
 		// `teardown` rethrows the first auth-store flush failure. Leaking the
 		// wasm client on that path would make a bad shutdown worse.

--- a/src/__tests__/bridge-client-owner.test.ts
+++ b/src/__tests__/bridge-client-owner.test.ts
@@ -264,6 +264,31 @@ describe('bridge client owner: discard', () => {
 		expect(h.teardownCalls.length).toBe(0)
 	})
 
+	it('joins an in-flight close instead of releasing its client again', async () => {
+		// `close()` keeps the client published for the whole of `teardown`, so a
+		// discard landing in that window used to take the same handle and
+		// release it a second time — two disconnect/free sequences on one wasm
+		// client. Reachable for real: a teardown's disconnect can make an
+		// in-flight `init()` bridge call reject, and that failure path discards.
+		let teardownDone = false
+		const h = makeHarness({
+			teardown: async () => {
+				await wait(120)
+				teardownDone = true
+			}
+		})
+		h.owner.adopt(h.client())
+
+		const closing = h.owner.close(undefined)
+		await h.owner.discard()
+
+		// Joined the close rather than racing it…
+		expect(teardownDone).toBe(true)
+		await closing
+		// …and the client was released exactly once.
+		expect(h.trace).toEqual(['teardown(with-client)', 'release(client)'])
+	})
+
 	it('is a no-op when nothing was adopted', async () => {
 		const h = makeHarness()
 

--- a/src/__tests__/bridge-free-safety.test.ts
+++ b/src/__tests__/bridge-free-safety.test.ts
@@ -31,6 +31,15 @@ import { expect } from './expect.ts'
 
 const SRC = import.meta.dirname
 
+interface ChildOutcome {
+	/** Exit code, or null when the watchdog killed it. */
+	code: number | null
+	timedOut: boolean
+	/** Whether the child got as far as the call under test. */
+	reachedTarget: boolean
+	stderr: string
+}
+
 /** Build a client against a dead loopback port, then run `body`. */
 const runChild = (body: string, folder: string) => {
 	const script = `
@@ -48,19 +57,31 @@ const runChild = (body: string, folder: string) => {
 		const c = await createWhatsAppClient(
 			makeTransport(cfg), makeHttpClient(cfg), undefined, state.store, null, undefined, null
 		)
+		// Printed once the client exists and just before the risky call, so the
+		// parent can tell "crashed at free()" from "never got there" — a bad
+		// import, an auth-store failure or a hung child would otherwise look
+		// exactly like the crash this suite documents.
+		console.log('READY')
 		${body}
 		await new Promise(r => setTimeout(r, 1500))
 		process.exit(0)
 	`
-	return new Promise<number | null>(resolve => {
-		const child = spawn(process.execPath, ['--input-type=module', '--eval', script], { stdio: 'ignore' })
+	return new Promise<ChildOutcome>(resolve => {
+		const child = spawn(process.execPath, ['--input-type=module', '--eval', script], {
+			stdio: ['ignore', 'pipe', 'pipe']
+		})
+		let stdout = ''
+		let stderr = ''
+		child.stdout.on('data', chunk => (stdout += String(chunk)))
+		child.stderr.on('data', chunk => (stderr += String(chunk)))
+
 		const timer = setTimeout(() => {
 			child.kill('SIGKILL')
-			resolve(null)
+			resolve({ code: null, timedOut: true, reachedTarget: stdout.includes('READY'), stderr })
 		}, 25_000)
 		child.on('exit', code => {
 			clearTimeout(timer)
-			resolve(code)
+			resolve({ code, timedOut: false, reachedTarget: stdout.includes('READY'), stderr })
 		})
 	})
 }
@@ -81,19 +102,27 @@ describe('bridge: free() safety with a call in flight', { timeout: 90_000 }, () 
 		// makes `free()` safe on its own, this test starts failing — which is
 		// the signal to drop the `disconnect()` from `end()`, not to relax the
 		// assertion.
-		const code = await runChild(
+		const outcome = await runChild(
 			`
 			c.fetchBlocklist().catch(() => {})
 			c.free()
 			`,
 			folder
 		)
-		expect(code === 0).toBe(false)
+
+		// It got to `free()`…
+		expect(outcome.reachedTarget).toBe(true)
+		// …died rather than hanging…
+		expect(outcome.timedOut).toBe(false)
+		expect(outcome.code === 0).toBe(false)
+		// …and died the documented way. Any other crash means the hazard moved
+		// and this suite is no longer describing it.
+		expect(outcome.stderr).toContain('psize <= size + max_overhead')
 	})
 
 	it('await disconnect() before free() survives the same pending call', async () => {
 		// The shape `end()` uses.
-		const code = await runChild(
+		const outcome = await runChild(
 			`
 			c.fetchBlocklist().catch(() => {})
 			await c.disconnect()
@@ -101,14 +130,15 @@ describe('bridge: free() safety with a call in flight', { timeout: 90_000 }, () 
 			`,
 			folder
 		)
-		expect(code).toBe(0)
+		expect(outcome.reachedTarget).toBe(true)
+		expect(outcome.code).toBe(0)
 	})
 
 	it('await disconnect() before free() survives an in-flight logout()', async () => {
 		// The production path: `Client::logout()` dispatches `LoggedOut` before
 		// awaiting its own `disconnect()`, so the terminal-close handler can
 		// re-enter `end()` while `logout()` is still running.
-		const code = await runChild(
+		const outcome = await runChild(
 			`
 			c.logout().catch(() => {})
 			await c.disconnect()
@@ -116,6 +146,7 @@ describe('bridge: free() safety with a call in flight', { timeout: 90_000 }, () 
 			`,
 			folder
 		)
-		expect(code).toBe(0)
+		expect(outcome.reachedTarget).toBe(true)
+		expect(outcome.code).toBe(0)
 	})
 })

--- a/src/__tests__/bridge-free-safety.test.ts
+++ b/src/__tests__/bridge-free-safety.test.ts
@@ -79,7 +79,11 @@ const runChild = (body: string, folder: string) => {
 			child.kill('SIGKILL')
 			resolve({ code: null, timedOut: true, reachedTarget: stdout.includes('READY'), stderr })
 		}, 25_000)
-		child.on('exit', code => {
+		// `close`, not `exit`: `exit` fires when the process ends, before the
+		// parent has necessarily drained its pipes. The panic text asserted
+		// below is the last thing a crashing child writes, so it is exactly the
+		// chunk most likely to still be in flight.
+		child.on('close', code => {
 			clearTimeout(timer)
 			resolve({ code, timedOut: false, reachedTarget: stdout.includes('READY'), stderr })
 		})

--- a/src/__tests__/bridge-free-safety.test.ts
+++ b/src/__tests__/bridge-free-safety.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Pins the bridge invariant that `sock.end()` depends on.
+ *
+ * Calling `WasmWhatsAppClient.free()` while any bridge call is still in flight
+ * corrupts the wasm heap: dlmalloc trips
+ * `assertion failed: psize <= size + max_overhead` and the process dies on
+ * `RuntimeError: unreachable`, thrown from a microtask no `try/catch` around
+ * `free()` can reach — `free()` itself returns normally. It is not specific to
+ * one method; `logout()`, `disconnect()` and a plain `fetchBlocklist()` all
+ * reproduce it.
+ *
+ * `await client.disconnect()` first drains those calls in order and makes the
+ * `free()` safe. That is why `end()` awaits it before freeing
+ * (`src/Socket/index.ts`).
+ *
+ * Why here and not through `makeWASocket`: offline, every socket method
+ * rejects immediately, so the window never opens — the whole point is a call
+ * that stays pending inside wasm, which needs either a live server or a
+ * `free()` with no awaits in between. Driving the bridge directly is the only
+ * way to hold that state open deterministically. Each case runs in a child
+ * process because heap corruption takes the whole process with it.
+ */
+
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, describe, it } from 'node:test'
+
+import { expect } from './expect.ts'
+
+const SRC = import.meta.dirname
+
+/** Build a client against a dead loopback port, then run `body`. */
+const runChild = (body: string, folder: string) => {
+	const script = `
+		import { createWhatsAppClient, initWasmEngine } from '@oxidezap/whatsapp-rust-bridge'
+		import { makeNativeCryptoProvider } from ${JSON.stringify(join(SRC, '../Utils/native-crypto-provider.ts'))}
+		import { useMultiFileAuthState } from ${JSON.stringify(join(SRC, '../Utils/use-multi-file-auth-state.ts'))}
+		import { makeHttpClient, makeTransport } from ${JSON.stringify(join(SRC, '../Socket/transport.ts'))}
+		import { DEFAULT_CONNECTION_CONFIG } from ${JSON.stringify(join(SRC, '../Defaults/index.ts'))}
+		import P from 'pino'
+
+		const logger = P({ level: 'silent' })
+		initWasmEngine(logger, makeNativeCryptoProvider())
+		const { state } = await useMultiFileAuthState(${JSON.stringify(folder)})
+		const cfg = { ...DEFAULT_CONNECTION_CONFIG, logger, waWebSocketUrl: 'ws://127.0.0.1:1' }
+		const c = await createWhatsAppClient(
+			makeTransport(cfg), makeHttpClient(cfg), undefined, state.store, null, undefined, null
+		)
+		${body}
+		await new Promise(r => setTimeout(r, 1500))
+		process.exit(0)
+	`
+	return new Promise<number | null>(resolve => {
+		const child = spawn(process.execPath, ['--input-type=module', '--eval', script], { stdio: 'ignore' })
+		const timer = setTimeout(() => {
+			child.kill('SIGKILL')
+			resolve(null)
+		}, 25_000)
+		child.on('exit', code => {
+			clearTimeout(timer)
+			resolve(code)
+		})
+	})
+}
+
+describe('bridge: free() safety with a call in flight', { timeout: 90_000 }, () => {
+	let folder: string
+
+	before(async () => {
+		folder = await mkdtemp(join(tmpdir(), 'baileyrs-freesafety-'))
+	})
+
+	after(async () => {
+		await rm(folder, { recursive: true, force: true })
+	})
+
+	it('free() with a pending call corrupts the heap and kills the process', async () => {
+		// Documents the hazard rather than endorsing it. If a future bridge
+		// makes `free()` safe on its own, this test starts failing — which is
+		// the signal to drop the `disconnect()` from `end()`, not to relax the
+		// assertion.
+		const code = await runChild(
+			`
+			c.fetchBlocklist().catch(() => {})
+			c.free()
+			`,
+			folder
+		)
+		expect(code === 0).toBe(false)
+	})
+
+	it('await disconnect() before free() survives the same pending call', async () => {
+		// The shape `end()` uses.
+		const code = await runChild(
+			`
+			c.fetchBlocklist().catch(() => {})
+			await c.disconnect()
+			c.free()
+			`,
+			folder
+		)
+		expect(code).toBe(0)
+	})
+
+	it('await disconnect() before free() survives an in-flight logout()', async () => {
+		// The production path: `Client::logout()` dispatches `LoggedOut` before
+		// awaiting its own `disconnect()`, so the terminal-close handler can
+		// re-enter `end()` while `logout()` is still running.
+		const code = await runChild(
+			`
+			c.logout().catch(() => {})
+			await c.disconnect()
+			c.free()
+			`,
+			folder
+		)
+		expect(code).toBe(0)
+	})
+})

--- a/src/__tests__/e2e/connection-contract.test-e2e.ts
+++ b/src/__tests__/e2e/connection-contract.test-e2e.ts
@@ -1,0 +1,229 @@
+/**
+ * E2E: the `connection.update` contract, against a live connection.
+ *
+ * `connection.update { close }` carries one meaning on this socket, the same
+ * one it carries in upstream Baileys: this socket is finished, build a new
+ * one. Disconnects the Rust engine retries surface as `connecting`.
+ *
+ * That split is what makes the canonical upstream handler safe here:
+ *
+ * ```ts
+ * if (connection === 'close') {
+ *   const shouldReconnect = statusCode !== DisconnectReason.loggedOut
+ *   if (shouldReconnect) connectToWhatsApp()
+ * }
+ * ```
+ *
+ * Upstream has no auto-reconnect, so that handler treats every `close` as
+ * final. If a transient drop surfaced as `close`, it would build a second
+ * socket while the engine was already restoring the first — two live sockets
+ * on one account, which the server answers with `<stream:error code="409">`.
+ *
+ * Needs the live mock server precisely because the offline suites cannot reach
+ * these states: a socket that never connects cannot drop, and every bridge
+ * call rejects immediately instead of staying pending inside wasm.
+ */
+
+import process from 'node:process'
+import { after, before, describe, test } from 'node:test'
+import P from 'pino'
+import { type Boom, DisconnectReason } from '../../index.ts'
+import { expect } from '../expect.ts'
+import { createTestClient, destroyTestClient, type TestClient } from './test-client.ts'
+import { type CuttableProxy, startCuttableProxy } from './tcp-proxy.ts'
+import { waitForEvent } from './wait.ts'
+
+const logger = P({ level: process.env.LOG_LEVEL ?? 'warn' })
+
+type ConnectionUpdate = { connection?: string; lastDisconnect?: { error?: Error } }
+
+const statusOf = (update: ConnectionUpdate) => (update.lastDisconnect?.error as Boom | undefined)?.output?.statusCode
+
+/** Record every `connection.update` a socket publishes, in order. */
+const recordUpdates = (client: TestClient) => {
+	const updates: ConnectionUpdate[] = []
+	client.sock.ev.on('connection.update', (update: ConnectionUpdate) => updates.push(update))
+	return {
+		all: () => updates,
+		closes: () => updates.filter(update => update.connection === 'close'),
+		connectings: () => updates.filter(update => update.connection === 'connecting')
+	}
+}
+
+describe('E2E: connection.update contract', { timeout: 180_000 }, () => {
+	let proxy: CuttableProxy
+	let alice: TestClient
+
+	before(async () => {
+		// Alice reaches the mock server through a proxy we can cut, so a drop
+		// happens underneath her socket with nobody asking for it.
+		proxy = await startCuttableProxy()
+		alice = await createTestClient({
+			label: 'alice',
+			folderPrefix: 'baileys-e2e-contract',
+			socketUrl: proxy.url
+		})
+		logger.info({ alice: alice.jid, proxy: proxy.url }, 'paired through the proxy')
+	})
+
+	after(async () => {
+		await destroyTestClient(alice)
+		await proxy.close()
+	})
+
+	test('a transport drop reports connecting, never close, and the engine restores it', async () => {
+		const seen = recordUpdates(alice)
+		const connectionsBefore = proxy.connections()
+
+		const reopened = waitForEvent(alice.sock, 'connection.update', u => u.connection === 'open', 90_000)
+		proxy.cut()
+		await reopened
+
+		// A fresh TCP connection proves the engine really reconnected rather
+		// than the old one having survived the cut.
+		expect(proxy.connections() > connectionsBefore).toBe(true)
+		// The whole point: an upstream-style handler keyed on `close` must not
+		// have fired, or it would have built a second socket while the engine
+		// was restoring this one.
+		expect(seen.closes().length).toBe(0)
+		expect(seen.connectings().length > 0).toBe(true)
+		expect(alice.sock.isConnected).toBe(true)
+	})
+
+	test('the retrying update clears the spent QR', async () => {
+		const seen = recordUpdates(alice)
+
+		const reopened = waitForEvent(alice.sock, 'connection.update', u => u.connection === 'open', 90_000)
+		proxy.cut()
+		await reopened
+
+		const connecting = seen.connectings()[0] as { qr?: string } | undefined
+		if (!connecting) throw new Error('expected a connecting update')
+		// A consumer merging partial state would otherwise keep rendering a QR
+		// the server has already rotated away.
+		expect(connecting.qr).toBe(undefined)
+	})
+
+	test('messages still flow after the engine-driven reconnect', async () => {
+		// Proves the restored socket is a working one, not just an `open` event:
+		// a second socket fighting for the session would have been kicked with
+		// `<stream:error code="409">` by now.
+		const bob = await createTestClient({ label: 'bob', folderPrefix: 'baileys-e2e-contract' })
+		try {
+			const text = `contract-${Date.now()}`
+			const received = waitForEvent(
+				bob.sock,
+				'messages.upsert',
+				upsert =>
+					upsert.messages.some(
+						m => !m.key?.fromMe && (m.message?.conversation || m.message?.extendedTextMessage?.text) === text
+					),
+				30_000
+			)
+			await alice.sock.sendMessage(bob.jid, { text })
+			await received
+		} finally {
+			await destroyTestClient(bob)
+		}
+	})
+})
+
+describe('E2E: teardown with a live connection', { timeout: 120_000 }, () => {
+	test('end() with a bridge call in flight does not corrupt the wasm heap', async () => {
+		// A regression guard for the teardown ordering, not a reproduction of
+		// the heap bug — worth stating plainly, because it passes with
+		// `end()`'s `await client.disconnect()` reverted.
+		//
+		// Freeing a client with a call still pending does corrupt the wasm heap
+		// (`__tests__/bridge-free-safety.test.ts` reproduces it directly), but
+		// `end()` drops the transport via `ws.close()` first, so pending calls
+		// reject before the free. The link is black-holed here to keep those
+		// calls outstanding for as long as possible — the closest this suite
+		// can get to the hazard through the public API. What it pins down is
+		// that a teardown racing in-flight work stays clean.
+		const proxy = await startCuttableProxy()
+		const client = await createTestClient({
+			label: 'inflight',
+			folderPrefix: 'baileys-e2e-contract',
+			socketUrl: proxy.url
+		})
+		try {
+			proxy.freeze()
+
+			// Requests leave, replies never come back: these stay pending inside
+			// wasm for the whole teardown.
+			void client.sock.groupFetchAllParticipating().catch(() => {})
+			void client.sock.fetchBlocklist().catch(() => {})
+			void client.sock.onWhatsApp('5599999999999').catch(() => {})
+			await new Promise(resolve => setTimeout(resolve, 500))
+
+			client.sock.setAutoReconnect(false)
+			await client.sock.end(undefined).catch(() => {})
+
+			// A corrupted heap surfaces asynchronously; give it room to land.
+			await new Promise(resolve => setTimeout(resolve, 3000))
+		} finally {
+			try {
+				await destroyTestClient(client)
+			} catch {
+				/* already ended */
+			}
+			await proxy.close()
+		}
+	})
+
+	test('logout() reports exactly one close, with loggedOut', async () => {
+		// `Client::logout()` dispatches `LoggedOut` before awaiting its own
+		// `disconnect()`, so the terminal-close path re-enters `end()` while
+		// `await sock.logout()` is still running. Two hazards: a duplicate
+		// synthetic close, and `free()` racing the in-flight call.
+		const client = await createTestClient({ label: 'logout', folderPrefix: 'baileys-e2e-contract' })
+		const seen = recordUpdates(client)
+		try {
+			await client.sock.logout().catch(() => {})
+			await new Promise(resolve => setTimeout(resolve, 1500))
+
+			const closes = seen.closes()
+			expect(closes.length).toBe(1)
+			expect(statusOf(closes[0]!)).toBe(DisconnectReason.loggedOut)
+		} finally {
+			try {
+				await destroyTestClient(client)
+			} catch {
+				/* already ended */
+			}
+		}
+	})
+
+	test('setAutoReconnect(false) turns a drop into a terminal close', async () => {
+		// `client/lifecycle.rs` dispatches `Disconnected` and only THEN tests
+		// the flag and breaks out of the run loop. Reporting `connecting` there
+		// would leave the socket in that state forever, with the wasm client
+		// never freed and the consumer's reconnect handler never firing.
+		const proxy = await startCuttableProxy()
+		const client = await createTestClient({
+			label: 'noreconnect',
+			folderPrefix: 'baileys-e2e-contract',
+			socketUrl: proxy.url
+		})
+		const seen = recordUpdates(client)
+		try {
+			client.sock.setAutoReconnect(false)
+
+			const closed = waitForEvent(client.sock, 'connection.update', u => u.connection === 'close', 60_000)
+			proxy.cut()
+			await closed
+
+			const closes = seen.closes()
+			expect(closes.length > 0).toBe(true)
+			expect(statusOf(closes[0]!)).toBe(DisconnectReason.connectionClosed)
+		} finally {
+			try {
+				await destroyTestClient(client)
+			} catch {
+				/* already ended */
+			}
+			await proxy.close()
+		}
+	})
+})

--- a/src/__tests__/e2e/connection-contract.test-e2e.ts
+++ b/src/__tests__/e2e/connection-contract.test-e2e.ts
@@ -39,14 +39,21 @@ type ConnectionUpdate = { connection?: string; lastDisconnect?: { error?: Error 
 
 const statusOf = (update: ConnectionUpdate) => (update.lastDisconnect?.error as Boom | undefined)?.output?.statusCode
 
-/** Record every `connection.update` a socket publishes, in order. */
+/**
+ * Record every `connection.update` a socket publishes, in order.
+ *
+ * `stop()` must be called — several tests share one long-lived socket, and a
+ * listener per test would accumulate on it and retain every array they filled.
+ */
 const recordUpdates = (client: TestClient) => {
 	const updates: ConnectionUpdate[] = []
-	client.sock.ev.on('connection.update', (update: ConnectionUpdate) => updates.push(update))
+	const listener = (update: ConnectionUpdate) => updates.push(update)
+	client.sock.ev.on('connection.update', listener)
 	return {
 		all: () => updates,
 		closes: () => updates.filter(update => update.connection === 'close'),
-		connectings: () => updates.filter(update => update.connection === 'connecting')
+		connectings: () => updates.filter(update => update.connection === 'connecting'),
+		stop: () => client.sock.ev.off('connection.update', listener)
 	}
 }
 
@@ -73,35 +80,42 @@ describe('E2E: connection.update contract', { timeout: 180_000 }, () => {
 
 	test('a transport drop reports connecting, never close, and the engine restores it', async () => {
 		const seen = recordUpdates(alice)
-		const connectionsBefore = proxy.connections()
+		try {
+			const connectionsBefore = proxy.connections()
 
-		const reopened = waitForEvent(alice.sock, 'connection.update', u => u.connection === 'open', 90_000)
-		proxy.cut()
-		await reopened
+			const reopened = waitForEvent(alice.sock, 'connection.update', u => u.connection === 'open', 90_000)
+			proxy.cut()
+			await reopened
 
-		// A fresh TCP connection proves the engine really reconnected rather
-		// than the old one having survived the cut.
-		expect(proxy.connections() > connectionsBefore).toBe(true)
-		// The whole point: an upstream-style handler keyed on `close` must not
-		// have fired, or it would have built a second socket while the engine
-		// was restoring this one.
-		expect(seen.closes().length).toBe(0)
-		expect(seen.connectings().length > 0).toBe(true)
-		expect(alice.sock.isConnected).toBe(true)
+			// A fresh TCP connection proves the engine really reconnected rather
+			// than the old one having survived the cut.
+			expect(proxy.connections() > connectionsBefore).toBe(true)
+			// The whole point: an upstream-style handler keyed on `close` must not
+			// have fired, or it would have built a second socket while the engine
+			// was restoring this one.
+			expect(seen.closes().length).toBe(0)
+			expect(seen.connectings().length > 0).toBe(true)
+			expect(alice.sock.isConnected).toBe(true)
+		} finally {
+			seen.stop()
+		}
 	})
 
 	test('the retrying update clears the spent QR', async () => {
 		const seen = recordUpdates(alice)
+		try {
+			const reopened = waitForEvent(alice.sock, 'connection.update', u => u.connection === 'open', 90_000)
+			proxy.cut()
+			await reopened
 
-		const reopened = waitForEvent(alice.sock, 'connection.update', u => u.connection === 'open', 90_000)
-		proxy.cut()
-		await reopened
-
-		const connecting = seen.connectings()[0] as { qr?: string } | undefined
-		if (!connecting) throw new Error('expected a connecting update')
-		// A consumer merging partial state would otherwise keep rendering a QR
-		// the server has already rotated away.
-		expect(connecting.qr).toBe(undefined)
+			const connecting = seen.connectings()[0] as { qr?: string } | undefined
+			if (!connecting) throw new Error('expected a connecting update')
+			// A consumer merging partial state would otherwise keep rendering a QR
+			// the server has already rotated away.
+			expect(connecting.qr).toBe(undefined)
+		} finally {
+			seen.stop()
+		}
 	})
 
 	test('messages still flow after the engine-driven reconnect', async () => {
@@ -181,12 +195,13 @@ describe('E2E: teardown with a live connection', { timeout: 120_000 }, () => {
 		const seen = recordUpdates(client)
 		try {
 			await client.sock.logout().catch(() => {})
-			await new Promise(resolve => setTimeout(resolve, 1500))
-
+			// No sleep: `logout()` resolves only after the close it caused has
+			// been published. Sleeping here would hide a regression in that.
 			const closes = seen.closes()
 			expect(closes.length).toBe(1)
 			expect(statusOf(closes[0]!)).toBe(DisconnectReason.loggedOut)
 		} finally {
+			seen.stop()
 			try {
 				await destroyTestClient(client)
 			} catch {
@@ -218,6 +233,7 @@ describe('E2E: teardown with a live connection', { timeout: 120_000 }, () => {
 			expect(closes.length > 0).toBe(true)
 			expect(statusOf(closes[0]!)).toBe(DisconnectReason.connectionClosed)
 		} finally {
+			seen.stop()
 			try {
 				await destroyTestClient(client)
 			} catch {

--- a/src/__tests__/e2e/tcp-proxy.ts
+++ b/src/__tests__/e2e/tcp-proxy.ts
@@ -111,10 +111,16 @@ export async function startCuttableProxy(
 			replyPipes.clear()
 		},
 		freeze: () => {
+			if (frozen) return
 			frozen = true
 			for (const [upstream, client] of replyPipes) upstream.unpipe(client)
 		},
 		thaw: () => {
+			// Guarded, because `pipe()` does not dedupe its destination: piping
+			// an already-piped pair adds a second `'data'` listener and every
+			// server reply reaches the client twice, corrupting the wss stream
+			// into failures nowhere near this file.
+			if (!frozen) return
 			frozen = false
 			for (const [upstream, client] of replyPipes) upstream.pipe(client)
 		},

--- a/src/__tests__/e2e/tcp-proxy.ts
+++ b/src/__tests__/e2e/tcp-proxy.ts
@@ -1,0 +1,104 @@
+/**
+ * A cuttable TCP proxy in front of the mock server.
+ *
+ * Simulating a network drop needs the connection to die underneath the socket
+ * without anyone asking it to — no `end()`, no `setAutoReconnect`, so the
+ * engine sees an unexpected read-loop exit and starts its Fibonacci backoff.
+ * Reaching into the socket's own WebSocket wrapper does not do that: the
+ * bridge owns the real transport, and closing the JS side is a request, not a
+ * drop.
+ *
+ * Byte-level forwarding is enough even though the tunnel is `wss:` — TLS
+ * terminates end to end between the client and the mock server, so the proxy
+ * never has to understand it.
+ */
+
+import { connect, createServer, type Server, type Socket } from 'node:net'
+
+export interface CuttableProxy {
+	/** `wss://` URL to hand to `makeWASocket`, pointing at this proxy. */
+	url: string
+	/** Kill every live connection, the way a dropped network does. */
+	cut: () => void
+	/**
+	 * Stop relaying server→client bytes while leaving the connection open — a
+	 * black-holed link. Requests reach the server, replies never come back, so
+	 * a bridge call stays pending inside wasm for as long as we want. That is
+	 * the only way to hold the window open against a local mock, which answers
+	 * everything faster than a teardown can race it.
+	 */
+	freeze: () => void
+	/** Resume relaying. */
+	thaw: () => void
+	/** How many connections have been accepted since start. */
+	connections: () => number
+	close: () => Promise<void>
+}
+
+/**
+ * @param targetPort port of the mock server (default 8080)
+ * @param path       websocket path appended to the returned URL
+ */
+export async function startCuttableProxy(targetPort = 8080, path = '/ws/chat'): Promise<CuttableProxy> {
+	const live = new Set<Socket>()
+	/** Server-side halves, so `freeze()` can stall just the reply direction. */
+	const upstreams = new Set<Socket>()
+	let connections = 0
+	let frozen = false
+
+	const server: Server = createServer(client => {
+		connections++
+		const upstream = connect(targetPort, '127.0.0.1')
+		live.add(client)
+		live.add(upstream)
+		upstreams.add(upstream)
+		// A connection opened while frozen starts frozen too, so a reconnect
+		// mid-test cannot quietly restore the link.
+		if (frozen) upstream.pause()
+
+		const drop = () => {
+			live.delete(client)
+			live.delete(upstream)
+			upstreams.delete(upstream)
+			client.destroy()
+			upstream.destroy()
+		}
+		client.on('error', drop)
+		upstream.on('error', drop)
+		client.on('close', drop)
+		upstream.on('close', drop)
+
+		client.pipe(upstream)
+		upstream.pipe(client)
+	})
+	server.on('error', () => {})
+
+	await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+	const address = server.address()
+	if (typeof address === 'string' || address === null) throw new Error('expected a TCP address')
+
+	return {
+		url: `wss://127.0.0.1:${address.port}${path}`,
+		connections: () => connections,
+		cut: () => {
+			for (const socket of live) socket.destroy()
+			live.clear()
+			upstreams.clear()
+		},
+		freeze: () => {
+			frozen = true
+			for (const upstream of upstreams) upstream.pause()
+		},
+		thaw: () => {
+			frozen = false
+			for (const upstream of upstreams) upstream.resume()
+		},
+		close: async () => {
+			frozen = false
+			for (const socket of live) socket.destroy()
+			live.clear()
+			upstreams.clear()
+			await new Promise<void>(resolve => server.close(() => resolve()))
+		}
+	}
+}

--- a/src/__tests__/e2e/tcp-proxy.ts
+++ b/src/__tests__/e2e/tcp-proxy.ts
@@ -39,27 +39,40 @@ export interface CuttableProxy {
  * @param targetPort port of the mock server (default 8080)
  * @param path       websocket path appended to the returned URL
  */
-export async function startCuttableProxy(targetPort = 8080, path = '/ws/chat'): Promise<CuttableProxy> {
+export async function startCuttableProxy(
+	targetPort = 8080,
+	path = '/ws/chat',
+	/** Where to report infrastructure failures the proxy would otherwise swallow. */
+	logger: ((message: string) => void) | undefined = message => console.error(message)
+): Promise<CuttableProxy> {
 	const live = new Set<Socket>()
-	/** Server-side halves, so `freeze()` can stall just the reply direction. */
-	const upstreams = new Set<Socket>()
+	/**
+	 * Server-side half → its client half. `freeze()` detaches the reply pipe
+	 * rather than pausing the socket: `pipe()` manages flow on its own and
+	 * resumes the source on `'drain'`, with no idea a manual `pause()` ever
+	 * happened — so a drain arriving after `freeze()` would silently reopen the
+	 * black hole the teardown test depends on staying shut.
+	 */
+	const replyPipes = new Map<Socket, Socket>()
 	let connections = 0
 	let frozen = false
 
 	const server: Server = createServer(client => {
 		connections++
 		const upstream = connect(targetPort, '127.0.0.1')
+		// A mock server that is down would otherwise surface as a test that
+		// simply never connects, minutes later, with nothing to read.
+		upstream.on('error', err => {
+			logger?.(`tcp-proxy: upstream connect failed: ${(err as Error).message}`)
+		})
 		live.add(client)
 		live.add(upstream)
-		upstreams.add(upstream)
-		// A connection opened while frozen starts frozen too, so a reconnect
-		// mid-test cannot quietly restore the link.
-		if (frozen) upstream.pause()
+		replyPipes.set(upstream, client)
 
 		const drop = () => {
 			live.delete(client)
 			live.delete(upstream)
-			upstreams.delete(upstream)
+			replyPipes.delete(upstream)
 			client.destroy()
 			upstream.destroy()
 		}
@@ -69,11 +82,23 @@ export async function startCuttableProxy(targetPort = 8080, path = '/ws/chat'): 
 		upstream.on('close', drop)
 
 		client.pipe(upstream)
-		upstream.pipe(client)
+		// A connection opened while frozen starts frozen too, so a reconnect
+		// mid-test cannot quietly restore the link.
+		if (!frozen) upstream.pipe(client)
 	})
-	server.on('error', () => {})
-
-	await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+	// Bind failures reject `startCuttableProxy` instead of being swallowed:
+	// a proxy that never listened makes every test in the file time out.
+	const listening = new Promise<void>((resolve, reject) => {
+		server.once('error', reject)
+		server.listen(0, '127.0.0.1', () => {
+			server.removeListener('error', reject)
+			// Past bind, per-connection errors are expected (we cut them
+			// ourselves) and must not take the server down.
+			server.on('error', err => logger?.(`tcp-proxy: server error: ${(err as Error).message}`))
+			resolve()
+		})
+	})
+	await listening
 	const address = server.address()
 	if (typeof address === 'string' || address === null) throw new Error('expected a TCP address')
 
@@ -83,21 +108,21 @@ export async function startCuttableProxy(targetPort = 8080, path = '/ws/chat'): 
 		cut: () => {
 			for (const socket of live) socket.destroy()
 			live.clear()
-			upstreams.clear()
+			replyPipes.clear()
 		},
 		freeze: () => {
 			frozen = true
-			for (const upstream of upstreams) upstream.pause()
+			for (const [upstream, client] of replyPipes) upstream.unpipe(client)
 		},
 		thaw: () => {
 			frozen = false
-			for (const upstream of upstreams) upstream.resume()
+			for (const [upstream, client] of replyPipes) upstream.pipe(client)
 		},
 		close: async () => {
 			frozen = false
 			for (const socket of live) socket.destroy()
 			live.clear()
-			upstreams.clear()
+			replyPipes.clear()
 			await new Promise<void>(resolve => server.close(() => resolve()))
 		}
 	}

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -1247,6 +1247,22 @@ describe('event buffer: connection.update delivery', () => {
 		expect(seen).toEqual(['first', 'second'])
 	})
 
+	it('calls listeners with the emitter as `this`, as emit() would', () => {
+		// A listener declared as a normal function that removes itself with
+		// `this.off(...)` is a common pattern; calling it bare makes `this`
+		// undefined and the throw is swallowed by the isolation above.
+		const ev = makeEventBuffer(noopLogger as never)
+		let receiverMatched = false
+
+		ev.on('connection.update', function selfRemoving(this: unknown) {
+			receiverMatched = typeof (this as { off?: unknown })?.off === 'function'
+		})
+
+		ev.emit('connection.update', { connection: 'close' } as never)
+
+		expect(receiverMatched).toBe(true)
+	})
+
 	it('still stops at a throwing listener on other channels, as upstream does', () => {
 		const ev = makeEventBuffer(noopLogger as never)
 		const seen: string[] = []

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -1236,12 +1236,22 @@ describe('dispatch: connect_failure → DisconnectReason mapping', () => {
 		expect(closeStatusFor(401)).toBe(401)
 	})
 
-	it('maps 405 (ClientOutdated) to badSession', () => {
-		expect(closeStatusFor(405)).toBe(500)
+	// The wire code, not `badSession` (500). badSession is what bots branch on
+	// to wipe credentials and re-pair, and an outdated build is the one failure
+	// where doing that helps nobody. Upstream keeps the wire code too —
+	// `getErrorCodeFromStreamError` reads `+node.attrs.code` first and only
+	// falls back to badSession when the stanza carries none.
+	it('maps 405 (ClientOutdated) to the wire code, not badSession', () => {
+		expect(closeStatusFor(405)).toBe(405)
 	})
 
-	it('maps 503 (ServiceUnavailable) to unavailableService', () => {
-		expect(closeStatusFor(503)).toBe(503)
+	// 500/503 are the two reasons `ConnectFailureReason::should_reconnect()`
+	// matches, so the engine keeps retrying and the socket reports `connecting`
+	// rather than a `close` the upstream handler would answer with a second
+	// socket. See `auto-reconnect-terminal-close.test.ts`.
+	it('does not close on 503 (ServiceUnavailable) — the engine retries it', () => {
+		const updates = collect({ type: 'connect_failure', data: { reason: 503, message: '' } }, 'connection.update')
+		expect(updates.map(update => update.connection)).toEqual(['connecting'])
 	})
 
 	it('falls back to connectionClosed for unknown codes', () => {

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -15,6 +15,7 @@ import { makeEventHandler, makeEventHandlers } from '../Socket/events.ts'
 import type { SocketContext } from '../Socket/types.ts'
 import type { BaileysEventMap, BinaryNode } from '../Types/index.ts'
 import { Boom } from '../Utils/boom.ts'
+import { makeEventBuffer } from '../Utils/event-buffer.ts'
 import { useBridgeStore } from '../Utils/use-bridge-store.ts'
 import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
 import { assertNodeErrorFree } from '../WABinary/generic-utils.ts'
@@ -1223,6 +1224,41 @@ describe('dispatch: offline_sync_completed', () => {
 	it('surfaces upstream receivedPendingNotifications readiness', () => {
 		const updates = collect({ type: 'offline_sync_completed', data: { count: 4 } }, 'connection.update')
 		expect(updates).toEqual([{ receivedPendingNotifications: true }])
+	})
+})
+
+describe('event buffer: connection.update delivery', () => {
+	// `EventEmitter.emit()` stops at the first listener that throws. On the
+	// lifecycle channel that means one bad handler keeps the app's reconnect
+	// handler from ever seeing a terminal `close` — the bot stays offline, which
+	// is the failure the whole close contract exists to prevent.
+	it('keeps notifying listeners after one throws', () => {
+		const ev = makeEventBuffer(noopLogger as never)
+		const seen: string[] = []
+
+		ev.on('connection.update', () => {
+			seen.push('first')
+			throw new Error('listener exploded')
+		})
+		ev.on('connection.update', () => seen.push('second'))
+
+		ev.emit('connection.update', { connection: 'close' } as never)
+
+		expect(seen).toEqual(['first', 'second'])
+	})
+
+	it('still stops at a throwing listener on other channels, as upstream does', () => {
+		const ev = makeEventBuffer(noopLogger as never)
+		const seen: string[] = []
+
+		ev.on('creds.update', () => {
+			seen.push('first')
+			throw new Error('listener exploded')
+		})
+		ev.on('creds.update', () => seen.push('second'))
+
+		expect(() => ev.emit('creds.update', {} as never)).toThrow()
+		expect(seen).toEqual(['first'])
 	})
 })
 

--- a/src/__tests__/socket-dispose-integration.test.ts
+++ b/src/__tests__/socket-dispose-integration.test.ts
@@ -319,6 +319,45 @@ describe('makeWASocket: disposing stops the bridge run loop', { timeout: 120_000
 		}
 	})
 
+	it('reports the logout close even when the auth store fails to flush', async () => {
+		// `end()` rethrows the first flush failure, and the owner releases the
+		// client regardless — so without publishing on that path listeners see
+		// no terminal close at all for a socket that has definitely ended.
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const store = new Proxy(state.store as object, {
+				get(target, prop, receiver) {
+					const value = Reflect.get(target, prop, receiver)
+					if (prop !== 'flush' || typeof value !== 'function') return value
+					return () => Promise.reject(new Error('flush exploded'))
+				}
+			}) as typeof state.store
+
+			const sock = makeWASocket({
+				auth: { ...state, store },
+				logger: silentLogger,
+				waWebSocketUrl: counter.url
+			})
+			let closes = 0
+			sock.ev.on('connection.update', update => {
+				if (update.connection === 'close') closes++
+			})
+
+			let thrown: unknown
+			await sock.logout().catch(err => {
+				thrown = err
+			})
+
+			// The flush failure still reaches the caller…
+			expect((thrown as Error | undefined)?.message).toBe('flush exploded')
+			// …and the close was not swallowed with it.
+			expect(closes).toBe(1)
+		} finally {
+			await counter.close()
+		}
+	})
+
 	it('an immediate dispose — before init settles — keeps the engine from reconnecting', async () => {
 		const counter = await startConnectionCounter()
 		try {

--- a/src/__tests__/socket-dispose-integration.test.ts
+++ b/src/__tests__/socket-dispose-integration.test.ts
@@ -511,7 +511,9 @@ const runChild = async (body: string, folder: string, url: string) => {
 			child.kill('SIGKILL')
 			resolve({ outcome: 'timeout', code: null })
 		}, 25_000)
-		child.on('exit', code => {
+		// `close` rather than `exit`, so the child's pipes are drained before
+		// the outcome is reported.
+		child.on('close', code => {
 			clearTimeout(timer)
 			resolve({ outcome: 'exited', code })
 		})

--- a/src/__tests__/socket-dispose-integration.test.ts
+++ b/src/__tests__/socket-dispose-integration.test.ts
@@ -319,6 +319,35 @@ describe('makeWASocket: disposing stops the bridge run loop', { timeout: 120_000
 		}
 	})
 
+	it('logout() after a close has already been reported does not synthesize a second one', async () => {
+		// A consumer that logs out from its own `close` handler finds no live
+		// client, so nothing dispatches `LoggedOut` and the terminal-close count
+		// cannot move. Treating that as "nobody announced it" gave every
+		// listener two terminal notifications for one socket — and a handler
+		// that logs out on close an asynchronous close/logout loop.
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const sock = makeWASocket({ auth: state, logger: silentLogger, waWebSocketUrl: counter.url })
+
+			let closes = 0
+			sock.ev.on('connection.update', update => {
+				if (update.connection === 'close') closes++
+			})
+
+			// First logout reports the close…
+			await sock.logout().catch(() => {})
+			expect(closes).toBe(1)
+
+			// …a second one, as a close handler would do, must stay silent.
+			await sock.logout().catch(() => {})
+			await wait(300)
+			expect(closes).toBe(1)
+		} finally {
+			await counter.close()
+		}
+	})
+
 	it('reports the logout close even when the auth store fails to flush', async () => {
 		// `end()` rethrows the first flush failure, and the owner releases the
 		// client regardless — so without publishing on that path listeners see

--- a/src/__tests__/socket-dispose-integration.test.ts
+++ b/src/__tests__/socket-dispose-integration.test.ts
@@ -387,6 +387,46 @@ describe('makeWASocket: disposing stops the bridge run loop', { timeout: 120_000
 		}
 	})
 
+	it('refuses a call that was waiting on init when teardown starts', async () => {
+		// The guard runs again after the `initPromise` await: a close landing
+		// while startup was still going would otherwise hand the client to a
+		// call that had been queued behind it.
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const store = new Proxy(state.store as object, {
+				get(target, prop, receiver) {
+					const value = Reflect.get(target, prop, receiver)
+					if (typeof value !== 'function' || prop === 'flush') return value
+					// Slow startup so the call below is still queued behind it.
+					return async (...args: unknown[]) => {
+						await wait(250)
+						return (value as (...a: unknown[]) => unknown).apply(target, args)
+					}
+				}
+			}) as typeof state.store
+
+			const sock = makeWASocket({
+				auth: { ...state, store },
+				logger: silentLogger,
+				waWebSocketUrl: counter.url
+			})
+
+			// Queued behind init…
+			const queued = sock
+				.sendNode({ tag: 'iq', attrs: {} })
+				.then(() => '<resolved>')
+				.catch((err: Error) => err.message)
+			// …and teardown starts before init finishes.
+			const ending = sock.end(undefined).catch(() => {})
+
+			expect(await queued).toContain('Connection Closed')
+			await ending
+		} finally {
+			await counter.close()
+		}
+	})
+
 	it('reports the logout close even when the auth store fails to flush', async () => {
 		// `end()` rethrows the first flush failure, and the owner releases the
 		// client regardless — so without publishing on that path listeners see

--- a/src/__tests__/socket-dispose-integration.test.ts
+++ b/src/__tests__/socket-dispose-integration.test.ts
@@ -348,6 +348,45 @@ describe('makeWASocket: disposing stops the bridge run loop', { timeout: 120_000
 		}
 	})
 
+	it('refuses socket operations once teardown owns the client', async () => {
+		// `peek()` keeps returning the client through `closing` so teardown can
+		// still close the transport with it — but handing it to an ordinary
+		// call racing shutdown starts a bridge operation while that client is
+		// being disconnected and freed, which is the heap-corruption hazard the
+		// teardown ordering exists to avoid.
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const store = new Proxy(state.store as object, {
+				get(target, prop, receiver) {
+					const value = Reflect.get(target, prop, receiver)
+					if (prop !== 'flush' || typeof value !== 'function') return value
+					// Hold teardown open so the racing call lands inside it.
+					return async () => wait(400)
+				}
+			}) as typeof state.store
+
+			const sock = makeWASocket({
+				auth: { ...state, store },
+				logger: silentLogger,
+				waWebSocketUrl: counter.url
+			})
+			await wait(300)
+
+			const ending = sock.end(undefined)
+			// `sendNode` goes through `ctx.getClient()`.
+			const message = await sock
+				.sendNode({ tag: 'iq', attrs: {} })
+				.then(() => '<resolved>')
+				.catch((err: Error) => err.message)
+			await ending
+
+			expect(message).toContain('Connection Closed')
+		} finally {
+			await counter.close()
+		}
+	})
+
 	it('reports the logout close even when the auth store fails to flush', async () => {
 		// `end()` rethrows the first flush failure, and the owner releases the
 		// client regardless — so without publishing on that path listeners see

--- a/src/__tests__/socket-dispose-integration.test.ts
+++ b/src/__tests__/socket-dispose-integration.test.ts
@@ -1,0 +1,513 @@
+/**
+ * Integration: disposing a socket really stops the bridge engine.
+ *
+ * No mock server needed. A bare TCP listener accepts each connection and drops
+ * it, so the WebSocket handshake always fails and the Rust run loop sits in
+ * its retry path — where it lives in production whenever the network is down.
+ * Counting accepted connections is the observable: while the engine retries
+ * the count climbs, and once the socket is disposed it must stop.
+ *
+ * Counting sockets rather than reading logs is deliberate: `initWasmEngine`
+ * runs once per process, so the Rust-side logger belongs to whichever socket
+ * was created first and later sockets in the same process log nothing.
+ *
+ * The bug this covers: `end()` fired before `init()` finished saw
+ * `client === undefined` and freed nothing, while the in-flight `init()` went
+ * on to create the client and call `run()`. The result was an ownerless
+ * `WasmWhatsAppClient` reconnecting on the Fibonacci backoff forever, immune
+ * to the `sock.end()` the caller had already awaited. Disposing right after
+ * `makeWASocket()` lands squarely in that window.
+ */
+
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createServer, type Server, type Socket } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, describe, it } from 'node:test'
+import P from 'pino'
+
+import makeWASocket from '../Socket/index.ts'
+import { downloadHistory } from '../Utils/process-history-message.ts'
+import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
+import { expect } from './expect.ts'
+
+const silentLogger = P({ level: 'silent' })
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+type Disposable = { [Symbol.asyncDispose](): Promise<void> }
+const dispose = (sock: unknown) => (sock as Disposable)[Symbol.asyncDispose]()
+
+/** Accepts and immediately drops every connection, counting the attempts. */
+const startConnectionCounter = async () => {
+	const live = new Set<Socket>()
+	let attempts = 0
+	const server: Server = createServer(socket => {
+		attempts++
+		live.add(socket)
+		socket.on('error', () => {})
+		socket.on('close', () => live.delete(socket))
+		socket.destroy()
+	})
+	server.on('error', () => {})
+	await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+	const address = server.address()
+	if (typeof address === 'string' || address === null) throw new Error('expected a TCP address')
+
+	return {
+		url: `ws://127.0.0.1:${address.port}`,
+		attempts: () => attempts,
+		close: async () => {
+			for (const socket of live) socket.destroy()
+			await new Promise<void>(resolve => server.close(() => resolve()))
+		}
+	}
+}
+
+/** Resolves once the engine has retried `count` times, or throws on timeout. */
+const waitForAttempts = async (attempts: () => number, count: number, timeoutMs = 15_000) => {
+	const deadline = Date.now() + timeoutMs
+	while (attempts() < count) {
+		if (Date.now() > deadline) throw new Error(`only saw ${attempts()} connection attempts, wanted ${count}`)
+		await wait(50)
+	}
+}
+
+describe('makeWASocket: disposing stops the bridge run loop', { timeout: 120_000 }, () => {
+	let authFolder: string
+
+	before(async () => {
+		authFolder = await mkdtemp(join(tmpdir(), 'baileyrs-dispose-'))
+	})
+
+	after(async () => {
+		await rm(authFolder, { recursive: true, force: true })
+	})
+
+	it('exposes Symbol.asyncDispose so `await using` works', async () => {
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const sock = makeWASocket({ auth: state, logger: silentLogger, waWebSocketUrl: counter.url })
+
+			expect(typeof (sock as Record<symbol, unknown>)[Symbol.asyncDispose]).toBe('function')
+			await dispose(sock)
+		} finally {
+			await counter.close()
+		}
+	})
+
+	it('a mid-init end() still closes the transport and drains the auth store', async () => {
+		// Both used to sit inside `if (client)`, so an `end()` landing before
+		// `createWhatsAppClient()` resolved skipped them: `ws.readyState` stayed
+		// at CONNECTING on a socket the caller had disposed, and whatever the
+		// store had buffered was dropped.
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			let flushes = 0
+			const store = new Proxy(state.store as object, {
+				get(target, prop, receiver) {
+					const value = Reflect.get(target, prop, receiver)
+					if (prop !== 'flush' || typeof value !== 'function') return value
+					return (...args: unknown[]) => {
+						flushes++
+						return (value as (...a: unknown[]) => unknown).apply(target, args)
+					}
+				}
+			}) as typeof state.store
+
+			const sock = makeWASocket({
+				auth: { ...state, store },
+				logger: silentLogger,
+				waWebSocketUrl: counter.url
+			})
+			await sock.end(undefined)
+
+			// 3 === CLOSED on the upstream-compatible readyState ladder. Private
+			// to `WebSocketClient`, but it is the observable a consumer reads
+			// through the upstream `ws` surface.
+			expect((sock.ws as unknown as { readyState: number }).readyState).toBe(3)
+			expect(flushes > 0).toBe(true)
+		} finally {
+			await counter.close()
+		}
+	})
+
+	it('end() runs the socket end handlers even when the auth store fails to flush', async () => {
+		// `end()` rethrows the first flush failure. Running the consumer's
+		// teardown hooks BEFORE that rethrow is deliberate: a corrupt-on-shutdown
+		// store is exactly when they most need to run.
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const store = new Proxy(state.store as object, {
+				get(target, prop, receiver) {
+					const value = Reflect.get(target, prop, receiver)
+					if (prop !== 'flush' || typeof value !== 'function') return value
+					return () => Promise.reject(new Error('flush exploded'))
+				}
+			}) as typeof state.store
+
+			const sock = makeWASocket({
+				auth: { ...state, store },
+				logger: silentLogger,
+				waWebSocketUrl: counter.url
+			})
+			let handlerRan = false
+			sock.registerSocketEndHandler(() => {
+				handlerRan = true
+			})
+
+			let thrown: unknown
+			try {
+				await sock.end(undefined)
+			} catch (err) {
+				thrown = err
+			}
+
+			expect((thrown as Error | undefined)?.message).toBe('flush exploded')
+			expect(handlerRan).toBe(true)
+		} finally {
+			await counter.close()
+		}
+	})
+
+	it('the disposer waits for initialization even when end() rejects', async () => {
+		// `end()` rethrows a flush failure, and letting that propagate straight
+		// out would skip `await initPromise` — resolving the disposer with
+		// `init()` still in flight, in exactly the situation where cleanup has
+		// already gone wrong. Hence the try/finally.
+		//
+		// Timed rather than counted: the wasm client's own `Drop` schedules a
+		// detached disconnect that touches the store on its own schedule, so
+		// counting post-dispose store calls is inherently racy. Slowing the
+		// store down instead makes `init()` take a known, long time, and the
+		// only way for the disposer to beat it is to not have waited.
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const INIT_DELAY_MS = 1200
+			const store = new Proxy(state.store as object, {
+				get(target, prop, receiver) {
+					const value = Reflect.get(target, prop, receiver)
+					if (typeof value !== 'function') return value
+					if (prop === 'flush') return () => Promise.reject(new Error('flush exploded'))
+					return async (...args: unknown[]) => {
+						await wait(INIT_DELAY_MS)
+						return (value as (...a: unknown[]) => unknown).apply(target, args)
+					}
+				}
+			}) as typeof state.store
+
+			const sock = makeWASocket({
+				auth: { ...state, store },
+				logger: silentLogger,
+				waWebSocketUrl: counter.url
+			})
+
+			const startedAt = Date.now()
+			let rejected: unknown
+			await dispose(sock).catch(err => {
+				rejected = err
+			})
+			const elapsed = Date.now() - startedAt
+
+			// The flush error still reaches the caller…
+			expect((rejected as Error | undefined)?.message).toBe('flush exploded')
+			// …and it did not short-circuit the wait for `init()`.
+			expect(elapsed >= INIT_DELAY_MS).toBe(true)
+		} finally {
+			await counter.close()
+		}
+	})
+
+	it('a second end() awaits the in-flight teardown instead of resolving early', async () => {
+		// The socket now ends itself on a terminal close, so the consumer's own
+		// `await sock.end()` is usually the SECOND call. Returning early on an
+		// `ended` flag resolved it while the store flush was still running —
+		// which is how `close` → `await sock.end()` → `makeWASocket()` ends up
+		// with two writers on one auth folder.
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			let flushDone = false
+			const store = new Proxy(state.store as object, {
+				get(target, prop, receiver) {
+					const value = Reflect.get(target, prop, receiver)
+					if (prop !== 'flush' || typeof value !== 'function') return value
+					return async (...args: unknown[]) => {
+						await wait(300)
+						const result = await (value as (...a: unknown[]) => unknown).apply(target, args)
+						flushDone = true
+						return result
+					}
+				}
+			}) as typeof state.store
+
+			const sock = makeWASocket({
+				auth: { ...state, store },
+				logger: silentLogger,
+				waWebSocketUrl: counter.url
+			})
+
+			// First call detached, the way `onTerminalClose` fires it.
+			void sock.end(undefined).catch(() => {})
+			// Second call is the consumer's; it must join, not skip.
+			await sock.end(undefined)
+
+			expect(flushDone).toBe(true)
+		} finally {
+			await counter.close()
+		}
+	})
+
+	it('logout() reports exactly one close even when the bridge never announces it', async () => {
+		// Normally `Client::logout()` dispatches `LoggedOut` and the dispatcher
+		// reports the close. When it cannot — no client yet, or `logout()` threw
+		// before reaching the bridge — `logout()` has to report it itself.
+		// Emitting unconditionally gave two closes; emitting never gave zero.
+		// Upstream always gives exactly one.
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const sock = makeWASocket({ auth: state, logger: silentLogger, waWebSocketUrl: counter.url })
+
+			let closes = 0
+			sock.ev.on('connection.update', update => {
+				if (update.connection === 'close') closes++
+			})
+
+			// No connection was ever established, so nothing will dispatch.
+			await sock.logout().catch(() => {})
+			await wait(500)
+
+			expect(closes).toBe(1)
+		} finally {
+			await counter.close()
+		}
+	})
+
+	it('an immediate dispose — before init settles — keeps the engine from reconnecting', async () => {
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const sock = makeWASocket({ auth: state, logger: silentLogger, waWebSocketUrl: counter.url })
+			// No await between creation and dispose: `init()` is still in flight.
+			await dispose(sock)
+			expect(sock.waClient).toBe(undefined)
+
+			// The engine may already have one connect in flight; what must not
+			// happen is a retry after it. The Fibonacci backoff starts at ~1s, so
+			// 3s covers several attempts.
+			const baseline = counter.attempts()
+			await wait(3000)
+			expect(counter.attempts()).toBe(baseline)
+		} finally {
+			await counter.close()
+		}
+	})
+
+	it('the disposer resolves only after in-flight initialization has finished', async () => {
+		// The async-disposal contract: once `await using` leaves scope, nothing
+		// belonging to the socket is still running. `end()` alone cannot deliver
+		// that — called mid-init it sees `client === undefined` and resolves
+		// while `init()` is still constructing the bridge client and reading the
+		// auth store. Counting store calls that land after the disposer resolved
+		// is the observable, because `init()` drives the store on that path.
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+
+			let disposed = false
+			let callsAfterDispose = 0
+			const store = new Proxy(state.store as object, {
+				get(target, prop, receiver) {
+					const value = Reflect.get(target, prop, receiver)
+					if (typeof value !== 'function') return value
+					return (...args: unknown[]) => {
+						if (disposed) callsAfterDispose++
+						return (value as (...a: unknown[]) => unknown).apply(target, args)
+					}
+				}
+			}) as typeof state.store
+
+			const sock = makeWASocket({
+				auth: { ...state, store },
+				logger: silentLogger,
+				waWebSocketUrl: counter.url
+			})
+			await dispose(sock)
+			disposed = true
+
+			// Generous enough for a disposer that resolved early to let `init()`
+			// run on and touch the store behind the caller's back.
+			await wait(2000)
+			expect(callsAfterDispose).toBe(0)
+		} finally {
+			await counter.close()
+		}
+	})
+
+	it('stops a run loop that was already retrying, and is idempotent', async () => {
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const sock = makeWASocket({ auth: state, logger: silentLogger, waWebSocketUrl: counter.url })
+
+			// Two attempts prove the engine is really in its retry loop, not just
+			// making its first connect.
+			await waitForAttempts(counter.attempts, 2)
+
+			await dispose(sock)
+			await dispose(sock) // second call: no-op, must not throw
+
+			const baseline = counter.attempts()
+			await wait(3000)
+			expect(counter.attempts()).toBe(baseline)
+		} finally {
+			await counter.close()
+		}
+	})
+
+	it('unregisters the freed client, so standalone helpers do not reach a null wasm pointer', async () => {
+		// `end()` calls `c.free()`. The module-level pointer the standalone
+		// helpers fall back on must not survive it: reaching through a freed
+		// handle raises an opaque wasm-bindgen error instead of the actionable
+		// "no bridge client available" Boom.
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const sock = makeWASocket({ auth: state, logger: silentLogger, waWebSocketUrl: counter.url })
+
+			// Wait for init to publish the client — that is what registers it.
+			await waitForAttempts(counter.attempts, 1)
+			await wait(200)
+			expect(sock.waClient !== undefined).toBe(true)
+
+			await dispose(sock)
+
+			let message = '<no error>'
+			try {
+				await downloadHistory(
+					{
+						directPath: '/v/history',
+						mediaKey: new Uint8Array(32),
+						fileSha256: new Uint8Array(32),
+						fileEncSha256: new Uint8Array(32),
+						fileLength: 1
+					},
+					{}
+				)
+			} catch (err) {
+				message = err instanceof Error ? err.message : String(err)
+			}
+			expect(message).toContain('no bridge client available')
+		} finally {
+			await counter.close()
+		}
+	})
+})
+
+/**
+ * Two effects that are invisible in-process and only a child can observe:
+ *
+ *  - `created.free()` on the mid-init dispose path. Nothing in the parent says
+ *    whether that client was freed, but an unfreed `WasmWhatsAppClient` keeps
+ *    the wasm instance alive and the process cannot exit.
+ *  - `await c.disconnect()` before `c.free()` in `end()`. Freeing with a bridge
+ *    call still in flight corrupts the wasm heap: dlmalloc trips
+ *    `assertion failed: psize <= size + max_overhead` and the process dies on
+ *    `RuntimeError: unreachable`, thrown from a microtask no try/catch reaches.
+ *
+ * Both therefore assert the same thing — the child exits cleanly, on its own.
+ */
+const runChild = async (body: string, folder: string, url: string) => {
+	const script = `
+		import makeWASocket from ${JSON.stringify(join(import.meta.dirname, '../Socket/index.ts'))}
+		import { useMultiFileAuthState } from ${JSON.stringify(join(import.meta.dirname, '../Utils/use-multi-file-auth-state.ts'))}
+		import P from 'pino'
+		const { state } = await useMultiFileAuthState(${JSON.stringify(folder)})
+		const sock = makeWASocket({
+			auth: state,
+			logger: P({ level: 'silent' }),
+			waWebSocketUrl: ${JSON.stringify(url)}
+		})
+		${body}
+	`
+	const child = spawn(process.execPath, ['--input-type=module', '--eval', script], { stdio: 'ignore' })
+	return new Promise<{ outcome: 'exited' | 'timeout'; code: number | null }>(resolve => {
+		const timer = setTimeout(() => {
+			child.kill('SIGKILL')
+			resolve({ outcome: 'timeout', code: null })
+		}, 25_000)
+		child.on('exit', code => {
+			clearTimeout(timer)
+			resolve({ outcome: 'exited', code })
+		})
+	})
+}
+
+describe('makeWASocket: teardown frees the client without corrupting the wasm heap', { timeout: 90_000 }, () => {
+	let folder: string
+	let counter: Awaited<ReturnType<typeof startConnectionCounter>>
+
+	before(async () => {
+		folder = await mkdtemp(join(tmpdir(), 'baileyrs-childexit-'))
+		counter = await startConnectionCounter()
+	})
+
+	after(async () => {
+		await rm(folder, { recursive: true, force: true })
+		await counter.close()
+	})
+
+	it('a socket disposed mid-init lets the process exit', async () => {
+		const result = await runChild('await sock[Symbol.asyncDispose]()', folder, counter.url)
+		expect(result.outcome).toBe('exited')
+		expect(result.code).toBe(0)
+	})
+
+	it('end() with a bridge call still in flight exits cleanly instead of corrupting the heap', async () => {
+		// `fetchBlocklist()` is deliberately not awaited: it stays pending
+		// inside wasm across the `end()`. Without `await c.disconnect()` before
+		// `c.free()`, this child dies on the dlmalloc assertion.
+		const result = await runChild(
+			`
+			await new Promise(r => setTimeout(r, 400))
+			sock.fetchBlocklist().catch(() => {})
+			await sock.end(undefined)
+			await new Promise(r => setTimeout(r, 1500))
+			`,
+			folder,
+			counter.url
+		)
+		expect(result.outcome).toBe('exited')
+		expect(result.code).toBe(0)
+	})
+
+	it('logout() reports exactly one close and exits cleanly', async () => {
+		// `Client::logout()` dispatches `LoggedOut` before awaiting its own
+		// `disconnect()`, so the terminal-close path re-enters `end()` while
+		// `await sock.logout()` is still running. Two hazards at once: a second
+		// synthetic close, and `free()` racing the in-flight call.
+		const result = await runChild(
+			`
+			await new Promise(r => setTimeout(r, 400))
+			let closes = 0
+			sock.ev.on('connection.update', u => { if (u.connection === 'close') closes++ })
+			await sock.logout().catch(() => {})
+			await new Promise(r => setTimeout(r, 1500))
+			if (closes !== 1) {
+				console.error('expected exactly one close, got ' + closes)
+				process.exit(3)
+			}
+			`,
+			folder,
+			counter.url
+		)
+		expect(result.outcome).toBe('exited')
+		expect(result.code).toBe(0)
+	})
+})

--- a/src/__tests__/socket-dispose-integration.test.ts
+++ b/src/__tests__/socket-dispose-integration.test.ts
@@ -289,6 +289,36 @@ describe('makeWASocket: disposing stops the bridge run loop', { timeout: 120_000
 		}
 	})
 
+	it('flushes the auth store through its own object, keeping the receiver', async () => {
+		// Collecting `store.flush` into an array and calling it bare drops the
+		// receiver, so a store whose `flush()` touches `this` throws on
+		// `undefined`. Teardown then records a flush failure and releases the
+		// client anyway — auth writes silently unpersisted.
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			let sawReceiver = false
+			const store = {
+				...(state.store as object),
+				flush() {
+					sawReceiver = this !== undefined
+					return Promise.resolve()
+				}
+			} as typeof state.store
+
+			const sock = makeWASocket({
+				auth: { ...state, store },
+				logger: silentLogger,
+				waWebSocketUrl: counter.url
+			})
+			await sock.end(undefined)
+
+			expect(sawReceiver).toBe(true)
+		} finally {
+			await counter.close()
+		}
+	})
+
 	it('an immediate dispose — before init settles — keeps the engine from reconnecting', async () => {
 		const counter = await startConnectionCounter()
 		try {

--- a/src/__tests__/terminal-close-reporter.test.ts
+++ b/src/__tests__/terminal-close-reporter.test.ts
@@ -101,6 +101,26 @@ describe('terminal close: reportAfter', () => {
 		expect(publishes).toBe(1)
 	})
 
+	it('publishes when teardown throws synchronously, not just when it rejects', async () => {
+		// A teardown that throws before returning a promise never reaches
+		// `.then`, so the close would wait for the watchdog — or never arrive
+		// at all if the timer were ever removed.
+		let published = false
+		const reporter = makeReporter()
+
+		reporter.reportAfter(
+			() => {
+				throw new Error('sync boom')
+			},
+			() => {
+				published = true
+			}
+		)
+		await reporter.published()
+
+		expect(published).toBe(true)
+	})
+
 	it('contains a throwing listener instead of letting it escape', async () => {
 		// `publish` emits on the consumer's bus, from a detached chain — an
 		// escaping throw is an unhandled rejection, i.e. process exit under

--- a/src/__tests__/terminal-close-reporter.test.ts
+++ b/src/__tests__/terminal-close-reporter.test.ts
@@ -1,0 +1,187 @@
+/**
+ * The terminal-close contract, tested without a socket.
+ *
+ * Nine review-found bugs lived in this logic while it was inline across the
+ * dispatcher hook and `logout()`. Each case below is one of them, and they are
+ * plain unit tests now — no wasm, no mock server, no child process — because
+ * the rule they check finally has one home.
+ */
+
+import { describe, it } from 'node:test'
+
+import { makeTerminalCloseReporter } from '../Socket/terminal-close-reporter.ts'
+import { expect } from './expect.ts'
+
+const noopLogger = {
+	trace() {},
+	debug() {},
+	info() {},
+	warn() {},
+	error() {},
+	child() {
+		return noopLogger
+	}
+}
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+const makeReporter = (publishTimeoutMs = 10_000) =>
+	makeTerminalCloseReporter({ logger: noopLogger as never, publishTimeoutMs })
+
+describe('terminal close: reportAfter', () => {
+	it('publishes only once teardown has finished', async () => {
+		// A consumer answering `close` with a replacement socket on the same
+		// auth folder would otherwise overlap this one's store flush and free.
+		const order: string[] = []
+		const reporter = makeReporter()
+
+		reporter.reportAfter(
+			async () => {
+				await wait(60)
+				order.push('teardown')
+			},
+			() => order.push('publish')
+		)
+		await reporter.published()
+
+		expect(order).toEqual(['teardown', 'publish'])
+	})
+
+	it('publishes even when teardown rejects', async () => {
+		// `end()` rethrows the first auth-store flush failure. Losing the close
+		// there leaves a socket that definitely ended with nobody told.
+		let published = false
+		const reporter = makeReporter()
+
+		reporter.reportAfter(
+			async () => {
+				throw new Error('flush exploded')
+			},
+			() => {
+				published = true
+			}
+		)
+		await reporter.published()
+
+		expect(published).toBe(true)
+	})
+
+	it('publishes anyway when teardown never settles', async () => {
+		// The watchdog. Trading "after teardown" for "at all" is deliberate:
+		// a close that never arrives is a bot offline with nothing in its logs.
+		let published = false
+		const reporter = makeReporter(50)
+
+		reporter.reportAfter(
+			() => new Promise<void>(() => {}),
+			() => {
+				published = true
+			}
+		)
+		await reporter.published()
+
+		expect(published).toBe(true)
+	})
+
+	it('publishes once, even if the watchdog and teardown both get there', async () => {
+		let publishes = 0
+		const reporter = makeReporter(30)
+
+		reporter.reportAfter(
+			async () => {
+				await wait(60)
+			},
+			() => {
+				publishes++
+			}
+		)
+		await reporter.published()
+		await wait(80)
+
+		expect(publishes).toBe(1)
+	})
+
+	it('contains a throwing listener instead of letting it escape', async () => {
+		// `publish` emits on the consumer's bus, from a detached chain — an
+		// escaping throw is an unhandled rejection, i.e. process exit under
+		// Node's default handler. Resolving is the assertion.
+		const reporter = makeReporter()
+
+		reporter.reportAfter(
+			async () => {},
+			() => {
+				throw new Error('listener exploded')
+			}
+		)
+		await reporter.published()
+	})
+})
+
+describe('terminal close: hasReported', () => {
+	it('is true as soon as a report is claimed, before it is published', () => {
+		// `logout()` checks this right after the bridge dispatched `LoggedOut`,
+		// while teardown is still running. Keying it on delivery would read
+		// `false` there and add a second close of its own.
+		const reporter = makeReporter()
+		expect(reporter.hasReported()).toBe(false)
+
+		reporter.reportAfter(
+			async () => {
+				await wait(60)
+			},
+			() => {}
+		)
+
+		expect(reporter.hasReported()).toBe(true)
+	})
+
+	it('is true after a direct report', () => {
+		const reporter = makeReporter()
+		reporter.reportNow(() => {})
+
+		expect(reporter.hasReported()).toBe(true)
+	})
+})
+
+describe('terminal close: published', () => {
+	it('resolves immediately when nothing has been reported', async () => {
+		// `logout()` awaits it unconditionally.
+		await makeReporter().published()
+	})
+
+	it('releases waiters at the moment the close is reported, not when teardown ends', async () => {
+		// The watchdog exists for a teardown that never settles, so a waiter
+		// tied to the teardown would hang past a close the consumer already
+		// received — which is how `await sock.logout()` used to deadlock.
+		const reporter = makeReporter(40)
+		let published = false
+
+		reporter.reportAfter(
+			() => new Promise<void>(() => {}),
+			() => {
+				published = true
+			}
+		)
+
+		await reporter.published()
+		expect(published).toBe(true)
+	})
+
+	it('tracks the most recent report', async () => {
+		const reporter = makeReporter()
+		const seen: string[] = []
+
+		reporter.reportNow(() => seen.push('first'))
+		await reporter.published()
+
+		reporter.reportAfter(
+			async () => {
+				await wait(40)
+			},
+			() => seen.push('second')
+		)
+		await reporter.published()
+
+		expect(seen).toEqual(['first', 'second'])
+	})
+})

--- a/src/__tests__/websocket-client-close.test.ts
+++ b/src/__tests__/websocket-client-close.test.ts
@@ -109,6 +109,34 @@ describe('WebSocketClient.close()', () => {
 		expect(calls).toBe(1)
 	})
 
+	it('does not let a reconnect reopen the facade mid-close', async () => {
+		// A close in flight has already told the client to disconnect, which is
+		// what makes `isConnected()` false — so `connect()` would clear the
+		// `closing` phase, and the next `close()` would start a second
+		// disconnect against a client still finishing the first.
+		let calls = 0
+		let connected = true
+		const client = {
+			isConnected: () => connected,
+			connect: async () => {},
+			disconnect: async () => {
+				calls++
+				connected = false
+				await wait(60)
+			}
+		} as unknown as WasmWhatsAppClient
+		const ws = makeWs(client)
+
+		const closing = ws.close()
+		await wait(10)
+		ws.connect() // a reconnect landing mid-teardown
+		expect(ws.isClosing).toBe(true)
+
+		await closing
+		await ws.close()
+		expect(calls).toBe(1)
+	})
+
 	it('settles for later callers even when the disconnect rejects', async () => {
 		let calls = 0
 		const client = {

--- a/src/__tests__/websocket-client-close.test.ts
+++ b/src/__tests__/websocket-client-close.test.ts
@@ -1,0 +1,108 @@
+/**
+ * `WebSocketClient.close()` is what the socket's teardown uses to drop the
+ * transport, and it is a `client.disconnect()` underneath.
+ *
+ * The early return on an already-closing socket used to be bare, so
+ * `void ws.close(); await sock.end()` saw the flag, returned immediately, and
+ * let teardown reach `free()` with the original `disconnect()` still in
+ * flight — the wasm heap corruption `bridge-free-safety.test.ts` documents.
+ * Awaiting a second `disconnect()` does not join the first one.
+ */
+
+import { describe, it } from 'node:test'
+
+import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+import { WebSocketClient } from '../Compatibility/websocket-client.ts'
+import type { SocketConfig } from '../Types/index.ts'
+import { expect } from './expect.ts'
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+/** A client whose `disconnect()` takes a known, observable amount of time. */
+const makeSlowClient = (ms: number) => {
+	let calls = 0
+	let finished = 0
+	const client = {
+		isConnected: () => true,
+		disconnect: async () => {
+			calls++
+			await wait(ms)
+			finished++
+		}
+	} as unknown as WasmWhatsAppClient
+	return { client, calls: () => calls, finished: () => finished }
+}
+
+const makeWs = (client: WasmWhatsAppClient) =>
+	new WebSocketClient('wss://127.0.0.1:1/ws', {} as SocketConfig, () => client)
+
+describe('WebSocketClient.close()', () => {
+	it('a second caller joins the in-flight close instead of returning early', async () => {
+		const slow = makeSlowClient(200)
+		const ws = makeWs(slow.client)
+
+		void ws.close()
+		await ws.close()
+
+		// Returning early would resolve here with the first disconnect still
+		// running, which is what let teardown free a busy client.
+		expect(slow.finished()).toBe(1)
+		// …and joining, not re-issuing.
+		expect(slow.calls()).toBe(1)
+	})
+
+	it('disconnects exactly once across concurrent callers', async () => {
+		const slow = makeSlowClient(100)
+		const ws = makeWs(slow.client)
+
+		await Promise.all([ws.close(), ws.close(), ws.close()])
+
+		expect(slow.calls()).toBe(1)
+	})
+
+	it('is a no-op once closed', async () => {
+		const slow = makeSlowClient(10)
+		const ws = makeWs(slow.client)
+
+		await ws.close()
+		await ws.close()
+
+		expect(slow.calls()).toBe(1)
+		expect(ws.isClosed).toBe(true)
+	})
+
+	it('reports CLOSING while in flight and CLOSED after', async () => {
+		const slow = makeSlowClient(120)
+		const ws = makeWs(slow.client)
+
+		const closing = ws.close()
+		// 2 === CLOSING, 3 === CLOSED on the upstream readyState ladder.
+		expect(ws.isClosing).toBe(true)
+		await closing
+		expect(ws.isClosed).toBe(true)
+		expect(ws.isClosing).toBe(false)
+	})
+
+	it('settles for later callers even when the disconnect rejects', async () => {
+		let calls = 0
+		const client = {
+			isConnected: () => true,
+			disconnect: async () => {
+				calls++
+				await wait(50)
+				throw new Error('disconnect exploded')
+			}
+		} as unknown as WasmWhatsAppClient
+		const ws = makeWs(client)
+
+		const first = ws.close().catch(() => 'rejected')
+		const second = ws.close().catch(() => 'rejected')
+
+		expect(await first).toBe('rejected')
+		expect(await second).toBe('rejected')
+		expect(calls).toBe(1)
+		// The socket is still considered closed: teardown must not be able to
+		// loop on a transport that refuses to go away.
+		expect(ws.isClosed).toBe(true)
+	})
+})

--- a/src/__tests__/websocket-client-close.test.ts
+++ b/src/__tests__/websocket-client-close.test.ts
@@ -83,6 +83,32 @@ describe('WebSocketClient.close()', () => {
 		expect(ws.isClosing).toBe(false)
 	})
 
+	it('is safe against a disconnect that re-enters close()', async () => {
+		// The state is stored before `disconnect()` runs, and the work deferred
+		// by a microtask so that ordering holds. An inline async body would run
+		// eagerly to its first await, invoking `disconnect()` while the state
+		// still said `open` — a synchronous callback reaching back into
+		// `close()` would then issue a second one on the same wasm handle.
+		let calls = 0
+		let ws!: WebSocketClient
+		let reentered: Promise<void> | undefined
+		const client = {
+			isConnected: () => true,
+			disconnect: async () => {
+				calls++
+				// Synchronous re-entry, before this body's first await.
+				reentered = ws.close()
+				await wait(20)
+			}
+		} as unknown as WasmWhatsAppClient
+		ws = makeWs(client)
+
+		await ws.close()
+		await reentered
+
+		expect(calls).toBe(1)
+	})
+
 	it('settles for later callers even when the disconnect rejects', async () => {
 		let calls = 0
 		const client = {


### PR DESCRIPTION
`connection.update { close }` carried two incompatible meanings, and no consumer could tell them apart.

A transient drop — network gone, `<failure reason="503">` — arrived as `close` while the Rust engine was already restoring the connection on its Fibonacci backoff. A terminal one — a replaced session, an outdated build, a temporary ban, an unrecoverable `<failure>` — arrived as `close` after the engine had cleared `enable_auto_reconnect` and left its run loop for good. The status codes overlap: a terminal `<failure reason="400">` and a lost transport both report `connectionClosed` (428).

So there was no correct handler. The canonical upstream pattern

```ts
if (connection === 'close' && statusCode !== DisconnectReason.loggedOut) connectToWhatsApp()
```

built a second socket while the engine was restoring the first — two live sockets on one account, which the server answers with `<stream:error code="409">`. Avoiding that by never recreating, which is what the README recommended, left the bot permanently offline after any terminal disconnect, with no log and no event.

## The split

Disconnects the engine retries now report `connection: 'connecting'` — the state upstream itself uses while a connection is being established, so the handler above never fires for them and consumers read a drop as `open → connecting → open`.

`close` is emitted only once the engine has given up, and only after the socket has fully torn down: transport closed, auth store flushed, end handlers run, wasm client freed. That ordering is upstream's own (`Socket/socket.ts` emits its close after `ws.close()` and the handlers), and it is what keeps a replacement socket from overlapping the old one's store flush on the same auth folder. It is also unconditional — both settle paths publish, a throwing consumer listener is swallowed, and a watchdog fires if teardown never settles, because a `close` that never arrives is the original bug wearing a different hat.

Freeing the client is not optional. The bridge holds the JS event callbacks as wasm-bindgen externrefs, those close over the `SocketContext`, and the context closes over the client handle — a cycle that crosses the JS/wasm boundary, so the `FinalizationRegistry` wasm-bindgen installs for `WasmWhatsAppClient` never fires.

The terminal set mirrors `whatsapp-rust`'s `client/lifecycle.rs` and lives in `src/Socket/terminal-close.ts`, documented against the Rust it duplicates. It exists in JS because `WasmWhatsAppClient.run()` returns `void` — it spawns the loop as a background task, so the loop's exit is not observable from here. A bridge that exposed loop completion would let us delete the table.

## One owner for the client's lifetime

The socket tracked that lifetime across six closure variables (`client`, `readyClient`, `ended`, `endPromise`, `initError`, `initPromise`), six `if (ended) return` guards scattered through `init()`, and hand-rolled promise memoization — with `let ended = false` declared 120 lines below the `init()` that read it. Every teardown bug in this file came from that shape.

`src/Socket/bridge-client-owner.ts` gathers it into three named operations — `adopt()`, `isClosing()`, `close()` — plus `peek()`, `discard()` and `settled()`. The guards now read as intent rather than bookkeeping.

The extraction earned itself immediately: it exposed that clearing the client handle before teardown turns `ws.close()` into a no-op, since that call is `getClient()?.disconnect()`. The disconnect moved after the auth-store flush, dropping the closing-session ratchet write on every clean shutdown — and neither the 588 unit tests nor the 82 e2e tests noticed, because the invariant was invisible while it lived across six variables. Fixed, and pinned by a test that fails when reintroduced.

## Fixes found along the way

**`stream_error` no longer reports `badSession`.** It reaches JS only from the engine's catch-all `<stream:error>` arm — an unknown code, an unacked `<ack/>`, `<xml-not-well-formed>` — all of which preserve or deliberately recycle the connection; the engine's own comment says *"the connection is intentionally preserved"*. The coded ones (401/409/515/516) dispatch their own events. `badSession` is 500, the code bots branch on to wipe credentials and re-pair, so a routine stream recycle could destroy a working session.

**`client_outdated` carries the wire code 405**, for the same reason. Upstream keeps the wire code too: `getErrorCodeFromStreamError` reads `+node.attrs.code` first and falls back to `badSession` only when the stanza carries none.

**`end()` runs once and later callers join it.** Now that the socket ends itself, a consumer's `await sock.end()` is usually the *second* call, and an `ended` early-return resolved it while the auth-store flush was still running — two writers on one folder for the `close` → `end()` → `makeWASocket()` flow this change encourages.

**`logout()` reports exactly one close on every path**, including when `client.logout()` throws, and no longer resolves a microtask before the close it caused.

**`connect_failure` 500/503 is only retryable while the engine may retry.** Under `setAutoReconnect(false)` the run loop breaks, and the socket was left reporting `connecting` forever with its client never freed. Same guard the `disconnected` dispatcher uses.

**`init()` survives a teardown landing mid-flight.** It reads the client it built rather than the shared handle, and re-checks `isClosing()` between awaits; a teardown used to turn the next call into a `TypeError`, swallowed into `initError` and reported later as a misleading "failed to initialize". A client adopted before a failed `init()` is discarded so the standalone helpers cannot keep reaching a client whose read loop never started.

**`end()` closes the transport and drains the store with no client yet**, so a mid-init end no longer leaves `ws.readyState` at CONNECTING.

**`setAutoReconnect()` before `init()` completes now reaches the engine.** It forwards through `client?.`, so the idiomatic first line moved only the JS mirror.

**The module-level bridge-client pointer is unregistered when the client is freed**, so standalone helpers report "no bridge client available" instead of reaching through a freed wasm pointer.

**`Symbol.asyncDispose`** on the socket, so `await using` frees the client on scope exit.

## Tests

64 new tests. Every load-bearing line was verified by reverting it and confirming a test fails — the table is what actually broke, not what should have:

| reverted | fails |
|---|---|
| `connecting`-vs-`close` contract | 3 e2e (two by timeout — the socket ends itself on a transient drop and never reopens) |
| client handle cleared before teardown | 2 |
| `onTerminalClose` before the emit | 2 |
| `setAutoReconnect(false)` guard | 1 |
| `qr: undefined` on `connecting` | 1 |
| `client_outdated` → 405 | 2 |
| `end()` promise memoization | 2 |
| `ws.close()`/flushes unconditional | 2 |
| end handlers before the flush rethrow | 2 |
| `Symbol.asyncDispose` try/finally | 1 |
| `await initPromise` in the disposer | 1 |
| `created.free()` in the init guard | 1 (child process fails to exit) |
| `_unregisterActiveBridgeClient` | 1 |
| `logout()` single-close | 1 |
| `setAutoReconnect` replay in `init()` | 1 |

`bridge-client-owner.test.ts` is the point of the extraction: races that used to need child processes, loopback listeners and a cuttable TCP proxy are now 15 plain unit cases in 165ms, because the lifetime sits behind an interface a fake client can drive.

`src/__tests__/e2e/connection-contract.test-e2e.ts` needs a real drop, which reaching into the socket's WebSocket wrapper cannot produce — the bridge owns the transport. `tcp-proxy.ts` proxies the mock server and can `cut()` (kill the connections) or `freeze()` (relay requests, black-hole replies), the only way to keep a bridge call pending across a teardown against a local mock.

`bridge-free-safety.test.ts` pins the bridge invariant the teardown ordering relies on: freeing a client with a call still pending corrupts the wasm heap — dlmalloc trips `psize <= size + max_overhead` and the process dies on `RuntimeError: unreachable`, from a microtask no `try/catch` around `free()` reaches, since `free()` itself returns normally. Each case runs in a child that signals it reached the risky call, so a bad import or a hang cannot pass as the crash.

Suite: 592 unit, 80/82 e2e. The two e2e failures are `presence`, pre-existing — verified against a clean tree.

## Not covered

`await client.disconnect()` before `free()` is defence in depth, not a reproduced failure being closed. The hazard is real at the bridge, but the transport close already disconnects first, so pending calls reject before the free. Forcing the window through `end()` failed offline, against the mock, and with the link black-holed; the line stays because it removes the dependence on that ordering, and covers `WebSocketClient.close()`'s early return when `closing`/`closed` is already set, which does not await the disconnect it skipped.

`isNewLogin` is declared in `ConnectionState` and never emitted by baileyrs, where upstream emits it after `pair-success`. Out of scope here, noted because it is the same class of compat trap.

## Public API

Unchanged. `compat:audit:strict` is byte-identical to before, verified by building the base in a separate worktree and diffing. Everything moved is internal to `makeWASocket`.

## Migration

Consumers counting `close` events for transient-drop telemetry stop seeing them; they are `connecting` now. Consumers branching on `badSession` from a stream error stop receiving it — that branch commonly wiped credentials, so this is a fix. Consumers that followed the previous README advice and did not recreate the socket must now handle `close` the upstream way; `README.md` and `Example/example.ts` are updated here, including the "opening a second socket leaks the first one" warning, which this change makes false.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved connection lifecycle handling with automatic retries for temporary interruptions.
  * Terminal disconnects now clearly indicate when a socket must be recreated.
  * Added safe asynchronous socket disposal and more reliable cleanup during logout or shutdown.
  * Preserved connection status codes and cleared stale QR states during retries.

* **Bug Fixes**
  * Prevented bridge-client leaks, duplicate close events, and unsafe cleanup during active operations.
  * Ensured connection update listeners continue receiving events when another listener fails.

* **Documentation**
  * Updated lifecycle guidance, Quick Start examples, migration notes, and troubleshooting information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->