### PR TITLE
perf(proto): give decoded messages a stable shape instead of re-parenting them

### DIFF
--- a/src/Compatibility/proto-runtime.ts
+++ b/src/Compatibility/proto-runtime.ts
@@ -655,24 +655,40 @@ class ProtoCompatibilityRuntime {
 		return this.hydrate(schemaId, codec.decode(reader, length))
 	}
 
+	/**
+	 * A fresh instance rather than an in-place re-parent: the codec installs its
+	 * own `toJSON` on what it returns, and deleting that normalizes the object
+	 * into dictionary mode, where every later read is a megamorphic lookup.
+	 */
 	private hydrate(schemaId: number, value: unknown): DynamicObject {
-		const object = isObject(value) ? value : {}
+		const source = isObject(value) ? value : {}
+		const instance = Object.create(this.constructorFor(schemaId).prototype) as DynamicObject
 		const messageFields = this.messageFieldsByName[schemaId]!
-		for (const key in object) {
+		for (const key in source) {
+			const nested = source[key]
 			const field = messageFields[key]
-			if (!field) continue
-			const nested = object[key]
-			if (field[3] & PROTO_FIELD_FLAG.repeated) {
-				if (Array.isArray(nested)) for (const item of nested) if (isObject(item)) this.hydrate(field[2], item)
-			} else if (field[3] & PROTO_FIELD_FLAG.map) {
-				if (isObject(nested)) for (const item of Object.values(nested)) if (isObject(item)) this.hydrate(field[2], item)
-			} else if (isObject(nested)) {
-				this.hydrate(field[2], nested)
+			if (!field) {
+				instance[key] = nested
+			} else if (field[3] & PROTO_FIELD_FLAG.repeated) {
+				if (Array.isArray(nested)) {
+					for (let index = 0; index < nested.length; index++) {
+						const item = nested[index]
+						if (isObject(item)) nested[index] = this.hydrate(field[2], item)
+					}
+				}
+				instance[key] = nested
+			} else if (field[3] & PROTO_FIELD_FLAG.map && isObject(nested)) {
+				const entries: DynamicObject = {}
+				for (const entry in nested) {
+					const item = nested[entry]
+					entries[entry] = isObject(item) ? this.hydrate(field[2], item) : item
+				}
+				instance[key] = entries
+			} else {
+				instance[key] = isObject(nested) ? this.hydrate(field[2], nested) : nested
 			}
 		}
-		if (hasOwn(object, 'toJSON')) delete object.toJSON
-		Object.setPrototypeOf(object, this.constructorFor(schemaId).prototype)
-		return object
+		return instance
 	}
 
 	private projectForEncode(schemaId: number, value: unknown): unknown {

--- a/src/__tests__/proto-decoded-shape.test.ts
+++ b/src/__tests__/proto-decoded-shape.test.ts
@@ -1,0 +1,101 @@
+import { spawnSync } from 'node:child_process'
+import { describe, it } from 'node:test'
+import { proto } from '../WAProto/runtime.ts'
+import { expect } from './expect.ts'
+
+type Dynamic = Record<string, unknown>
+
+const encoded = (fixture: Dynamic): Uint8Array => proto.Message.encode(proto.Message.fromObject(fixture)).finish()
+
+const shapeProbe = (source: string): Dynamic => {
+	const result = spawnSync(process.execPath, ['--allow-natives-syntax', '--input-type=module', '-e', source], {
+		cwd: new URL('../..', import.meta.url),
+		encoding: 'utf8'
+	})
+	if (result.status !== 0) throw new Error(result.stderr)
+	return JSON.parse(result.stdout) as Dynamic
+}
+
+describe('decoded protobuf message shape', () => {
+	it('keeps the public object contract of a decoded message', () => {
+		const fixture = { conversation: 'hello' }
+		const decoded = proto.Message.decode(encoded(fixture))
+
+		expect(decoded).toBeInstanceOf(proto.Message)
+		expect(Object.keys(decoded)).toEqual(['conversation'])
+		expect(decoded.toJSON()).toEqual(proto.Message.fromObject(fixture).toJSON())
+		expect(Object.getOwnPropertyNames(decoded)).toEqual(['conversation'])
+		expect(decoded.toJSON).toBe(Object.getPrototypeOf(decoded).toJSON)
+
+		// Absent fields still resolve through the prototype defaults.
+		expect(decoded.reactionMessage).toBe(null)
+		expect(decoded.protocolMessage).toBe(null)
+		expect(proto.Message.toObject(decoded, { defaults: true })).toEqual(
+			proto.Message.toObject(proto.Message.fromObject(fixture), { defaults: true })
+		)
+	})
+
+	it('keeps the same tree for nested, repeated and map fields', () => {
+		const nested = {
+			buttonsMessage: {
+				text: 'heading',
+				imageMessage: { caption: 'image', mediaKey: 'AQID' },
+				buttons: [
+					{ buttonId: 'one', buttonText: { displayText: 'first' }, type: 1 },
+					{ buttonId: 'two', buttonText: { displayText: 'second' }, type: 1 }
+				]
+			}
+		}
+		const decoded = proto.Message.decode(encoded(nested))
+		const expected = proto.Message.fromObject(nested)
+		const buttons = decoded.buttonsMessage!
+
+		expect(decoded.toJSON()).toEqual(expected.toJSON())
+		expect(buttons).toBeInstanceOf(proto.Message.ButtonsMessage)
+		expect(buttons.imageMessage).toBeInstanceOf(proto.Message.ImageMessage)
+		expect(buttons.buttons!.length).toBe(2)
+		expect(buttons.buttons![0]).toBeInstanceOf(proto.Message.ButtonsMessage.Button)
+		expect(buttons.buttons![0]!.buttonText).toBeInstanceOf(proto.Message.ButtonsMessage.Button.ButtonText)
+		// Repeated and map fields absent from the wire still read as the
+		// prototype defaults rather than as own properties.
+		expect(Object.keys(buttons.buttons![0]!.buttonText!)).toEqual(['displayText'])
+		expect(buttons.contextInfo).toBe(null)
+
+		const mapFixture = { field: { '1': { minVersion: 1, subfield: { '9': { isMessage: true } } } }, version: 3 }
+		const config = proto.Config.decode(proto.Config.encode(proto.Config.fromObject(mapFixture)).finish())
+		expect(config.toJSON()).toEqual(proto.Config.fromObject(mapFixture).toJSON())
+		expect(config.field!['1']).toBeInstanceOf(proto.Field)
+		expect(config.field!['1']!.subfield!['9']).toBeInstanceOf(proto.Field)
+	})
+
+	/**
+	 * Regression guard for the decoded object's hidden class. Before the fresh
+	 * instance, `hydrate` deleted the codec's own `toJSON` and re-parented what
+	 * was left, which normalized every message into dictionary mode.
+	 */
+	it('decodes into fast-property instances that share a hidden class per field set', () => {
+		const probe = shapeProbe(`
+			import { proto } from './src/WAProto/runtime.ts'
+			const bytes = fixture => proto.Message.encode(proto.Message.fromObject(fixture)).finish()
+			const first = proto.Message.decode(bytes({ conversation: 'first' }))
+			const second = proto.Message.decode(bytes({ conversation: 'second and longer' }))
+			const reaction = proto.Message.decode(bytes({ reactionMessage: { text: 'x' } }))
+			const nested = proto.Message.decode(bytes({ extendedTextMessage: { text: 'a', contextInfo: { stanzaId: 'b' } } }))
+			console.log(JSON.stringify({
+				fastProperties: %HasFastProperties(first) && %HasFastProperties(reaction) && %HasFastProperties(nested),
+				fastNested: %HasFastProperties(nested.extendedTextMessage.contextInfo),
+				sameFieldSet: %HaveSameMap(first, second),
+				differentFieldSet: %HaveSameMap(first, reaction)
+			}))
+		`)
+
+		expect(probe.fastProperties).toBe(true)
+		expect(probe.fastNested).toBe(true)
+		expect(probe.sameFieldSet).toBe(true)
+		// Two different field sets are two different fast maps. Collapsing them
+		// would mean materializing every schema field as an own property, which
+		// would change `Object.keys()`; the property that matters is that neither
+		// map is a dictionary.
+		expect(probe.differentFieldSet).toBe(false)
+	})
+})


### PR DESCRIPTION
## Summary

`hydrate` in `src/Compatibility/proto-runtime.ts` took the plain object the bridge codec returns, deleted the own `toJSON` the codec installs on it, and re-parented what was left with `Object.setPrototypeOf`.

The delete is the expensive half. Deleting an own property normalizes a fast object into dictionary mode, and re-parenting a dictionary-mode object then mints a brand new map per object instead of reusing a prototype transition, which is where the `Factory::NewMap` and `NumberDictionary::EnsureCapacity` samples come from. The result was that every decoded message had a unique dictionary-mode hidden class, so every later property read on it was a megamorphic dictionary lookup that no inline cache could ever settle.

The consumer paying for that is `hasMessageSideEffects` in `src/Socket/events.ts:135`, called once per message from `dispatchCanonicalEvent`: its two loads of `reactionMessage` and `protocolMessage` were megamorphic on every single message. So is any user code doing `msg.message.conversation`, because the object they read is the same one.

Fields now land on a fresh `Object.create(prototype)` instance, assigned in the order the codec produced them. Nothing is deleted, nothing is re-parented.

## Evidence

Under `--allow-natives-syntax`, decoding the same message twice and two different messages:

| probe | before | after |
| --- | --- | --- |
| `%HasFastProperties(decoded)` | `false` | `true` |
| `%HaveSameMap(a, b)`, same field set | `false` | `true` |
| `%HaveSameMap(a, c)`, different field sets | `false` | `false` |

Before the change, every decoded object was a dictionary-mode object with its own map, including two decodes of byte-identical input. The `false` in the last row after the change is not a regression: it is the honest ceiling. Two messages with different field sets are two different fast maps, and collapsing them would mean materializing every schema field as an own property, which changes `Object.keys()`. What changed is that neither map is a dictionary any more.

Isolating the two operations on a freshly decoded object confirms which one did the damage:

```
after codec decode          fast=true
after delete object.toJSON  fast=false      <-- normalizes to dictionary mode
after setPrototypeOf        fast=false
setPrototypeOf only         fast=true       <-- and shares maps across same-shape objects
```

So the re-parent was not the root cause. V8's prototype transition cache handles it fine on a fast object.

At the IC level, running 10000 messages of the mixed corpus through `--log-ic`, counting log entries whose new IC state is megamorphic:

| property | before | after |
| --- | ---: | ---: |
| `LoadIC reactionMessage` | 9991 | 6 |
| `LoadIC protocolMessage` | 9389 | 4 |
| `LoadIC conversation` | 9991 | 6 |
| all megamorphic entries | 30512 | 1158 |

Roughly one megamorphic entry per property per message before, essentially none after. The 1158 that remain are almost entirely `encode`/`decode` lookups on the facade namespace objects (341 + 148 and similar), which are constant, not per message.

## Design

Chosen: `Object.create(prototype)` and copy the present fields, at every level of the tree.

Alternatives, all measured in the same process against the same baseline (round medians, mixed corpus p50 ns/message and history sync p50 us/envelope):

| variant | flat | nested | why not |
| --- | ---: | ---: | --- |
| baseline | 3000 | 371 | |
| `new constructor(decoded)` | 2860 | ~700 | The constructor walks every field of the schema to seed repeated `[]` and map `{}`. `Message` has hundreds. It also adds those as own properties, which changes `Object.keys()` on decoded messages. |
| keep the walk in place, only stop deleting `toJSON` at the root | 1720 | 353 | Correct and minimal, but `setPrototypeOf` per nested node costs more than allocating a fresh one. Loses 35% of the win on nested trees. |
| fresh instance, but write hydrated children back into the source first | 1700 | 288 | Writing a re-mapped child back into the decoded parent generalizes the parent's field type and deprecates its map. |
| **fresh instance, children assigned straight onto it (chosen)** | **1670** | **262** | |

The number that decided it is the nested column. The flat path is a wash between the last three, but a history sync envelope carries thousands of nodes, and only the chosen variant never touches the codec's object at all.

The trade-off framing turned out to be backwards: copying fields does allocate a second object per node, but a dictionary-mode object with a `NameDictionary` backing store is bigger than a fast object plus the discarded original, so this is cheaper in memory too. Numbers in `## Cost`.

## Changes

- `hydrate` builds the instance with `Object.create(constructor.prototype)` instead of deleting `toJSON` and calling `setPrototypeOf`, because the delete is what forced dictionary mode.
- Nested messages, repeated elements and map values are hydrated into the instance as they are walked, so the codec's object is never written to and never has its field types generalized.
- Repeated arrays are still reused in place, since array element kinds do not carry the field-type tracking that object properties do and copying them buys nothing.
- New `src/__tests__/proto-decoded-shape.test.ts` pins the public object contract plus the hidden class, the latter through a child process with `--allow-natives-syntax`, mirroring the `spawnSync` pattern already used by `proto-runtime-compatibility.test.ts`. It fails on `main`.

## Cost

Mixed traffic corpus, decode plus the reads production does:

| metric | before | after | delta |
| --- | ---: | ---: | ---: |
| flat message p50 (ns/msg) | 2489 | 1224 | -51% |
| flat message p99 (ns/msg) | 5806 | 2792 | -52% |
| history sync p50 (us / 800-message envelope) | 238 | 143 | -40% |
| history sync p99 (us / envelope) | 556 | 448 | -19% |
| megamorphic IC entries / 10000 msgs | 30512 | 1158 | -96% |
| retained heap (bytes/msg, 50000 messages held) | 482 | 187 | -61% |
| retained RSS (bytes/msg) | 708 | 346 | -51% |
| process RSS at 50000 retained (MB) | 139.3 | 121.5 | -13% |

Methodology. Node 22.22.2, pinned with `taskset -c 2`. Baseline and patch run as two separate facades over the same neutral codec objects inside a single process, plus a control that decodes through the bridge codec with no facade at all and is otherwise untouched. Each of the three gets its own read-site function literal so one variant's shapes do not pollute another's inline caches. 200 warmup batches discarded, then 5 rounds of 400 samples of 100 messages each, p50 and p99 over samples, and the table reports the median round. The control moved 862 to 889 ns across rounds (3.0%) and 65.3 to 72.0 us on the nested scenario, so the deltas above are well clear of run-to-run noise. Absolute numbers shift when the number of variants in the process changes, since they share the codec's own call sites, so only within-run comparisons are meaningful. Memory was measured one variant per process under `--expose-gc`, retaining 50000 decoded messages so the objects are alive when `process.memoryUsage()` is read.

Shape mix, derived from `Message` payloads encoded through the bridge codec rather than captured bytes (there are no message fixtures in `src/__tests__/fixtures/`, only a legacy session): 62% plain `conversation`, 12% `extendedTextMessage` with a link preview, 8% quoted reply (`extendedTextMessage` plus `contextInfo.quotedMessage`), 6% `reactionMessage`, 5% `protocolMessage` revoke, 4% `imageMessage`, 3% `conversation` plus `messageContextInfo`. Deterministically shuffled so shapes interleave instead of arriving in blocks.

Where the win shows up and where it does not. It shows up on any workload that decodes messages and then reads properties off them, which is every incoming message and every history sync batch, and it grows with how much the consumer reads. It does not show up on send: `sendMessage` builds objects through `fromObject` and `create`, which never went through `hydrate`. A process that decodes and immediately discards without reading anything sees only the smaller allocation half of the win, not the IC half.

The benchmark was temporary and is not in this PR. The regression test is.

## Checked and not changed

- `Object.setPrototypeOf` on its own. Measured: it keeps the object in fast-properties mode and reuses V8's prototype transition cache, so two objects with the same field set come out sharing a map. It was only pathological here because it ran on an object the delete had already normalized. Recording this so the next person does not re-open the lead.
- The instance constructor in `makeConstructor` and the comment above it about staying on the megamorphic path. Still accurate for `create`/`fromObject`, which upstream requires to materialize repeated `[]` and map `{}` as own properties. Routing `decode` through it would add those keys to decoded messages and change `Object.keys()`, and it walks the whole schema per node. Load-bearing as is.
- `hasMessageSideEffects` in `src/Socket/events.ts`. Left exactly as it is on purpose. It is the thermometer for this change, not a target, and rewriting it to dodge the read is a separate piece of work.
- `projectForEncode`'s `INSTANCE_SCHEMA` probe. Reads through the prototype, so a fresh `Object.create(prototype)` instance still satisfies it.
- The bridge installing an own `toJSON` on every `decode` result. That is the bridge's call and changing it is a cross-repo change. Not writing to the object at all is cheaper and keeps this fix self-contained.
- `defineLazyValue` and the lazy namespace install. Untouched, and the lazy-namespace test still passes unmodified.

## Validation

```
npm run format
npm run lint
npm test                                     # 539 pass, 0 fail, no existing test adapted
npm run compat:audit:proto -- --details --strict
```

The proto auditor is unchanged and clean:

```
object contracts: 498/498 (100.00%)
enum values: 174/174 (100.00%)
codec types: 497/498 (99.80%)
wire fields: 2406/2424 (99.26%)
unsupported codecs: BotAvatarMetadata
```

`npm run test:e2e` was not run: it needs a mock server that is not available here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGwq5GD1CVSmLUaCDAXieh)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make decoded protobuf messages keep a stable, fast hidden class by creating fresh instances instead of deleting `toJSON` and re-parenting. This cuts megamorphic property reads and speeds up decode-plus-read while lowering memory.

- **Refactors**
  - `hydrate` now uses `Object.create(prototype)` and copies fields in decode order.
  - Hydrates nested messages into the new instance; never writes to the codec’s object.
  - Reuses repeated arrays; copies map fields into new plain objects.
  - Public contract unchanged: `instanceof`, `toJSON`, `Object.keys()`, and prototype defaults.
  - Added `src/__tests__/proto-decoded-shape.test.ts` to pin object contract and hidden class behavior.

- **Performance**
  - Flat decode+read p50: 2489 ns → 1224 ns (-51%)
  - History sync p50 (800 msgs): 238 µs → 143 µs (-40%)
  - Megamorphic IC entries/10k msgs: 30512 → 1158 (-96%)
  - Retained heap: 482 B/msg → 187 B/msg (-61%)

<sup>Written for commit 94c6a02949db1c58b2966896a85a3bde16ab1801. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

