### PR TITLE
perf(messages): resolve the content type once per send

### DIFF
--- a/src/Socket/messages.ts
+++ b/src/Socket/messages.ts
@@ -37,9 +37,11 @@ function getMediaContent(content: WAMessageContent | null | undefined) {
  * it across the delete and restore it on a fresh contextInfo.
  *
  * Mutates `msg` in place.
+ *
+ * `contentType` is a parameter so the send path can hand over the type it has
+ * already resolved rather than have it scanned out of `msg` a second time.
  */
-export function stripContextInfoForBridge(msg: WAMessageContent): void {
-	const contentType = getContentType(msg)
+export function stripContextInfoForBridge(msg: WAMessageContent, contentType = getContentType(msg)): void {
 	const pinAddOnDuration =
 		contentType === 'pinInChatMessage' ? msg.messageContextInfo?.messageAddOnDurationInSecs : undefined
 	delete (msg as Record<string, unknown>).messageContextInfo
@@ -116,7 +118,7 @@ export const makeMessageMethods = (ctx: SocketContext) => ({
 			}
 		}
 
-		stripContextInfoForBridge(msg)
+		stripContextInfoForBridge(msg, contentType)
 
 		let msgId: string
 		const msgBytes = encodeProto('Message', msg as Record<string, unknown>)

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -628,11 +628,15 @@ export const generateWAMessageFromContent = (
 	options: MessageGenerationOptionsFromContent
 ) => {
 	const innerMessage = normalizeMessageContent(message)!
-	const key = getContentType(innerMessage)! as Exclude<keyof proto.IMessage, 'conversation'>
 	const timestamp = unixTimestampSeconds(options.timestamp)
 	const { quoted, userJid } = options
+	// Only the quote and ephemeral branches read the content key, and a plain
+	// send takes neither, so resolve it on demand instead of on every send.
+	let key: Exclude<keyof proto.IMessage, 'conversation'> | undefined
 
 	if (quoted && !isJidNewsletter(jid)) {
+		const contentKey = getContentType(innerMessage)! as Exclude<keyof proto.IMessage, 'conversation'>
+		key = contentKey
 		const participant = quoted.key.fromMe
 			? userJid // TODO: Add support for LIDs
 			: quoted.participant || quoted.key.participant || quoted.key.remoteJid
@@ -648,7 +652,7 @@ export const generateWAMessageFromContent = (
 		}
 
 		const contextInfo: proto.IContextInfo =
-			('contextInfo' in innerMessage[key]! && innerMessage[key]?.contextInfo) || {}
+			('contextInfo' in innerMessage[contentKey]! && innerMessage[contentKey]?.contextInfo) || {}
 		contextInfo.participant = jidNormalizedUser(participant!)
 		contextInfo.stanzaId = quoted.key.id
 		contextInfo.quotedMessage = quotedMsg
@@ -659,27 +663,28 @@ export const generateWAMessageFromContent = (
 			contextInfo.remoteJid = quoted.key.remoteJid
 		}
 
-		if (contextInfo && innerMessage[key]) {
+		if (contextInfo && innerMessage[contentKey]) {
 			/* @ts-ignore */
-			innerMessage[key].contextInfo = contextInfo
+			innerMessage[contentKey].contextInfo = contextInfo
 		}
 	}
 
 	if (
 		// if we want to send a disappearing message
 		!!options?.ephemeralExpiration &&
-		// and it's not a protocol message -- delete, toggle disappear message
-		key !== 'protocolMessage' &&
-		// already not converted to disappearing message
-		key !== 'ephemeralMessage' &&
 		// newsletters don't support ephemeral messages
 		!isJidNewsletter(jid)
 	) {
-		/* @ts-ignore */
-		innerMessage[key].contextInfo = {
-			...((innerMessage[key] as Record<string, unknown>).contextInfo as Record<string, unknown>),
-			expiration: options.ephemeralExpiration || WA_DEFAULT_EPHEMERAL
-			//ephemeralSettingTimestamp: options.ephemeralOptions.eph_setting_ts?.toString()
+		const contentKey = key ?? (getContentType(innerMessage)! as Exclude<keyof proto.IMessage, 'conversation'>)
+		// skip protocol messages -- delete, toggle disappear message -- and
+		// content already converted to a disappearing message
+		if (contentKey !== 'protocolMessage' && contentKey !== 'ephemeralMessage') {
+			/* @ts-ignore */
+			innerMessage[contentKey].contextInfo = {
+				...((innerMessage[contentKey] as Record<string, unknown>).contextInfo as Record<string, unknown>),
+				expiration: options.ephemeralExpiration || WA_DEFAULT_EPHEMERAL
+				//ephemeralSettingTimestamp: options.ephemeralOptions.eph_setting_ts?.toString()
+			}
 		}
 	}
 

--- a/src/__tests__/content-type-resolution.test.ts
+++ b/src/__tests__/content-type-resolution.test.ts
@@ -1,0 +1,187 @@
+import { describe, it } from 'node:test'
+import { PROTO_MESSAGE_SCHEMAS } from '../WAProto/compatibility-schema.ts'
+import { stripContextInfoForBridge } from '../Socket/messages.ts'
+import type { WAMessage, WAMessageContent } from '../Types/index.ts'
+import { WAProto } from '../Types/index.ts'
+import { proto } from '../WAProto/runtime.ts'
+import { generateWAMessageFromContent, getContentType } from '../Utils/messages.ts'
+import { expect } from './expect.ts'
+
+/**
+ * `getContentType` is public API and its answer is positional: it returns the
+ * FIRST key in `Object.keys` order that names message content. Anything that
+ * makes the lookup cheaper has to keep that choice, so the ambiguous cases are
+ * pinned here rather than left to the shape of whatever the decoder happened
+ * to produce.
+ */
+
+/** Every field of `proto.Message` the helper must NOT report as content. */
+const NON_CONTENT_FIELDS = [
+	'senderKeyDistributionMessage',
+	'call',
+	'chat',
+	'messageContextInfo',
+	'callLogMesssage',
+	'messageHistoryBundle',
+	'eventCoverImage',
+	'statusAddYours',
+	'messageHistoryNotice'
+]
+
+const MESSAGE_FIELDS = PROTO_MESSAGE_SCHEMAS.find(([path]) => path === 'Message')![1].map(field => field[0])
+
+const asContent = (value: object) => value as WAMessageContent
+
+describe('getContentType — every field of the Message schema', () => {
+	it('covers the whole schema, not a sample', () => {
+		expect(MESSAGE_FIELDS.length).toBeGreaterThan(90)
+		for (const excluded of NON_CONTENT_FIELDS) expect(MESSAGE_FIELDS).toContain(excluded)
+	})
+
+	it('reports every content field under its own name', () => {
+		const contentFields = MESSAGE_FIELDS.filter(name => !NON_CONTENT_FIELDS.includes(name))
+		for (const name of contentFields) {
+			expect(getContentType(asContent({ [name]: {} }))).toBe(name as keyof proto.IMessage)
+		}
+	})
+
+	it('reports nothing for fields that are not user content', () => {
+		for (const name of NON_CONTENT_FIELDS) {
+			expect(getContentType(asContent({ [name]: {} }))).toBeUndefined()
+		}
+	})
+
+	it('resolves the same key on messages that came back through the codec', () => {
+		const shapes: WAMessageContent[] = [
+			{ conversation: 'ping' },
+			{ extendedTextMessage: { text: 'pong' } },
+			{ reactionMessage: { text: '\u{1F44D}', senderTimestampMs: 1700000000000 } },
+			{ protocolMessage: { type: proto.Message.ProtocolMessage.Type.REVOKE } },
+			{ imageMessage: { mimetype: 'image/jpeg', caption: 'look' } },
+			{ viewOnceMessageV2: { message: { conversation: 'peek' } } }
+		]
+		for (const shape of shapes) {
+			const decoded = WAProto.Message.decode(WAProto.Message.encode(shape).finish()) as WAMessageContent
+			expect(getContentType(decoded)).toBe(getContentType(shape))
+		}
+	})
+})
+
+describe('getContentType — more than one candidate field', () => {
+	// The predicate matches several fields at once, so the answer depends on key
+	// order. Both directions are asserted so a schema-ordered rewrite cannot pass.
+	it('returns conversation when conversation was inserted first', () => {
+		expect(getContentType(asContent({ conversation: 'hi', imageMessage: {} }))).toBe('conversation')
+	})
+
+	it('returns imageMessage when imageMessage was inserted first', () => {
+		expect(getContentType(asContent({ imageMessage: {}, conversation: 'hi' }))).toBe('imageMessage')
+	})
+
+	it('skips senderKeyDistributionMessage even when it comes first', () => {
+		expect(getContentType(asContent({ senderKeyDistributionMessage: {}, conversation: 'hi' }))).toBe('conversation')
+	})
+
+	it('keeps insertion order across three candidates', () => {
+		expect(getContentType(asContent({ pollUpdateMessage: {}, extendedTextMessage: {}, conversation: 'hi' }))).toBe(
+			'pollUpdateMessage'
+		)
+	})
+})
+
+describe('getContentType — nothing to report', () => {
+	it('returns undefined for undefined content', () => {
+		expect(getContentType(undefined)).toBeUndefined()
+	})
+
+	it('returns undefined for an empty object', () => {
+		expect(getContentType(asContent({}))).toBeUndefined()
+	})
+
+	it('returns undefined when only senderKeyDistributionMessage is present', () => {
+		expect(getContentType(asContent({ senderKeyDistributionMessage: {}, messageContextInfo: {} }))).toBeUndefined()
+	})
+})
+
+/**
+ * `generateWAMessageFromContent` resolves the content key only where it is
+ * read. These pin the branches that read it, so the deferral cannot quietly
+ * drop a quote or an expiration.
+ */
+describe('generateWAMessageFromContent — content key branches', () => {
+	const jid = '5511988888888@s.whatsapp.net'
+	const userJid = '5511977777777:1@s.whatsapp.net'
+	const quoted = {
+		key: { remoteJid: jid, id: 'AABBCCDD11223344', fromMe: false },
+		message: { conversation: 'ping' }
+	} as unknown as WAMessage
+
+	const textContent = () => WAProto.Message.create({ extendedTextMessage: { text: 'pong' } }) as WAMessageContent
+
+	it('leaves a plain send untouched', () => {
+		const wm = generateWAMessageFromContent(jid, textContent(), { userJid })
+		expect(wm.message?.extendedTextMessage?.text).toBe('pong')
+		expect(wm.message?.extendedTextMessage?.contextInfo).toBeFalsy()
+	})
+
+	it('stamps the quote onto the resolved content key', () => {
+		const wm = generateWAMessageFromContent(jid, textContent(), { userJid, quoted })
+		const ctx = wm.message?.extendedTextMessage?.contextInfo
+		expect(ctx?.stanzaId).toBe('AABBCCDD11223344')
+		expect(ctx?.quotedMessage?.conversation).toBe('ping')
+	})
+
+	it('stamps the expiration onto the resolved content key', () => {
+		const wm = generateWAMessageFromContent(jid, textContent(), { userJid, ephemeralExpiration: 86400 })
+		expect(wm.message?.extendedTextMessage?.contextInfo?.expiration).toBe(86400)
+	})
+
+	// Quote and expiration together share one resolution; both must still land.
+	it('stamps quote and expiration together', () => {
+		const wm = generateWAMessageFromContent(jid, textContent(), { userJid, quoted, ephemeralExpiration: 604800 })
+		const ctx = wm.message?.extendedTextMessage?.contextInfo
+		expect(ctx?.stanzaId).toBe('AABBCCDD11223344')
+		expect(ctx?.expiration).toBe(604800)
+	})
+
+	it('does not make a protocol message disappear', () => {
+		const content = WAProto.Message.create({
+			protocolMessage: { type: proto.Message.ProtocolMessage.Type.REVOKE }
+		}) as WAMessageContent
+		const wm = generateWAMessageFromContent(jid, content, { userJid, ephemeralExpiration: 86400 })
+		expect((wm.message?.protocolMessage as Record<string, unknown> | undefined)?.contextInfo).toBeFalsy()
+	})
+
+	it('does not apply an expiration on newsletters', () => {
+		const wm = generateWAMessageFromContent('123456@newsletter', textContent(), {
+			userJid,
+			ephemeralExpiration: 86400
+		})
+		expect(wm.message?.extendedTextMessage?.contextInfo).toBeFalsy()
+	})
+})
+
+describe('stripContextInfoForBridge — caller-supplied content type', () => {
+	const pinContent = () =>
+		WAProto.Message.create({
+			pinInChatMessage: { type: proto.PinInChat.Type.PIN_FOR_ALL, senderTimestampMs: 1700000000000 },
+			messageContextInfo: { messageAddOnDurationInSecs: 604800, messageSecret: new Uint8Array(32) }
+		}) as WAMessageContent
+
+	it('matches the type it would have resolved on its own', () => {
+		const resolved = pinContent()
+		const passed = pinContent()
+		stripContextInfoForBridge(resolved)
+		stripContextInfoForBridge(passed, getContentType(passed))
+		expect(passed.messageContextInfo?.messageAddOnDurationInSecs).toBe(
+			resolved.messageContextInfo?.messageAddOnDurationInSecs
+		)
+		expect(passed.messageContextInfo?.messageAddOnDurationInSecs).toBe(604800)
+	})
+
+	it('honours a caller that says the message is not a pin', () => {
+		const msg = pinContent()
+		stripContextInfoForBridge(msg, 'conversation')
+		expect(Object.hasOwn(msg, 'messageContextInfo')).toBe(false)
+	})
+})


### PR DESCRIPTION
## Summary

A plain outbound message resolved its content type **three times**: `generateWAMessageFromContent` computed it on entry, `sendMessage` computed it again on the normalized content, and `stripContextInfoForBridge` computed it a third time on the same object twenty lines later. Two of the three were dead work, and they are gone. The remaining one is the one that is actually read.

The audit that opened this task also claimed the per-call `Object.keys` array and the `.find` closure inside `getContentType` were worth removing. I measured that and it did not hold, so `getContentType`'s body is unchanged. Details in `## Cost`.

The PR title differs from the one in the task brief (`resolve content type without allocating per call`) because that title describes the change the measurement refuted.

## Design

**`getContentType` is untouched, so nothing about the ordering contract moved.** The helper still returns the first key in `Object.keys` order that names content, which is insertion order and therefore wire order for decoded messages. I did not try to prove that the multi-candidate case never happens: it is public API and callers pass whatever they like, so the safe route was to not change the resolution at all. The new tests pin the contract in both directions (`{conversation, imageMessage}` -> `conversation`, `{imageMessage, conversation}` -> `imageMessage`) so a future rewrite to schema order fails loudly instead of quietly. I checked that the tests are non-vacuous by swapping in a `toSorted()` implementation: two of them fail.

**Nothing is memoized**, so there is no interaction with `proto-hydrate-hidden-class`. No property, symbol or otherwise, is added to any message instance; no WeakMap, no keyed cache. The whole change is about *where* the existing call happens, not what it stores. That also means there is no staleness question to answer.

**Deferring the resolution in `generateWAMessageFromContent`** is safe because the key was only ever read by two branches. The quote branch resolves it before it mutates anything, exactly where the old code's value was captured. The ephemeral branch reuses the quote branch's result when both apply, so no path resolves it more than once, and the newsletter guard moved ahead of the key comparisons (all three predicates are pure, so the reorder is inert). A content object with no recognisable type still throws the same `TypeError` in the same place it did before.

**One direction I checked and dropped:** getting the discriminant from the proto layer. `proto.Message` has 95 fields and **zero oneof groups** in the generated schema, so `defineOneofs` installs nothing for it and there is no discriminant to read. That route does not exist without inventing one.

## Changes

- `generateWAMessageFromContent`: content key resolved inside the quote and ephemeral branches instead of on entry, since a plain send reads neither.
- Same function: the ephemeral guard is now `expiration && !newsletter` outer, key comparisons inner, so the key is not resolved for sends that were never going to get an expiration anyway.
- `stripContextInfoForBridge(msg, contentType = getContentType(msg))`: the send path passes the type it already resolved. Default parameter, so the other two call sites and both existing test files are unaffected.
- New `src/__tests__/content-type-resolution.test.ts`: exhaustive over the `Message` schema (all 95 fields, not a sample), plus the ambiguous-order cases, the empty/undefined/SKDM-only edges, and the send-path branches that read the key.

## Cost

Node 22.22, single Xeon core pinned with `taskset -c 2`, `--max-semi-space-size=1` so scavenge count tracks bytes allocated. Baseline and patched run **in the same process**: the pre-change `generateWAMessageFromContent` is copied verbatim from `HEAD` into the harness and driven through the same corpus, alongside a byte-identical **control** copy of the baseline that is never modified. 400 iterations x 2048 sends per round, 60 warmup iterations discarded, 5 rounds.

Outbound mix: 62% plain `extendedTextMessage`, 12% the same with a `contextInfo`, 8% reaction, 7% `protocolMessage` revoke, 6% image with thumbnail and media keys, 5% bare `conversation`. A fresh `Message.create` instance per send, since the real path never re-sends the same object.

| | p50 ns/send | p99 ns/send | min ns/send | scavenges / 1k sends |
|---|---|---|---|---|
| before (3 lookups) | 1890 | 3108 | 1764 | 0.123 |
| after (1 lookup) | **1778** | 2774 | **1678** | **0.107** |
| control (unmodified) | 1870 | 3031 | 1753 | 0.123 |

p50 and scavenges are medians of the 5 per-round figures. The control drifts across a 58 ns band round to round (1845-1903); the patched-vs-baseline gap was 87-130 ns in every round and patched came in under both baseline and control every time, so the effect clears the noise floor. **p99 does not**: it swings 1979-3434 ns and is dominated by whichever round happened to catch a GC. Read the p99 column as "no regression", not as a gain. Allocation is the cleanest signal: baseline and control sat at exactly 0.123 scavenges/1k sends in all 5 rounds, patched at 0.107, a 13% drop.

**Be honest about the magnitude.** In the 10k-message workload this came from, ~112 ns x 10000 sends is about **1.1 ms out of 4.28 s of CPU, roughly 0.03%**. This is not a throughput change anyone will notice. It is worth taking because it is dead work with no downside, not because of the number.

### The refuted part

Rewriting `getContentType`'s body was measured and dropped. Four variants (the original; `find` with a module-level predicate; an indexed loop with a module-level predicate; an indexed loop with a precomputed 95-entry lookup table) over a realistic inbound mix (40% 1:1 `conversation`, 18% group `conversation` + SKDM + `messageContextInfo`, 14% quoted `extendedTextMessage`, plus reaction / protocol / image / poll / view-once / a no-candidate case, all round-tripped through the codec so key sets and order match production, deterministically interleaved so the call site stays megamorphic):

| corpus | baseline p50 | best variant p50 | control p50 |
|---|---|---|---|
| inbound (decoded protos) | 172 ns/call | 170 ns/call | 172 ns/call |
| outbound (`Message.create`) | 42 ns/call | 39 ns/call | 42 ns/call |

Every variant sat inside the control's own spread. Over 20M calls all variants produced **identical** scavenge counts (176 inbound, 119 outbound) - so the `.find` closure captures nothing and V8 was already eliding it, and the `Object.keys` array is the same array in both shapes. There was no allocation to remove, which is why there was no time to win.

What the split does show is where the cost actually is: **170 ns/call on decoded messages against 42 ns on constructed ones**, a 4x gap on the same code. `%HasFastProperties` says decoded protos are in dictionary mode - `hydrate`'s `Object.setPrototypeOf` puts them there - and `Object.keys` on a dictionary-mode object costs ~130 ns against ~12 ns on a fast-mode one. That is the whole difference, and it belongs to `proto-hydrate-hidden-class`, not here.

The benchmark harness was temporary and is not in this PR. The tests are.

## Checked and not changed

- **`getContentType`'s body.** Measured, refuted, left alone. See above.
- **`new WAProto.WebMessageInfo()`** allocates 10 empty arrays per send (its repeated fields). This is the largest single allocation on the send path, and it is deliberate: the existing comment calls out protobufjs parity, and the prototype defaults it would fall back to are a frozen shared `EMPTY_ARRAY`, so dropping the own arrays would turn `wm.messageStubParameters.push(...)` into a throw for callers. Semantic change, not an optimization.
- **`WAProto.Message.create(m)`** in `generateWAMessageContent` copies via `Object.keys(properties)`. The instance is the documented return type, and line 693 already avoids doing it twice.
- **`Object.keys(m)[0]`** in `generateWAMessageContent` (twice) allocates a full key array to read one key. Both sit on the `mentions` / `contextInfo` branches, so a plain send never reaches them; not worth the churn on a cold path.
- **The `Message` constructor loop in `proto-runtime.ts`** walks all 95 fields per instantiation to install repeated/map defaults, and `Message` has none of either, so for this type the loop is pure overhead. Fixing it means precomputing the repeated/map subset at constructor-build time, which is `proto-runtime.ts` object-shape territory and overlaps `proto-hydrate-hidden-class`. Left for that task.
- **Sharing one resolution between `generateWAMessageFromContent` and `sendMessage`.** They resolve against different objects: the former works on the pre-`create` content, the latter re-normalizes `fullMsg.message` after `Message.create` has copied it. Threading a value across that boundary would be wrong whenever the copy diverges.

## Validation

```
npm run format
npm run lint     # tsc && oxlint, clean
npm test         # 555 tests, 555 pass (536 before, 19 new)
```

No existing test was adapted. `test:e2e` was not run: it needs a mock server this environment does not have.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiD7BwswKJPU8okpyKvbKN)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve message content type once per send and reuse it across the send path, removing two redundant lookups. This cuts small dead work, improving p50 send time by ~6% with no behavior changes.

- Refactors
  - In `generateWAMessageFromContent`, compute the content key only inside the quote/ephemeral branches and reuse it when both apply.
  - `stripContextInfoForBridge(msg, contentType?)` now accepts an optional `contentType`; the send path passes the resolved key, and other callers keep the old defaulted lookup.
  - `getContentType` is unchanged and still returns the first content key in `Object.keys` order.
  - Added tests covering all `proto.Message` fields, ambiguous key-order cases, and the send-path branches.
  - Measured locally: ~6% p50 speedup and ~13% fewer scavenges on the send path.

<sup>Written for commit bd9919b48a9b2549ef4929184f1ed91705cd48b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

