### PR TITLE
chore(deps): upgrade bridge to 0.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.6.4",
+        "@oxidezap/whatsapp-rust-bridge": "0.6.5",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -974,9 +974,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.6.4.tgz",
-      "integrity": "sha512-SvKAucV7m2G/Pa7e6J6mPQKauuANP8sy1E4Kh4e4u3E//jzhwz18JDFzqspuGPl5XuQL4MshqADU8P5c7H3lZA==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.6.5.tgz",
+      "integrity": "sha512-vRkO2vWAG79DWGxp5ffoUvBENO6WloTh1+u1Tsf/s+LQ/VmUAIsCSAuk996MsnmFbCrtKauhSx82EPGWXlt88Q==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@oxidezap/whatsapp-rust-bridge": "0.6.4",
+    "@oxidezap/whatsapp-rust-bridge": "0.6.5",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `@oxidezap/whatsapp-rust-bridge` from 0.6.4 to 0.6.5 to stay current and pick up latest fixes. Only package manifest and lockfile were updated; no code changes.

<sup>Written for commit 2e7b108b27739f43425826dd7def71d6bfe45736. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WhatsApp integration component to version 0.6.5 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->