### PR TITLE
perf(events): opt the packed receipt and ack paths into borrowed batches

### DIFF
--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -1106,12 +1106,29 @@ export const makeEventHandlers = (ctx: SocketContext, callbacks?: EventCallbacks
 		for (const data of acks) onEvent({ type: 'server_ack', data } as unknown as WhatsAppEvent)
 	}
 
+	// Opting the two packed paths into the bridge's borrowing contract, which
+	// lets it hand every batch out of one reused buffer instead of allocating
+	// per batch. Both handlers already satisfied the contract unchanged: each
+	// decodes as its first act, and `decodeReceiptWireBatch` /
+	// `decodeServerAckWireBatch` materialise every field rather than keeping a
+	// view, so nothing points at the buffer once they return. Neither is async,
+	// and no exception escapes them — the decode is guarded here and the
+	// dispatch is guarded in `dispatchCanonicalEvent` — both of which the
+	// contract requires, since either one drops the whole session back to a
+	// buffer per batch.
+	//
+	// Declaring a borrowing name replaces its copying counterpart as the sink,
+	// so the pair below is the whole opt-in. There is deliberately none for
+	// messages: `decodeMessageWireBatch` returns views over the batch, so reuse
+	// would alias the decoded result and not just the buffer.
 	return {
 		onEvent,
 		onMessageBatch,
 		onHistorySyncBatch,
 		onReceiptBatch,
 		onServerAckBatch,
+		onReceiptBatchBorrowed: onReceiptBatch,
+		onServerAckBatchBorrowed: onServerAckBatch,
 		historySyncConversationTypes: CONVERSATION_HISTORY_SYNC_TYPES
 	}
 }


### PR DESCRIPTION
## Summary

The bridge hands packed receipt and server-ack batches across in a buffer it allocates per batch. Its borrowing form reuses one buffer for the whole session instead, and declaring the borrowing name is the entire opt-in — `onReceiptBatchBorrowed` replaces `onReceiptBatch` as the sink, same for acks.

Both handlers already satisfied the contract without changing a line, which is why this is nine lines of wiring and a comment rather than a rewrite.

## Why it is safe

The bridge's contract (`whatsapp_rust_bridge.d.ts`) says a borrowed batch is a window on shared memory, valid only for the synchronous duration of the call. Checked against `onReceiptBatch` / `onServerAckBatch` point by point:

- **Decoded before returning.** Each handler's first act is `decodeReceiptWireBatch` / `decodeServerAckWireBatch`, and the contract states these "materialize every field and keep no view over the buffer". Nothing points at the buffer once the handler returns.
- **Not retained.** Only the decoded `receipts` / `acks` arrays cross into `onEvent`; the `batch` argument is never stored.
- **Not async, no Promise returned.** Both are plain arrow functions returning `void`.
- **No exception escapes.** The decode is wrapped in `try/catch` in the handler, and the dispatch is wrapped in `dispatchCanonicalEvent` ("One bad event must not poison the rest of the pipeline"). This matters because the contract treats an escaping exception the same as a retained view: it drops every borrowing callback of every packed kind back to a buffer per batch for the rest of the session.

Messages deliberately stay on the copying path. `decodeMessageWireBatch` returns views over the batch, so reuse there would alias the decoded result and not only the buffer — the bridge documents that there is no borrowing form for it, and none is declared here.

## Changes

- `makeEventHandlers` declares `onReceiptBatchBorrowed` and `onServerAckBatchBorrowed`, both pointing at the existing handlers.
- A comment recording why the handlers already satisfy the contract, and why messages are excluded.

No cast is needed: the bridge is on 0.6.5 (#24), whose types carry both names, and `makeEventHandlers` already declares `WhatsAppEventCallbacks` as its return type. An earlier local version of this change carried an `as WhatsAppEventCallbacks` because the then-pinned types predated the names; it is gone, and `tsc` passes without it.

## Cost

Not measured in this tree. The mechanism is one buffer per session in place of one per packed batch, on the receipt and ack paths only, so the win scales with packed-batch traffic and is allocation, not CPU. Happy to run an A/B before merge if you want a number rather than a mechanism.

## Validation

```
npm run lint   # tsc && oxlint, clean
npm test       # 645 tests, 645 pass, 0 fail
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opted packed receipt and server-ack handling into the bridge’s borrowed-batch mode to reuse a single buffer per session and reduce allocations. Messages stay on the copying path because their decoder returns views.

- **Refactors**
  - In `makeEventHandlers`, added `onReceiptBatchBorrowed` and `onServerAckBatchBorrowed` wired to existing handlers.
  - Added comments clarifying the borrowed-batch safety (sync handlers, decode upfront, no retained views) and why messages are excluded.

<sup>Written for commit dfe60e82ade9383bc1aba154f0dd9960633f2cd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

