### PR TITLE
fix(deps): update whatsapp-rust-bridge to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.6.5",
+        "@oxidezap/whatsapp-rust-bridge": "0.7.0",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -974,9 +974,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.6.5.tgz",
-      "integrity": "sha512-vRkO2vWAG79DWGxp5ffoUvBENO6WloTh1+u1Tsf/s+LQ/VmUAIsCSAuk996MsnmFbCrtKauhSx82EPGWXlt88Q==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.7.0.tgz",
+      "integrity": "sha512-RD8Ueg+xf2MAIUoYz+rlkHvWyOOEqvafEH6nh7xARq6JvGOcWBYy9xxDwRy03HWP9lVeIYUPeY5lqRYaTH9W6g==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@oxidezap/whatsapp-rust-bridge": "0.6.5",
+    "@oxidezap/whatsapp-rust-bridge": "0.7.0",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"

--- a/src/__tests__/auto-reconnect-terminal-close.test.ts
+++ b/src/__tests__/auto-reconnect-terminal-close.test.ts
@@ -234,11 +234,12 @@ describe('connection.update: terminal disconnects', () => {
  * with nothing here failing to build. Bridge 0.7.0 writes the spellings down
  * instead, keeping every value it already emitted.
  *
- * That makes them a contract, and this is where the contract is observed: the
- * reason is interpolated straight into the close message, so it is the text a
- * consumer logs and greps. It steers nothing, the status code is always
- * `loggedOut`, but a change to it is a change to the public surface, and
- * without this test the next one would pass unnoticed too.
+ * The events are synthetic, so this pins our half of that contract rather than
+ * the bridge's: the dispatcher hands the reason through untouched, the close
+ * message is exactly `Logged out: <reason>`, and the status code stays
+ * `loggedOut` whatever the reason says. The list doubles as the record of which
+ * values the bridge undertakes to emit. A change on the bridge side of the line
+ * is caught by the bridge's own tests, which assert those spellings literally.
  */
 const LOGGED_OUT_REASONS = [
 	'Generic',

--- a/src/__tests__/auto-reconnect-terminal-close.test.ts
+++ b/src/__tests__/auto-reconnect-terminal-close.test.ts
@@ -227,6 +227,56 @@ describe('connection.update: terminal disconnects', () => {
 	}
 })
 
+/**
+ * `logged_out.reason` used to be `format!("{:?}")` on the core's
+ * `ConnectFailureReason`, a `Debug` string, which is not a stable API: a
+ * variant renamed upstream would have silently changed what a consumer reads,
+ * with nothing here failing to build. Bridge 0.7.0 writes the spellings down
+ * instead, keeping every value it already emitted.
+ *
+ * That makes them a contract, and this is where the contract is observed: the
+ * reason is interpolated straight into the close message, so it is the text a
+ * consumer logs and greps. It steers nothing, the status code is always
+ * `loggedOut`, but a change to it is a change to the public surface, and
+ * without this test the next one would pass unnoticed too.
+ */
+const LOGGED_OUT_REASONS = [
+	'Generic',
+	'LoggedOut',
+	'TempBanned',
+	'AccountLocked',
+	'UnknownLogout',
+	'ClientOutdated',
+	'BadUserAgent',
+	'CatExpired',
+	'CatInvalid',
+	'NotFound',
+	'ClientUnknown',
+	'InternalServerError',
+	'Experimental',
+	'ServiceUnavailable',
+	// The core's own fallback for a code it cannot name, carried through.
+	'Unknown(499)'
+]
+
+describe('logged out: the reason reaches the consumer verbatim', () => {
+	for (const reason of LOGGED_OUT_REASONS) {
+		it(`${reason} → 'Logged out: ${reason}'`, () => {
+			const result = dispatch({ type: 'logged_out', data: { reason } })
+
+			expect((result.close?.lastDisconnect?.error as Boom | undefined)?.message).toBe(`Logged out: ${reason}`)
+			expect(result.statusCode).toBe(DisconnectReason.loggedOut)
+		})
+	}
+
+	it('no reason at all → plain "Logged out"', () => {
+		const result = dispatch({ type: 'logged_out', data: {} })
+
+		expect((result.close?.lastDisconnect?.error as Boom | undefined)?.message).toBe('Logged out')
+		expect(result.statusCode).toBe(DisconnectReason.loggedOut)
+	})
+})
+
 describe('connection.update: disconnects the engine retries', () => {
 	for (const { label, event } of RETRYING) {
 		it(`${label} → 'connecting', never 'close'`, () => {

--- a/src/__tests__/bridge-argument-rejection.test.ts
+++ b/src/__tests__/bridge-argument-rejection.test.ts
@@ -8,12 +8,22 @@
  * rejects with `invalid-argument` naming the parameter, and it does the same
  * for a stream parameter that cannot do what a stream does.
  *
- * What this pins is the bridge boundary itself, driven directly, not the socket
- * methods layered over it. The distinction is real: `sock.readMessages` runs its
- * input through `receiptMessageKeys` first, which drops anything without a
- * `remoteJid` and an `id`, so this exact bad value resolves there without ever
- * reaching the bridge. The boundary is still a consumer-facing contract, since
- * `MediaGenerationOptions.processMedia` hands the raw client over.
+ * What this pins is the bridge boundary itself, driven directly. How much of
+ * the socket surface each probe stands for varies, so to be exact about it:
+ *
+ *  - `muteChat` is a bare pass-through on the socket, so that probe is the
+ *    public path, argument and all.
+ *  - `encryptMediaStream` reaches consumers raw, handed over by
+ *    `MediaGenerationOptions.processMedia`.
+ *  - `readMessages` is filtered by `receiptMessageKeys` first, which drops
+ *    anything without a `remoteJid` and an `id`, so through the socket this
+ *    value resolves to a no-op instead of reaching the bridge.
+ *  - `sendPresence` sits behind `sendPresenceUpdate`, which turns an off-union
+ *    status into a missing-target-jid Boom before the bridge sees it.
+ *
+ * The last two are still worth probing here: the boundary is one contract, and
+ * a normalizer that happens to absorb one bad value today is not a reason to
+ * leave the boundary under it untested.
  *
  * The probes run in a child process because the old failure mode is fatal: only
  * a separate process can tell "the call rejected" from "the call took the test

--- a/src/__tests__/bridge-argument-rejection.test.ts
+++ b/src/__tests__/bridge-argument-rejection.test.ts
@@ -19,6 +19,7 @@
  * runner down with it", which is the whole distinction under test.
  */
 
+import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -100,12 +101,19 @@ const runProbes = (folder: string) => {
 			const pending = new Promise(resolve => {
 				timer = setTimeout(() => resolve({ label, settled: 'pending' }), 8000)
 			})
-			const settled = run().then(
-				() => ({ label, settled: 'resolved' }),
-				e => ({ label, settled: 'rejected', kind: e?.kind, field: e?.field })
-			)
-			report(await Promise.race([settled, pending]))
+			const outcome = await Promise.race([
+				run().then(
+					() => ({ label, settled: 'resolved' }),
+					e => ({ label, settled: 'rejected', kind: e?.kind, field: e?.field })
+				),
+				pending
+			])
 			clearTimeout(timer)
+			report(outcome)
+			// The call is still in flight, so continuing would reach free()
+			// with a pending call: the heap corruption bridge-free-safety
+			// documents, whose crash would then be reported instead of this.
+			if (outcome.settled === 'pending') process.exit(9)
 		}
 
 		${PROBES.map(({ label, call }) => `await probe(${JSON.stringify(label)}, () => ${call})`).join('\n\t\t')}
@@ -124,6 +132,12 @@ const runProbes = (folder: string) => {
 		child.stderr.on('data', chunk => (stderr += String(chunk)))
 
 		const timer = setTimeout(() => child.kill('SIGKILL'), 60_000)
+		// Unlistened, a failed spawn throws in the test runner and leaves this
+		// promise pending until the suite times out.
+		child.on('error', error => {
+			clearTimeout(timer)
+			resolve({ code: null, outcomes: [], stderr: `${stderr}\nspawn failed: ${String(error)}` })
+		})
 		// `close`, not `exit`: the parent has to have drained the pipes before
 		// the reports can be parsed.
 		child.on('close', code => {
@@ -152,8 +166,12 @@ describe('bridge: a bad argument rejects instead of escaping the caller', { time
 
 	it('every probe settles, and the process survives all of them', () => {
 		// On 0.6.5 the first probe alone ended the child, so nothing after it
-		// was ever reported.
-		expect(run.outcomes.map(outcome => outcome.label)).toEqual(PROBES.map(probe => probe.label))
+		// was ever reported. The child's stderr is the only account of why.
+		assert.deepStrictEqual(
+			run.outcomes.map(outcome => outcome.label),
+			PROBES.map(probe => probe.label),
+			`child exited with ${run.code}; stderr:\n${run.stderr}`
+		)
 		expect(run.code).toBe(0)
 	})
 

--- a/src/__tests__/bridge-argument-rejection.test.ts
+++ b/src/__tests__/bridge-argument-rejection.test.ts
@@ -1,0 +1,171 @@
+/**
+ * A bad argument has to come back as a rejection.
+ *
+ * Bridge 0.6.5 deserialized typed parameters inside the async shim, so a value
+ * of the wrong shape threw from a place no `await` could catch: the promise
+ * stayed pending for good and the throw surfaced as an uncaught exception,
+ * which in Node ends the process. 0.7.0 deserializes them explicitly and
+ * rejects with `invalid-argument` naming the parameter, and it does the same
+ * for a stream parameter that cannot do what a stream does.
+ *
+ * Every method here is reachable from this package's public surface:
+ * `readMessages` and `muteChat` are socket methods, `encryptMediaStream` is
+ * handed to consumers through `MediaGenerationOptions.processMedia`. None of
+ * them is called with a bad argument by our own code, so what this pins is the
+ * contract a consumer gets, not a path we take.
+ *
+ * The probes run in a child process because the old failure mode is fatal: only
+ * a separate process can tell "the call rejected" from "the call took the test
+ * runner down with it", which is the whole distinction under test.
+ */
+
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, describe, it } from 'node:test'
+
+import { expect } from './expect.ts'
+
+const SRC = import.meta.dirname
+
+interface ProbeOutcome {
+	label: string
+	/** `pending` means the call never settled, the 0.6.5 failure. */
+	settled: 'rejected' | 'resolved' | 'pending'
+	kind?: string
+	field?: string
+}
+
+interface ProbeSpec {
+	label: string
+	/** Body of the call, evaluated in the child against the client `c`. */
+	call: string
+	field: string
+	why: string
+}
+
+const PROBES: ProbeSpec[] = [
+	{
+		label: 'readMessages with a string where the key list goes',
+		call: `c.readMessages('not-an-array')`,
+		field: 'keys',
+		why: 'a typed list parameter'
+	},
+	{
+		label: 'sendPresence with a status outside the union',
+		call: `c.sendPresence('nope')`,
+		field: 'status',
+		why: 'a typed enum parameter'
+	},
+	{
+		label: 'muteChat with a non-finite timestamp',
+		call: `c.muteChat('123@s.whatsapp.net', Infinity)`,
+		field: 'muteUntil',
+		// `as i64` saturates, so Infinity used to arrive as i64::MAX and pass
+		// every check downstream of the cast.
+		why: 'a millisecond instant the core takes as i64'
+	},
+	{
+		label: 'encryptMediaStream with plain objects for the streams',
+		call: `c.encryptMediaStream({}, {}, 'image')`,
+		field: 'input',
+		why: 'an imported class parameter wasm-bindgen casts unchecked'
+	}
+]
+
+/** Build a client against a dead loopback port and run every probe in it. */
+const runProbes = (folder: string) => {
+	const script = `
+		import { createWhatsAppClient, initWasmEngine } from '@oxidezap/whatsapp-rust-bridge'
+		import { makeNativeCryptoProvider } from ${JSON.stringify(join(SRC, '../Utils/native-crypto-provider.ts'))}
+		import { useMultiFileAuthState } from ${JSON.stringify(join(SRC, '../Utils/use-multi-file-auth-state.ts'))}
+		import { makeHttpClient, makeTransport } from ${JSON.stringify(join(SRC, '../Socket/transport.ts'))}
+		import { DEFAULT_CONNECTION_CONFIG } from ${JSON.stringify(join(SRC, '../Defaults/index.ts'))}
+		import P from 'pino'
+
+		const logger = P({ level: 'silent' })
+		initWasmEngine(logger, makeNativeCryptoProvider())
+		const { state } = await useMultiFileAuthState(${JSON.stringify(folder)})
+		const cfg = { ...DEFAULT_CONNECTION_CONFIG, logger, waWebSocketUrl: 'ws://127.0.0.1:1' }
+		const c = await createWhatsAppClient(
+			makeTransport(cfg), makeHttpClient(cfg), undefined, state.store, null, undefined, null
+		)
+
+		const report = outcome => console.log('PROBE ' + JSON.stringify(outcome))
+		const probe = async (label, run) => {
+			// A call that never settles is the failure being tested for, so it
+			// has to be reported rather than waited on.
+			let timer
+			const pending = new Promise(resolve => {
+				timer = setTimeout(() => resolve({ label, settled: 'pending' }), 8000)
+			})
+			const settled = run().then(
+				() => ({ label, settled: 'resolved' }),
+				e => ({ label, settled: 'rejected', kind: e?.kind, field: e?.field })
+			)
+			report(await Promise.race([settled, pending]))
+			clearTimeout(timer)
+		}
+
+		${PROBES.map(({ label, call }) => `await probe(${JSON.stringify(label)}, () => ${call})`).join('\n\t\t')}
+
+		await c.disconnect()
+		c.free()
+		process.exit(0)
+	`
+	return new Promise<{ code: number | null; outcomes: ProbeOutcome[]; stderr: string }>(resolve => {
+		const child = spawn(process.execPath, ['--input-type=module', '--eval', script], {
+			stdio: ['ignore', 'pipe', 'pipe']
+		})
+		let stdout = ''
+		let stderr = ''
+		child.stdout.on('data', chunk => (stdout += String(chunk)))
+		child.stderr.on('data', chunk => (stderr += String(chunk)))
+
+		const timer = setTimeout(() => child.kill('SIGKILL'), 60_000)
+		// `close`, not `exit`: the parent has to have drained the pipes before
+		// the reports can be parsed.
+		child.on('close', code => {
+			clearTimeout(timer)
+			const outcomes = stdout
+				.split('\n')
+				.filter(line => line.startsWith('PROBE '))
+				.map(line => JSON.parse(line.slice('PROBE '.length)) as ProbeOutcome)
+			resolve({ code, outcomes, stderr })
+		})
+	})
+}
+
+describe('bridge: a bad argument rejects instead of escaping the caller', { timeout: 120_000 }, () => {
+	let folder: string
+	let run: Awaited<ReturnType<typeof runProbes>>
+
+	before(async () => {
+		folder = await mkdtemp(join(tmpdir(), 'baileyrs-argreject-'))
+		run = await runProbes(folder)
+	})
+
+	after(async () => {
+		await rm(folder, { recursive: true, force: true })
+	})
+
+	it('every probe settles, and the process survives all of them', () => {
+		// On 0.6.5 the first probe alone ended the child, so nothing after it
+		// was ever reported.
+		expect(run.outcomes.map(outcome => outcome.label)).toEqual(PROBES.map(probe => probe.label))
+		expect(run.code).toBe(0)
+	})
+
+	for (const [index, { label, field, why }] of PROBES.entries()) {
+		it(`${label} (${why}) rejects naming '${field}'`, () => {
+			const outcome = run.outcomes[index]
+
+			expect(outcome?.settled).toBe('rejected')
+			// Naming the parameter is the point: `internal` would leave a
+			// consumer unable to tell its own bad argument from a bridge fault.
+			expect(outcome?.kind).toBe('invalid-argument')
+			expect(outcome?.field).toBe(field)
+		})
+	}
+})

--- a/src/__tests__/bridge-argument-rejection.test.ts
+++ b/src/__tests__/bridge-argument-rejection.test.ts
@@ -8,11 +8,12 @@
  * rejects with `invalid-argument` naming the parameter, and it does the same
  * for a stream parameter that cannot do what a stream does.
  *
- * Every method here is reachable from this package's public surface:
- * `readMessages` and `muteChat` are socket methods, `encryptMediaStream` is
- * handed to consumers through `MediaGenerationOptions.processMedia`. None of
- * them is called with a bad argument by our own code, so what this pins is the
- * contract a consumer gets, not a path we take.
+ * What this pins is the bridge boundary itself, driven directly, not the socket
+ * methods layered over it. The distinction is real: `sock.readMessages` runs its
+ * input through `receiptMessageKeys` first, which drops anything without a
+ * `remoteJid` and an `id`, so this exact bad value resolves there without ever
+ * reaching the bridge. The boundary is still a consumer-facing contract, since
+ * `MediaGenerationOptions.processMedia` hands the raw client over.
  *
  * The probes run in a child process because the old failure mode is fatal: only
  * a separate process can tell "the call rejected" from "the call took the test
@@ -93,7 +94,11 @@ const runProbes = (folder: string) => {
 			makeTransport(cfg), makeHttpClient(cfg), undefined, state.store, null, undefined, null
 		)
 
-		const report = outcome => console.log('PROBE ' + JSON.stringify(outcome))
+		// Awaits the write callback rather than using console.log: stdout is a
+		// pipe here, so process.exit() below would drop whatever is still
+		// buffered and the parent would read a truncated run as a regression.
+		const report = outcome =>
+			new Promise(done => process.stdout.write('PROBE ' + JSON.stringify(outcome) + '\\n', done))
 		const probe = async (label, run) => {
 			// A call that never settles is the failure being tested for, so it
 			// has to be reported rather than waited on.
@@ -109,7 +114,7 @@ const runProbes = (folder: string) => {
 				pending
 			])
 			clearTimeout(timer)
-			report(outcome)
+			await report(outcome)
 			// The call is still in flight, so continuing would reach free()
 			// with a pending call: the heap corruption bridge-free-safety
 			// documents, whose crash would then be reported instead of this.

--- a/src/__tests__/bridge-free-safety.test.ts
+++ b/src/__tests__/bridge-free-safety.test.ts
@@ -10,8 +10,9 @@
  * Which memory check trips first is a property of the build, not of the hazard:
  * bridge 0.6.5 hit dlmalloc's own consistency assertion, 0.7.0 faults on an
  * out-of-bounds access before dlmalloc gets to look. So the assertion below
- * accepts either, and pins instead what does not vary: the fault comes from
- * inside wasm, and the process does not survive it.
+ * accepts any signature a build has actually produced, and pins instead what
+ * does not vary: the fault comes from inside wasm, and the process does not
+ * survive it.
  *
  * `await client.disconnect()` first drains those calls in order and makes the
  * `free()` safe. That is why `end()` awaits it before freeing
@@ -25,6 +26,7 @@
  * process because heap corruption takes the whole process with it.
  */
 
+import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -106,13 +108,13 @@ describe('bridge: free() safety with a call in flight', { timeout: 90_000 }, () 
 	})
 
 	it('free() with a pending call corrupts the heap and kills the process', async () => {
-		// Every way the corruption has been observed to announce itself. Kept as
-		// a list rather than widened to "the child died": a rejection, a JS
-		// TypeError or an OOM would all mean the hazard moved.
+		// Every way the corruption has been observed to announce itself, each
+		// tied to the build that produced it. Kept as a list rather than widened
+		// to "the child died": a rejection, a JS TypeError or an OOM would all
+		// mean the hazard moved. Add a signature only once a build emits it.
 		const WASM_MEMORY_FAULTS = [
 			'psize <= size + max_overhead', // dlmalloc's own check (bridge 0.6.5)
-			'memory access out of bounds', // the fault that beats it (bridge 0.7.0)
-			'unreachable'
+			'memory access out of bounds' // the fault that beats it (bridge 0.7.0)
 		]
 
 		// Documents the hazard rather than endorsing it. If a future bridge
@@ -134,7 +136,10 @@ describe('bridge: free() safety with a call in flight', { timeout: 90_000 }, () 
 		expect(outcome.code === 0).toBe(false)
 		// …and died the documented way. Any other crash means the hazard moved
 		// and this suite is no longer describing it.
-		expect(WASM_MEMORY_FAULTS.some(fault => outcome.stderr.includes(fault))).toBe(true)
+		assert.ok(
+			WASM_MEMORY_FAULTS.some(fault => outcome.stderr.includes(fault)),
+			`no known wasm memory fault in stderr:\n${outcome.stderr}`
+		)
 		// The fault has to come from wasm. A crash raised in JS would satisfy
 		// the strings above by accident and describe something else entirely.
 		expect(outcome.stderr).toContain('wasm://wasm/')

--- a/src/__tests__/bridge-free-safety.test.ts
+++ b/src/__tests__/bridge-free-safety.test.ts
@@ -2,12 +2,16 @@
  * Pins the bridge invariant that `sock.end()` depends on.
  *
  * Calling `WasmWhatsAppClient.free()` while any bridge call is still in flight
- * corrupts the wasm heap: dlmalloc trips
- * `assertion failed: psize <= size + max_overhead` and the process dies on
- * `RuntimeError: unreachable`, thrown from a microtask no `try/catch` around
- * `free()` can reach — `free()` itself returns normally. It is not specific to
- * one method; `logout()`, `disconnect()` and a plain `fetchBlocklist()` all
- * reproduce it.
+ * corrupts the wasm heap, and the process dies from inside wasm, in a microtask
+ * no `try/catch` around `free()` can reach. `free()` itself returns normally.
+ * It is not specific to one method; `logout()`, `disconnect()` and a plain
+ * `fetchBlocklist()` all reproduce it.
+ *
+ * Which memory check trips first is a property of the build, not of the hazard:
+ * bridge 0.6.5 hit dlmalloc's own consistency assertion, 0.7.0 faults on an
+ * out-of-bounds access before dlmalloc gets to look. So the assertion below
+ * accepts either, and pins instead what does not vary: the fault comes from
+ * inside wasm, and the process does not survive it.
  *
  * `await client.disconnect()` first drains those calls in order and makes the
  * `free()` safe. That is why `end()` awaits it before freeing
@@ -102,6 +106,15 @@ describe('bridge: free() safety with a call in flight', { timeout: 90_000 }, () 
 	})
 
 	it('free() with a pending call corrupts the heap and kills the process', async () => {
+		// Every way the corruption has been observed to announce itself. Kept as
+		// a list rather than widened to "the child died": a rejection, a JS
+		// TypeError or an OOM would all mean the hazard moved.
+		const WASM_MEMORY_FAULTS = [
+			'psize <= size + max_overhead', // dlmalloc's own check (bridge 0.6.5)
+			'memory access out of bounds', // the fault that beats it (bridge 0.7.0)
+			'unreachable'
+		]
+
 		// Documents the hazard rather than endorsing it. If a future bridge
 		// makes `free()` safe on its own, this test starts failing — which is
 		// the signal to drop the `disconnect()` from `end()`, not to relax the
@@ -121,7 +134,10 @@ describe('bridge: free() safety with a call in flight', { timeout: 90_000 }, () 
 		expect(outcome.code === 0).toBe(false)
 		// …and died the documented way. Any other crash means the hazard moved
 		// and this suite is no longer describing it.
-		expect(outcome.stderr).toContain('psize <= size + max_overhead')
+		expect(WASM_MEMORY_FAULTS.some(fault => outcome.stderr.includes(fault))).toBe(true)
+		// The fault has to come from wasm. A crash raised in JS would satisfy
+		// the strings above by accident and describe something else entirely.
+		expect(outcome.stderr).toContain('wasm://wasm/')
 	})
 
 	it('await disconnect() before free() survives the same pending call', async () => {


### PR DESCRIPTION
## Summary

`@oxidezap/whatsapp-rust-bridge` 0.6.5 to 0.7.0.

Nothing new is exposed. 0.7.0 adds roughly fifty operations (newsletter, labels, quick replies, business catalog, server queries, privacy and tokens); none of them is wired up here. This PR is only the bump plus the four runtime behavior changes that came with it.

Observable for a consumer of this package:

- A mistyped argument to a bridge-backed socket method now rejects with `invalid-argument` naming the parameter, where it used to leave the promise pending forever and end the Node process with an uncaught exception.
- An app-state mutation rejected for the caller's own input (mute, pin, archive, star, contact names) now reports `invalid-argument` instead of `internal`.
- `logged_out.reason` is now a written-down string rather than a `Debug` rendering. The values did not change, so no consumer comparison breaks.
- `encryptMediaStream` rejects a non-stream instead of accepting it and failing much deeper.

Type surface: I diffed the emitted `.d.ts` between the two versions with comments stripped. There is no removal, no signature change and no shape change to any exported type. The only deletions are wasm-bindgen glue symbols in `InitOutput`. `npm run lint` (which runs `tsc`) passed on the first try across the roughly 60 import sites, and the `WhatsAppEvent` union is byte-identical, so `Bridge/__tests__/dts-drift.test.ts` needed nothing.

## Behavior changes absorbed

### Public strings no longer come from `Debug` (bridge #28)

`logged_out.reason`, newsletter `verification`/`state`, and newsletter follower `role` used to cross as `format!("{:?}", ...)`. `Debug` is not a stable API, so a variant renamed in the core would have silently changed a string consumers compare, with nothing failing to build on either side.

The important detail, and the one the pre-research guessed the other way: **this is a change of source, not of value.** The mappings emit exactly what `Debug` emitted (`"LoggedOut"`, `"TempBanned"`, `"Verified"`, `"Active"`, `"Owner"`, and `Unknown(499)`-style values for the core's own fallback). Nothing arriving here changed.

What this repository does with it: `evt.reason` is consumed in one place, `src/Socket/events.ts:392`, where it is interpolated into the close message. It decides nothing; the status code is always `DisconnectReason.loggedOut`. `connect_failure.reason` is a separate field and a `number`, so `isReconnectableConnectFailure` is untouched.

Because the string is now a contract rather than an accident, `src/__tests__/auto-reconnect-terminal-close.test.ts` pins all fifteen spellings against the close message a consumer sees, plus the no-reason case. The events are synthetic, so to be precise about what that buys: it pins our half of the contract, that the dispatcher passes the reason through untouched, that the message is exactly the literal `Logged out: ` followed by the reason, and that the status code stays `loggedOut` whatever the reason says. A change on the bridge side of the line is caught by the bridge's own tests, which assert those spellings literally. This test therefore passes on 0.6.5 too, since the values are the same on both.

### A mistyped parameter rejects instead of escaping the caller (bridge #25)

Twenty-four typed parameters were deserialized by tsify's own `FromWasmAbi`, inside the async shim, where a throw escapes as an uncaught exception. The result was the worst of both: the promise never settled, and the process died. 0.7.0 takes them as `JsValue` and deserializes explicitly, rejecting with `invalid-argument` and the parameter name.

The accepted set of values is unchanged (same serde deserialization, different call site), so no valid call started failing.

Our own call sites are type-correct and I checked each one that touches an affected parameter: `readMessages`/`markPlayed` go through `receiptMessageKeys`, which already projects to the exact `{remoteJid, id, participant?}` shape and drops keys missing either required field; `addLidPnMappings` filters before calling; `muteChat`, `sendPresence`, `sendChatState`, the group and block actions, and the media-type parameters are all pass-throughs of typed values. Nothing here needed changing.

`src/__tests__/bridge-argument-rejection.test.ts` covers the new contract: four probes against a real offline bridge client, in a child process so a rejection can be told apart from a call that ends the runner. All of them fail on 0.6.5 and pass on 0.7.0.

They drive the bridge boundary directly rather than the socket methods layered over it, which matters for reading them honestly: `sock.readMessages` filters its input through `receiptMessageKeys` first, so that particular bad value resolves there without ever reaching the bridge. The boundary is still consumer-facing, since `MediaGenerationOptions.processMedia` hands the raw client over.

### A bad argument reports `invalid-argument`, not `internal` (bridge #29)

Six rejections that were about the caller's input said `internal`. The broad one is `AppStateError::InvalidRequest`, which covers every app-state mutation: mute, pin, archive, star, labels, contact names.

Nothing in `src/` branches on a bridge error `kind`; I grepped for `kind`, `serverCode` and code comparisons, including the tests. `src/Utils/generics.ts`'s `getCodeFromWSError` reads transport errors, not bridge errors. So the impact here is entirely in what an end user sees, and no code changed.

Two narrower cases in the same PR do change what a call does. `muteChat` now range-checks its timestamp before the `as i64` cast, so `Infinity` rejects with `invalid-argument` on `muteUntil` instead of saturating to `i64::MAX` and passing every check downstream. That one is covered in the rejection test above.

### `encryptMediaStream` rejects a non-stream (bridge #30)

`input` and `output` were imported class types, which wasm-bindgen casts unchecked, so a plain object was accepted at the boundary and blew up deep inside the stream machinery as another uncaught exception with the call pending forever. 0.7.0 probes each one by calling `getReader()`/`getWriter()` and releasing the lock, and rejects naming the parameter.

This repository never calls `encryptMediaStream` itself. It reaches consumers through `MediaGenerationOptions.processMedia`, which is handed `waClient` typed as a `Pick` of `WasmWhatsAppClient` over `uploadMedia`, `encryptMediaStream` and `uploadEncryptedMediaStream` (`src/Types/Message.ts:359`). The rejection test covers the parameter contract; the happy path with real web streams lives in `src/__tests__/e2e/send-receive-message.test-e2e.ts`, which I could not run locally but which CI ran green on this branch.

Note for anyone passing streams through `processMedia`: the probe consumes and releases a reader/writer, so an already-locked stream is now rejected rather than accepted.

## Bugs this surfaced

One test failure, and it was not a bug in this repository.

`src/__tests__/bridge-free-safety.test.ts` asserted that `free()` with a call in flight dies with dlmalloc's `assertion failed: psize <= size + max_overhead`. On 0.7.0 it dies with `RuntimeError: memory access out of bounds` instead.

I checked before touching it. The assertion string is still compiled into both wasm builds, and both crashes are deterministic across repeated runs (5/5 each). The hazard is unchanged: `free()` with a pending call still corrupts the heap, still ends the process, and awaiting `disconnect()` first still makes it safe, which the suite's other two cases confirm on both versions. What changed is which memory check trips first, a property of the larger 0.7.0 heap layout, not of the invariant `end()` depends on.

So the test was pinning a build detail. It now accepts either fault and additionally requires the stack to come from inside wasm, which the old assertion did not check. That second condition is new coverage, not slack: a crash raised in JS would previously not have been distinguished.

No assertion was loosened elsewhere, no timeout raised, nothing skipped. The other 645 tests passed unchanged.

## Reviewed and no change needed

- **`src/Types/Newsletter.ts` unions.** The pre-research suspected `verification?: 'VERIFIED' | 'UNVERIFIED'` and `mute_state?: 'ON' | 'OFF'` never matched what the bridge sends, and that 0.7.0 might fix a latent bug. Neither is the case. `NewsletterMetadata` in that file is a mirror of upstream Baileys' type, kept for API compatibility, and is not what `sock.newsletterMetadata()` returns: that returns the bridge's `NewsletterMetadataResult`, where `verification` and `state` are plain `string`. Nothing in `src/` compares them to those literals. The unions are correct as upstream mirrors and wrong to "fix" here; the real gap is that `newsletterMetadata()` does not project onto them, which belongs to the newsletter domain, not to a version bump.
- **`connect_failure.reason`.** A `number` (`ConnectFailureReason` wire code), untouched by #28. `isReconnectableConnectFailure` and `mapConnectFailureToDisconnect` in `src/Socket/events.ts` keep working on the same values.
- **Error-code handling.** No path in `src/` reads a bridge error's `kind`, so #29 cannot change control flow here. The one test that asserts on a bridge error (`src/__tests__/group-operations-compatibility.test.ts`) checks `serverCode`, which #29 does not touch.
- **`getMediaConn` doc drift.** The 0.6.5 doc comment claimed `hosts` carried `maxContentLengthBytes`; 0.7.0 corrected the comment. `MediaHost` itself is `{ hostname: string }` in both, so nothing here was relying on a field that was never there.
- **Module split (bridge #26).** `wasm_client.rs` was split per domain. Every type still resolves from the same import path: `dist/whatsapp_rust_bridge.d.ts` is the only declaration file that changed at all, and the comment-stripped diff shows no declaration moved, was removed, or changed shape.
- **`src/Socket/index.ts` logout path.** Builds its own `'Logged out'` Boom independently of `evt.reason`, so the dispatcher's message and this one stay separate as before.

## Coverage

`npm run compat:audit` before: **97.15% (21717/22354)**
`npm run compat:audit` after: **97.15% (21717/22354)**

Identical across all four categories (exports 85.31%, functions 96.04%, fields 98.00%, events 100.00%). It should be: the audit measures this package's public surface against upstream Baileys, and this PR adds no public method. A move here would have meant a new surface slipped in.

## Follow-ups

Deliberately unused, one domain per PR:

- **Newsletter** (`compat-newsletter.md`): the remaining newsletter operations from bridge #23, plus projecting `newsletterMetadata()` onto the upstream `NewsletterMetadata` shape noted above.
- **Labels, contacts, quick replies** (`compat-labels-contacts-quickreply.md`): `addChatLabel`, `addMessageLabel` and the rest of bridge #21's app-state label actions. The new `QuickReplyUpdate` type arrived with them but no matching `WhatsAppEvent` variant, worth checking how it is delivered before building on it.
- **Business catalog** (`compat-business-catalog.md`): bridge #24, including `getOrder` and the new `ProductAvailability` type.
- **Server queries** (`compat-server-queries.md`): bridge #20's lifecycle and server-side operations, e.g. `cleanDirtyBits`.
- **Privacy and tokens** (`compat-privacy-and-tokens.md`) and **socket internals** (`compat-socket-internals.md`).

Also worth knowing when those land: `assertSessions`' `force` and `getUSyncDevices`' `useCache`/`ignoreZeroDevices` are documented in 0.7.0 as having no effect. The parameters existed before; only the documentation is new.

## Release type

The bump is committed as `fix(deps)`, not `chore(deps)`, and the PR title matches. `.github/workflows/release.yml` records the reason: only feat/fix/perf produce a release, and a chore-typed bridge bump would leave the upgrade sitting on main until an unrelated commit dragged it out.

## Validation

Run locally and green:

- `npm run format`
- `npm run lint` (`tsc` plus `oxlint`)
- `npm test`: 666 tests across 167 suites, 0 failures. 645 across 165 before this PR, so 21 added and none removed.
- `npm run compat:audit`

`npm run test:e2e` could not run locally, since it needs a mock server this environment does not have. CI does have it, and the E2E workflow passed on this branch, which is what covers the `encryptMediaStream` happy path with real `ReadableStream`/`WritableStream` values. All four workflows (Build, Run Tests, Linting, E2E) are green.

Cross-version checks done by hand, against real bridge builds:

- The four rejection probes: 5 failures on 0.6.5, 5 passes on 0.7.0.
- The free-safety crash signature: 3 runs on 0.6.5 all dlmalloc, 5 runs on 0.7.0 all out-of-bounds, and the reworked test passes on both.