### PR TITLE
feat(privacy): add call and message privacy controls

### DIFF
--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -27,11 +27,7 @@ import type {
 	ReachoutTimelockState,
 	SignalKeyStoreWithTransaction,
 	UserFacingSocketConfig,
-	WAPrivacyGroupAddValue,
-	WAPrivacyOnlineValue,
-	WAPrivacyValue,
 	WABusinessProfile,
-	WAReadReceiptsValue,
 	WAMessage,
 	WAMessageKey
 } from '../Types/index.ts'
@@ -57,6 +53,7 @@ import { makeMessageMethods } from './messages.ts'
 import { makeNewsletterMethods } from './newsletter.ts'
 import { makePreKeyMethods } from './prekeys.ts'
 import { makePresenceMethods } from './presence.ts'
+import { makePrivacyMethods } from './privacy.ts'
 import { makeProfileMethods } from './profile.ts'
 import { mapReachoutTimelock } from './reachout.ts'
 import { makeHttpClient, makeTransport } from './transport.ts'
@@ -902,31 +899,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			const bytes = data instanceof Uint8Array && !Buffer.isBuffer(data) ? data : new Uint8Array(data)
 			return (await ctx.getClient()).uploadMedia(bytes, toBridgeMediaType(opts.mediaType))
 		},
-		fetchPrivacySettings: async (force?: boolean) => {
-			void force
-			return (await ctx.getClient()).fetchPrivacySettings()
-		},
-		updatePrivacySetting: async (category: string, value: string) => {
-			await (await ctx.getClient()).updatePrivacySetting(category, value)
-		},
-		updateLastSeenPrivacy: async (value: WAPrivacyValue) => {
-			await (await ctx.getClient()).updatePrivacySetting('last', value)
-		},
-		updateOnlinePrivacy: async (value: WAPrivacyOnlineValue) => {
-			await (await ctx.getClient()).updatePrivacySetting('online', value)
-		},
-		updateProfilePicturePrivacy: async (value: WAPrivacyValue) => {
-			await (await ctx.getClient()).updatePrivacySetting('profile', value)
-		},
-		updateStatusPrivacy: async (value: WAPrivacyValue) => {
-			await (await ctx.getClient()).updatePrivacySetting('status', value)
-		},
-		updateReadReceiptsPrivacy: async (value: WAReadReceiptsValue) => {
-			await (await ctx.getClient()).updatePrivacySetting('readreceipts', value)
-		},
-		updateGroupsAddPrivacy: async (value: WAPrivacyGroupAddValue) => {
-			await (await ctx.getClient()).updatePrivacySetting('groupadd', value)
-		},
+		...makePrivacyMethods(ctx),
 		updateDefaultDisappearingMode: async (duration: number) => {
 			await (await ctx.getClient()).updateDefaultDisappearingMode(duration)
 		},

--- a/src/Socket/privacy.ts
+++ b/src/Socket/privacy.ts
@@ -6,61 +6,71 @@ import type {
 	WAPrivacyValue,
 	WAReadReceiptsValue
 } from '../Types/index.ts'
-import { Boom } from '../Utils/boom.ts'
 import type { SocketContext } from './types.ts'
 
-export const makePrivacyMethods = (ctx: SocketContext) => ({
-	fetchPrivacySettings: async (force?: boolean) => {
-		void force
-		return (await ctx.getClient()).fetchPrivacySettings()
-	},
+export const makePrivacyMethods = (ctx: SocketContext) => {
+	/** Per socket, so a send loop calling this does not flood the log. */
+	let warnedAboutPrivacyTokens = false
 
-	updatePrivacySetting: async (category: string, value: string) => {
-		await (await ctx.getClient()).updatePrivacySetting(category, value)
-	},
+	return {
+		fetchPrivacySettings: async (force?: boolean) => {
+			void force
+			return (await ctx.getClient()).fetchPrivacySettings()
+		},
 
-	updateLastSeenPrivacy: async (value: WAPrivacyValue) => {
-		await (await ctx.getClient()).updatePrivacySetting('last', value)
-	},
+		updatePrivacySetting: async (category: string, value: string) => {
+			await (await ctx.getClient()).updatePrivacySetting(category, value)
+		},
 
-	updateOnlinePrivacy: async (value: WAPrivacyOnlineValue) => {
-		await (await ctx.getClient()).updatePrivacySetting('online', value)
-	},
+		updateLastSeenPrivacy: async (value: WAPrivacyValue) => {
+			await (await ctx.getClient()).updatePrivacySetting('last', value)
+		},
 
-	updateProfilePicturePrivacy: async (value: WAPrivacyValue) => {
-		await (await ctx.getClient()).updatePrivacySetting('profile', value)
-	},
+		updateOnlinePrivacy: async (value: WAPrivacyOnlineValue) => {
+			await (await ctx.getClient()).updatePrivacySetting('online', value)
+		},
 
-	updateStatusPrivacy: async (value: WAPrivacyValue) => {
-		await (await ctx.getClient()).updatePrivacySetting('status', value)
-	},
+		updateProfilePicturePrivacy: async (value: WAPrivacyValue) => {
+			await (await ctx.getClient()).updatePrivacySetting('profile', value)
+		},
 
-	updateReadReceiptsPrivacy: async (value: WAReadReceiptsValue) => {
-		await (await ctx.getClient()).updatePrivacySetting('readreceipts', value)
-	},
+		updateStatusPrivacy: async (value: WAPrivacyValue) => {
+			await (await ctx.getClient()).updatePrivacySetting('status', value)
+		},
 
-	updateGroupsAddPrivacy: async (value: WAPrivacyGroupAddValue) => {
-		await (await ctx.getClient()).updatePrivacySetting('groupadd', value)
-	},
+		updateReadReceiptsPrivacy: async (value: WAReadReceiptsValue) => {
+			await (await ctx.getClient()).updatePrivacySetting('readreceipts', value)
+		},
 
-	updateCallPrivacy: async (value: WAPrivacyCallValue) => {
-		await (await ctx.getClient()).updatePrivacySetting('calladd', value)
-	},
+		updateGroupsAddPrivacy: async (value: WAPrivacyGroupAddValue) => {
+			await (await ctx.getClient()).updatePrivacySetting('groupadd', value)
+		},
 
-	updateMessagesPrivacy: async (value: WAPrivacyMessagesValue) => {
-		await (await ctx.getClient()).updatePrivacySetting('messages', value)
-	},
+		updateCallPrivacy: async (value: WAPrivacyCallValue) => {
+			await (await ctx.getClient()).updatePrivacySetting('calladd', value)
+		},
 
-	/**
-	 * Declared to reject rather than to run: the core issues these tokens on
-	 * every 1:1 send, rate limited by a sender bucket. A manual call would
-	 * issue a second token outside that bucket and move the timestamp the
-	 * limiter reads.
-	 */
-	issuePrivacyTokens: async (_jids: string[], _timestamp?: number): Promise<never> => {
-		throw new Boom(
-			'issuePrivacyTokens is not supported: the engine issues privacy tokens automatically on every 1:1 send, and a manual call would bypass its rate limiter. Remove the call.',
-			{ statusCode: 501 }
-		)
+		updateMessagesPrivacy: async (value: WAPrivacyMessagesValue) => {
+			await (await ctx.getClient()).updatePrivacySetting('messages', value)
+		},
+
+		/**
+		 * Resolves without issuing anything. The engine already issues these
+		 * tokens on every 1:1 send, rate limited by a sender bucket, so the
+		 * caller's intent is met before they ask; a second manual issue would land
+		 * outside that bucket and move the timestamp the limiter reads.
+		 *
+		 * Warned once rather than thrown: upstream callers await this inside a send
+		 * workflow, and rejecting would abort a workflow that was going to succeed.
+		 */
+		issuePrivacyTokens: async (jids: string[], _timestamp?: number): Promise<void> => {
+			if (!warnedAboutPrivacyTokens) {
+				warnedAboutPrivacyTokens = true
+				ctx.logger.warn(
+					{ count: jids.length },
+					'issuePrivacyTokens is a no-op: the engine issues privacy tokens on every 1:1 send, so this call can be removed'
+				)
+			}
+		}
 	}
-})
+}

--- a/src/Socket/privacy.ts
+++ b/src/Socket/privacy.ts
@@ -1,9 +1,12 @@
 import type {
+	WAPrivacyCallValue,
 	WAPrivacyGroupAddValue,
+	WAPrivacyMessagesValue,
 	WAPrivacyOnlineValue,
 	WAPrivacyValue,
 	WAReadReceiptsValue
 } from '../Types/index.ts'
+import { Boom } from '../Utils/boom.ts'
 import type { SocketContext } from './types.ts'
 
 export const makePrivacyMethods = (ctx: SocketContext) => ({
@@ -38,5 +41,26 @@ export const makePrivacyMethods = (ctx: SocketContext) => ({
 
 	updateGroupsAddPrivacy: async (value: WAPrivacyGroupAddValue) => {
 		await (await ctx.getClient()).updatePrivacySetting('groupadd', value)
+	},
+
+	updateCallPrivacy: async (value: WAPrivacyCallValue) => {
+		await (await ctx.getClient()).updatePrivacySetting('calladd', value)
+	},
+
+	updateMessagesPrivacy: async (value: WAPrivacyMessagesValue) => {
+		await (await ctx.getClient()).updatePrivacySetting('messages', value)
+	},
+
+	/**
+	 * Declared to reject rather than to run: the core issues these tokens on
+	 * every 1:1 send, rate limited by a sender bucket. A manual call would
+	 * issue a second token outside that bucket and move the timestamp the
+	 * limiter reads.
+	 */
+	issuePrivacyTokens: async (_jids: string[], _timestamp?: number): Promise<never> => {
+		throw new Boom(
+			'issuePrivacyTokens is not supported: the engine issues privacy tokens automatically on every 1:1 send, and a manual call would bypass its rate limiter. Remove the call.',
+			{ statusCode: 501 }
+		)
 	}
 })

--- a/src/Socket/privacy.ts
+++ b/src/Socket/privacy.ts
@@ -1,0 +1,42 @@
+import type {
+	WAPrivacyGroupAddValue,
+	WAPrivacyOnlineValue,
+	WAPrivacyValue,
+	WAReadReceiptsValue
+} from '../Types/index.ts'
+import type { SocketContext } from './types.ts'
+
+export const makePrivacyMethods = (ctx: SocketContext) => ({
+	fetchPrivacySettings: async (force?: boolean) => {
+		void force
+		return (await ctx.getClient()).fetchPrivacySettings()
+	},
+
+	updatePrivacySetting: async (category: string, value: string) => {
+		await (await ctx.getClient()).updatePrivacySetting(category, value)
+	},
+
+	updateLastSeenPrivacy: async (value: WAPrivacyValue) => {
+		await (await ctx.getClient()).updatePrivacySetting('last', value)
+	},
+
+	updateOnlinePrivacy: async (value: WAPrivacyOnlineValue) => {
+		await (await ctx.getClient()).updatePrivacySetting('online', value)
+	},
+
+	updateProfilePicturePrivacy: async (value: WAPrivacyValue) => {
+		await (await ctx.getClient()).updatePrivacySetting('profile', value)
+	},
+
+	updateStatusPrivacy: async (value: WAPrivacyValue) => {
+		await (await ctx.getClient()).updatePrivacySetting('status', value)
+	},
+
+	updateReadReceiptsPrivacy: async (value: WAReadReceiptsValue) => {
+		await (await ctx.getClient()).updatePrivacySetting('readreceipts', value)
+	},
+
+	updateGroupsAddPrivacy: async (value: WAPrivacyGroupAddValue) => {
+		await (await ctx.getClient()).updatePrivacySetting('groupadd', value)
+	}
+})

--- a/src/__tests__/privacy-compatibility.test.ts
+++ b/src/__tests__/privacy-compatibility.test.ts
@@ -91,15 +91,35 @@ describe('privacy wrappers do not swallow a bridge failure', () => {
 	}
 })
 
-describe('issuePrivacyTokens refuses instead of issuing a second token', () => {
-	it('rejects, and the message says the engine already does it', async () => {
+/**
+ * The engine issues these on every 1:1 send, so the caller's intent is already
+ * met and the method has nothing to do. Resolving keeps an upstream send
+ * workflow that awaits it running; issuing anything would land outside the
+ * core's rate bucket and move the timestamp its limiter reads.
+ */
+describe('issuePrivacyTokens is a no-op that says so once', () => {
+	it('resolves without reaching the bridge', async () => {
 		const { calls, methods } = makeHarness()
 
-		await expect(methods.issuePrivacyTokens(['15550000000@s.whatsapp.net'])).rejects.toThrow(
-			/issues privacy tokens automatically/
-		)
-		// Nothing reached the bridge: a rejection that still sent something
-		// would be the regression this method exists to avoid.
+		await methods.issuePrivacyTokens(['15550000000@s.whatsapp.net'])
+
 		expect(calls).toEqual([])
+	})
+
+	it('warns the first time and stays quiet after, so a send loop does not flood', async () => {
+		const warnings: string[] = []
+		const ctx = {
+			ev: new EventEmitter(),
+			logger: { ...logger, warn: (_data: unknown, msg: string) => warnings.push(msg) },
+			getClient: async () => ({}) as never
+		} as unknown as SocketContext
+		const methods = makePrivacyMethods(ctx)
+
+		await methods.issuePrivacyTokens(['a@s.whatsapp.net'])
+		await methods.issuePrivacyTokens(['b@s.whatsapp.net'])
+		await methods.issuePrivacyTokens(['c@s.whatsapp.net'])
+
+		expect(warnings.length).toBe(1)
+		expect(warnings[0]).toContain('no-op')
 	})
 })

--- a/src/__tests__/privacy-compatibility.test.ts
+++ b/src/__tests__/privacy-compatibility.test.ts
@@ -1,0 +1,105 @@
+/**
+ * A privacy wrapper is one line, and the only thing that line can get wrong is
+ * the category string. Nothing downstream catches that: the bridge takes
+ * `category` as a plain `string`, and the core's wire enum has a fallback
+ * variant, so a typo travels all the way to the server and changes a different
+ * setting on the user's account than the one they asked for.
+ *
+ * So every wrapper is pinned to its category here, existing ones included.
+ */
+
+import { EventEmitter } from 'node:events'
+import { describe, it } from 'node:test'
+import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+
+import { makePrivacyMethods } from '../Socket/privacy.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import type { ILogger } from '../Utils/logger.ts'
+import { expect } from './expect.ts'
+
+const logger = {
+	level: 'silent',
+	child: () => logger,
+	trace: () => undefined,
+	debug: () => undefined,
+	info: () => undefined,
+	warn: () => undefined,
+	error: () => undefined
+} as ILogger
+
+const makeHarness = (overrides: Partial<WasmWhatsAppClient> = {}) => {
+	const calls: Array<[string, string]> = []
+	const client = {
+		updatePrivacySetting: async (category: string, value: string) => {
+			calls.push([category, value])
+		},
+		...overrides
+	} as unknown as WasmWhatsAppClient
+	const ctx = {
+		ev: new EventEmitter(),
+		logger,
+		getClient: async () => client
+	} as unknown as SocketContext
+	return { calls, methods: makePrivacyMethods(ctx) }
+}
+
+/** Every wrapper, with the wire category the core matches it to. */
+const CATEGORIES: Array<{ method: string; category: string; value: string }> = [
+	{ method: 'updateLastSeenPrivacy', category: 'last', value: 'contacts' },
+	{ method: 'updateOnlinePrivacy', category: 'online', value: 'match_last_seen' },
+	{ method: 'updateProfilePicturePrivacy', category: 'profile', value: 'contacts' },
+	{ method: 'updateStatusPrivacy', category: 'status', value: 'contacts' },
+	{ method: 'updateReadReceiptsPrivacy', category: 'readreceipts', value: 'all' },
+	{ method: 'updateGroupsAddPrivacy', category: 'groupadd', value: 'contacts' },
+	{ method: 'updateCallPrivacy', category: 'calladd', value: 'known' },
+	{ method: 'updateMessagesPrivacy', category: 'messages', value: 'contacts' }
+]
+
+describe('privacy wrappers send the category the core expects', () => {
+	for (const { method, category, value } of CATEGORIES) {
+		it(`${method} → '${category}'`, async () => {
+			const { calls, methods } = makeHarness()
+
+			await (methods as unknown as Record<string, (v: string) => Promise<void>>)[method]!(value)
+
+			expect(calls).toEqual([[category, value]])
+		})
+	}
+
+	it('the generic passes both arguments through untouched', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.updatePrivacySetting('defense', 'on_standard')
+
+		expect(calls).toEqual([['defense', 'on_standard']])
+	})
+})
+
+describe('privacy wrappers do not swallow a bridge failure', () => {
+	for (const method of ['updateCallPrivacy', 'updateMessagesPrivacy']) {
+		it(`${method} propagates the rejection`, async () => {
+			const { methods } = makeHarness({
+				updatePrivacySetting: async () => {
+					throw new Error('server error 403: forbidden')
+				}
+			} as Partial<WasmWhatsAppClient>)
+
+			await expect(
+				(methods as unknown as Record<string, (v: string) => Promise<void>>)[method]!('all')
+			).rejects.toThrow(/server error 403: forbidden/)
+		})
+	}
+})
+
+describe('issuePrivacyTokens refuses instead of issuing a second token', () => {
+	it('rejects, and the message says the engine already does it', async () => {
+		const { calls, methods } = makeHarness()
+
+		await expect(methods.issuePrivacyTokens(['15550000000@s.whatsapp.net'])).rejects.toThrow(
+			/issues privacy tokens automatically/
+		)
+		// Nothing reached the bridge: a rejection that still sent something
+		// would be the regression this method exists to avoid.
+		expect(calls).toEqual([])
+	})
+})


### PR DESCRIPTION
## Summary

Two methods, one line each. `updateCallPrivacy` sends category `calladd`, `updateMessagesPrivacy` sends `messages`, both through the generic privacy IQ this package already had. Nothing was needed in the core or the bridge.

A third method, `issuePrivacyTokens`, is declared as a no-op that warns once. Actually issuing a token would be a regression.

The privacy family moved out of the socket builder into `src/Socket/privacy.ts` first. That is not cosmetic: inline in `makeWASocket` is the one place in this package a method cannot be reached from a test, and the entire contract of these wrappers is which category string comes out the other side.

## Layer classification

| item | class | why |
|---|---|---|
| `updateCallPrivacy` | **(a)** | Core enumerates `PrivacyCategory::CallAdd` with wire value `calladd`; the bridge passes category and value straight through. |
| `updateMessagesPrivacy` | **(a)** | Same, `PrivacyCategory::Messages` with wire value `messages`. |
| `updateDisableLinkPreviewsPrivacy` | **(a), deferred** | Not a privacy IQ despite the name. It is an app-state mutation under index `['setting_disableLinkPreviews']`, and it lands in the silent `else` branch of `chatModify` today. It belongs to the labels task mechanically, and that is where I am doing it, so the two do not both touch that branch. |
| `issuePrivacyTokens` | **declared, no-op** | See below. |

Verified against `wacore/src/iq/privacy.rs` rather than assumed: `PrivacyCategory` carries `#[wire = "calladd"]` and `#[wire = "messages"]` alongside the six categories already wrapped here.

## Types

`WAPrivacyCallValue` and `WAPrivacyMessagesValue` already existed in `src/Types/Chat.ts`, and already match upstream's declarations character for character (`'all' | 'known'` and `'all' | 'contacts'`). No type work was needed.

One divergence worth recording, in the safe direction. The core documents `calladd` as accepting `all | known | contacts`, three values, while upstream's `WAPrivacyCallValue` has two. So our type is narrower than the server accepts. That costs a caller the ability to express `contacts` through the typed wrapper, and they can still reach it through `updatePrivacySetting('calladd', 'contacts')`. The failure mode this prompt warned about is the opposite one, a local type wider than the server accepts, which turns a compile error into a runtime error. That is not the case here.

## Deferred

**`updateDisableLinkPreviewsPrivacy`** goes to `fix/chat-modify-silent-noop`, for the reason in the table above. Recording the coordination explicitly so the two PRs do not collide on the same `chatModify` branch.

**`issuePrivacyTokens` does nothing, deliberately, and no gap prompt is being opened for it.** I checked the claim rather than taking it: `maybe_include_tc_token` is called from the send path (`src/send/mod.rs:2420`) on every 1:1 send, and `should_issue_tc_token` rate limits issuance through a sender bucket. The bridge exposes no token-issuing method, which is consistent with that being deliberate. A manual call would issue a second token outside the bucket and move the timestamp the limiter reads.

It first rejected, and a review pointed out that was wrong. The rule I was missing, which I will apply consistently across the rest of this series:

- **Throw when the caller's intent is not achieved.** A `chatModify({addChatLabel})` that resolves while nothing syncs is silent data loss and has to fail loudly. Making it do so is the point of the next PR.
- **Do nothing when the intent is already achieved by other means.** By the time a caller asks for privacy tokens, the engine has issued them. Rejecting aborts an upstream send workflow that awaits this mid-flight, breaking a call that was going to succeed, and buys nothing.

It warns once per socket rather than per call, so someone migrating from upstream finds out they can delete the call without a send loop flooding their log.

## Coverage

`npm run compat:audit` before: **97.15% (21717/22354)**
after: **97.22% (21732/22354)**

+15 matched declarations from three methods, because each one lands in several of the aggregate socket types the auditor walks.

One honest note on the shape of that delta. Missing dropped (functions 243 → 234, fields 235 → 226) while mismatches rose slightly. The new mismatches are not new incompatibilities: adding any method to the socket changes the giant inline return type of `makeWASocket`, and the auditor compares that as a string, so it re-reports it wherever it appears. The three methods themselves count as clean matches, which I confirmed by grepping the detailed report for them: zero hits under either `missing` or `mismatch`.

## Validation

- `npm run format`
- `npm run lint` (`tsc` plus `oxlint`)
- `npm test`: 679 tests, 0 failures, up from 666 with no existing test adapted
- `npm run compat:audit`

Not run: `npm run test:e2e`, which needs a mock server this environment does not have. Nothing in this PR is e2e-observable.

Each new assertion was mutation checked rather than assumed to bite: changing `calladd` to `call` fails the suite, and making `issuePrivacyTokens` stop warning fails it too. Both were verified by making the edit and running the tests, not by reading the assertion.