### PR TITLE
fix(chats): stop silently dropping unsupported chatModify variants

### DIFF
--- a/src/Socket/chat-actions.ts
+++ b/src/Socket/chat-actions.ts
@@ -96,7 +96,9 @@ export const makeChatActionMethods = (ctx: SocketContext) => {
 			} else if ('quickReply' in mod) {
 				// Upstream's `timestamp` is the app-state index key, the same slot
 				// the core calls `id`. Deleting is the same upsert with `deleted`.
-				const id = mod.quickReply.timestamp ?? String(Math.floor(Date.now() / 1000))
+				// `||`, not `??`: upstream treats an empty timestamp as absent and
+				// mints a key, and the core rejects an empty index outright.
+				const id = mod.quickReply.timestamp || String(Math.floor(Date.now() / 1000))
 				if (mod.quickReply.deleted) {
 					await client.deleteQuickReply(id)
 				} else {

--- a/src/Socket/chat-actions.ts
+++ b/src/Socket/chat-actions.ts
@@ -1,3 +1,6 @@
+import type { proto } from '../WAProto/runtime.ts'
+import type { QuickReplyAction } from '../Types/Bussines.ts'
+import type { LabelActionBody } from '../Types/Label.ts'
 import type { ChatModification, WAPatchName } from '../Types/index.ts'
 import { Boom } from '../Utils/boom.ts'
 import type { SocketContext } from './types.ts'
@@ -120,6 +123,51 @@ export const makeChatActionMethods = (ctx: SocketContext) => {
 		 */
 		resyncAppState: async (_collections?: readonly WAPatchName[], _isInitialSync?: boolean) => {
 			ctx.logger.info('resyncAppState: app state is synced automatically by the Rust bridge')
+		},
+
+		// Upstream models all of these as sugar over `chatModify`, and so do we:
+		// one place decides which bridge call a modification becomes, so the
+		// method and the modification can never disagree.
+
+		addOrEditContact: async (jid: string, contact: proto.SyncActionValue.IContactAction) => {
+			await methods.chatModify({ contact }, jid)
+		},
+
+		removeContact: async (jid: string) => {
+			await methods.chatModify({ contact: null }, jid)
+		},
+
+		addLabel: async (jid: string, labels: LabelActionBody) => {
+			await methods.chatModify({ addLabel: { ...labels } }, jid)
+		},
+
+		addChatLabel: async (jid: string, labelId: string) => {
+			await methods.chatModify({ addChatLabel: { labelId } }, jid)
+		},
+
+		removeChatLabel: async (jid: string, labelId: string) => {
+			await methods.chatModify({ removeChatLabel: { labelId } }, jid)
+		},
+
+		addMessageLabel: async (jid: string, messageId: string, labelId: string) => {
+			await methods.chatModify({ addMessageLabel: { labelId, messageId } }, jid)
+		},
+
+		removeMessageLabel: async (jid: string, messageId: string, labelId: string) => {
+			await methods.chatModify({ removeMessageLabel: { labelId, messageId } }, jid)
+		},
+
+		star: async (jid: string, messages: { id: string; fromMe?: boolean }[], star: boolean) => {
+			await methods.chatModify({ star: { messages, star } }, jid)
+		},
+
+		// No jid: a quick reply is account-wide, keyed only by its index.
+		addOrEditQuickReply: async (quickReply: QuickReplyAction) => {
+			await methods.chatModify({ quickReply }, '')
+		},
+
+		removeQuickReply: async (timestamp: string) => {
+			await methods.chatModify({ quickReply: { timestamp, deleted: true } }, '')
 		}
 	}
 	return methods

--- a/src/Socket/chat-actions.ts
+++ b/src/Socket/chat-actions.ts
@@ -5,6 +5,21 @@ import type { ChatModification, WAPatchName } from '../Types/index.ts'
 import { Boom } from '../Utils/boom.ts'
 import type { SocketContext } from './types.ts'
 
+/**
+ * Refuse a field the mutation carries but the wire call cannot. Dropping it
+ * would report success for a change that never happened, which is the failure
+ * this whole path exists to stop.
+ */
+const rejectUnsupportedFields = (where: string, value: object, fields: readonly string[]) => {
+	const present = fields.filter(field => (value as Record<string, unknown>)[field] != null)
+	if (present.length) {
+		throw new Boom(`${where}: ${present.join(', ')} cannot be set through this client`, {
+			statusCode: 400,
+			data: { fields: present }
+		})
+	}
+}
+
 export const makeChatActionMethods = (ctx: SocketContext) => {
 	const methods = {
 		pinChat: async (jid: string, pin: boolean) => {
@@ -55,6 +70,7 @@ export const makeChatActionMethods = (ctx: SocketContext) => {
 				// Save/rename a contact (syncs the name to linked devices). `jid` is the
 				// contact's bare PN jid.
 				if (mod.contact) {
+					rejectUnsupportedFields('chatModify contact', mod.contact, ['lidJid', 'pnJid', 'username'])
 					await client.saveContact(
 						jid,
 						mod.contact.fullName ?? undefined,
@@ -83,6 +99,7 @@ export const makeChatActionMethods = (ctx: SocketContext) => {
 				if (mod.addLabel.deleted) {
 					await client.deleteLabel(mod.addLabel.id)
 				} else {
+					rejectUnsupportedFields('chatModify addLabel', mod.addLabel, ['predefinedId'])
 					await client.createLabel(mod.addLabel.id, mod.addLabel.name ?? '', mod.addLabel.color ?? 0)
 				}
 			} else if ('addChatLabel' in mod) {

--- a/src/Socket/chat-actions.ts
+++ b/src/Socket/chat-actions.ts
@@ -100,7 +100,17 @@ export const makeChatActionMethods = (ctx: SocketContext) => {
 					await client.deleteLabel(mod.addLabel.id)
 				} else {
 					rejectUnsupportedFields('chatModify addLabel', mod.addLabel, ['predefinedId'])
-					await client.createLabel(mod.addLabel.id, mod.addLabel.name ?? '', mod.addLabel.color ?? 0)
+					// The mutation replaces the whole label, so a missing field is
+					// not "leave it alone", it is "set it to nothing". Upstream can
+					// omit one because it builds the proto directly; this call
+					// cannot, so both are required rather than defaulted.
+					if (mod.addLabel.name === undefined || mod.addLabel.color === undefined) {
+						throw new Boom(
+							'chatModify addLabel: name and color are both required, because the label mutation is a full replace and an omitted field would reset it',
+							{ statusCode: 400 }
+						)
+					}
+					await client.createLabel(mod.addLabel.id, mod.addLabel.name, mod.addLabel.color)
 				}
 			} else if ('addChatLabel' in mod) {
 				await client.addChatLabel(mod.addChatLabel.labelId, jid)

--- a/src/Socket/chat-actions.ts
+++ b/src/Socket/chat-actions.ts
@@ -1,93 +1,126 @@
 import type { ChatModification, WAPatchName } from '../Types/index.ts'
+import { Boom } from '../Utils/boom.ts'
 import type { SocketContext } from './types.ts'
 
-export const makeChatActionMethods = (ctx: SocketContext) => ({
-	pinChat: async (jid: string, pin: boolean) => {
-		await (await ctx.getClient()).pinChat(jid, pin)
-	},
+export const makeChatActionMethods = (ctx: SocketContext) => {
+	const methods = {
+		pinChat: async (jid: string, pin: boolean) => {
+			await (await ctx.getClient()).pinChat(jid, pin)
+		},
 
-	muteChat: async (jid: string, muteUntil?: number | null) => {
-		await (await ctx.getClient()).muteChat(jid, muteUntil)
-	},
+		muteChat: async (jid: string, muteUntil?: number | null) => {
+			await (await ctx.getClient()).muteChat(jid, muteUntil)
+		},
 
-	archiveChat: async (jid: string, archive: boolean) => {
-		await (await ctx.getClient()).archiveChat(jid, archive)
-	},
+		archiveChat: async (jid: string, archive: boolean) => {
+			await (await ctx.getClient()).archiveChat(jid, archive)
+		},
 
-	starMessage: async (jid: string, messageId: string, star: boolean) => {
-		await (await ctx.getClient()).starMessage(jid, messageId, star)
-	},
+		starMessage: async (jid: string, messageId: string, star: boolean) => {
+			await (await ctx.getClient()).starMessage(jid, messageId, star)
+		},
 
-	/**
-	 * Compatibility wrapper for original Baileys chatModify API.
-	 * Routes to the appropriate bridge method based on the modification type.
-	 *
-	 * Fully supported: archive, pin, mute, star, markRead, delete, deleteForMe, pushNameSetting, contact, clear
-	 * Not yet in bridge (app-state patches): disableLinkPreviews, labels, quickReply
-	 */
-	chatModify: async (mod: ChatModification, jid: string) => {
-		const client = await ctx.getClient()
-		if ('archive' in mod) {
-			await client.archiveChat(jid, mod.archive)
-		} else if ('pin' in mod) {
-			await client.pinChat(jid, mod.pin)
-		} else if ('mute' in mod) {
-			await client.muteChat(jid, mod.mute)
-		} else if ('star' in mod) {
-			for (const msg of mod.star.messages) {
-				await client.starMessage(jid, msg.id, mod.star.star)
-			}
-		} else if ('markRead' in mod) {
-			await client.markChatAsRead(jid, mod.markRead)
-		} else if ('delete' in mod) {
-			await client.deleteChat(jid)
-		} else if ('deleteForMe' in mod) {
-			await client.deleteMessageForMe(jid, mod.deleteForMe.key.id!, !!mod.deleteForMe.key.fromMe)
-		} else if ('pushNameSetting' in mod) {
-			await client.setPushName(mod.pushNameSetting)
-		} else if ('contact' in mod) {
-			// Save/rename a contact (syncs the name to linked devices). `jid` is the
-			// contact's bare PN jid.
-			if (mod.contact) {
-				await client.saveContact(
-					jid,
-					mod.contact.fullName ?? undefined,
-					mod.contact.firstName ?? undefined,
-					mod.contact.saveOnPrimaryAddressbook ?? true
-				)
+		/**
+		 * Compatibility wrapper for original Baileys chatModify API.
+		 * Routes to the appropriate bridge method based on the modification type.
+		 *
+		 * Every variant either runs or throws. A variant that resolved without
+		 * doing anything told the caller their chat was labelled when nothing was
+		 * synced, and no signature or type catches that.
+		 */
+		chatModify: async (mod: ChatModification, jid: string) => {
+			const client = await ctx.getClient()
+			if ('archive' in mod) {
+				await client.archiveChat(jid, mod.archive)
+			} else if ('pin' in mod) {
+				await client.pinChat(jid, mod.pin)
+			} else if ('mute' in mod) {
+				await client.muteChat(jid, mod.mute)
+			} else if ('star' in mod) {
+				for (const msg of mod.star.messages) {
+					await client.starMessage(jid, msg.id, mod.star.star)
+				}
+			} else if ('markRead' in mod) {
+				await client.markChatAsRead(jid, mod.markRead)
+			} else if ('delete' in mod) {
+				await client.deleteChat(jid)
+			} else if ('deleteForMe' in mod) {
+				await client.deleteMessageForMe(jid, mod.deleteForMe.key.id!, !!mod.deleteForMe.key.fromMe)
+			} else if ('pushNameSetting' in mod) {
+				await client.setPushName(mod.pushNameSetting)
+			} else if ('contact' in mod) {
+				// Save/rename a contact (syncs the name to linked devices). `jid` is the
+				// contact's bare PN jid.
+				if (mod.contact) {
+					await client.saveContact(
+						jid,
+						mod.contact.fullName ?? undefined,
+						mod.contact.firstName ?? undefined,
+						mod.contact.saveOnPrimaryAddressbook ?? true
+					)
+				} else {
+					// Its own method, not `saveContact` with empty fields: removal is
+					// the one contact mutation the wire models as a `Remove`, and a
+					// `Set` carrying empty values renames the contact to "".
+					await client.removeContact(jid)
+				}
+			} else if ('clear' in mod) {
+				// Clear a chat's messages while keeping the chat. `lastMessages` (the
+				// message range) is ignored, same as the `delete` branch — the bridge
+				// clears the whole chat. deleteStarred/deleteMedia aren't part of the
+				// Baileys `clear` shape, so default both to false (keep starred + media).
+				if (mod.clear) {
+					await client.clearChat(jid, false, false)
+				}
+			} else if ('disableLinkPreviews' in mod) {
+				await client.setLinkPreviewsDisabled(mod.disableLinkPreviews.isPreviewsDisabled ?? false)
+			} else if ('addLabel' in mod) {
+				// One upstream variant, two wire actions: an edit carrying
+				// `deleted` is the delete, not a separate modification.
+				if (mod.addLabel.deleted) {
+					await client.deleteLabel(mod.addLabel.id)
+				} else {
+					await client.createLabel(mod.addLabel.id, mod.addLabel.name ?? '', mod.addLabel.color ?? 0)
+				}
+			} else if ('addChatLabel' in mod) {
+				await client.addChatLabel(mod.addChatLabel.labelId, jid)
+			} else if ('removeChatLabel' in mod) {
+				await client.removeChatLabel(mod.removeChatLabel.labelId, jid)
+			} else if ('addMessageLabel' in mod) {
+				await client.addMessageLabel(mod.addMessageLabel.labelId, jid, mod.addMessageLabel.messageId)
+			} else if ('removeMessageLabel' in mod) {
+				await client.removeMessageLabel(mod.removeMessageLabel.labelId, jid, mod.removeMessageLabel.messageId)
+			} else if ('quickReply' in mod) {
+				// Upstream's `timestamp` is the app-state index key, the same slot
+				// the core calls `id`. Deleting is the same upsert with `deleted`.
+				const id = mod.quickReply.timestamp ?? String(Math.floor(Date.now() / 1000))
+				if (mod.quickReply.deleted) {
+					await client.deleteQuickReply(id)
+				} else {
+					await client.setQuickReply(
+						id,
+						mod.quickReply.shortcut ?? '',
+						mod.quickReply.message ?? '',
+						mod.quickReply.keywords ?? [],
+						mod.quickReply.count ?? 0
+					)
+				}
 			} else {
-				// `contact: null` = remove-contact in upstream Baileys; no
-				// bridge/core path yet — warn instead of silently dropping.
-				ctx.logger.warn({ jid }, 'chatModify: contact removal (contact: null) not yet supported by bridge')
+				const variant = Object.keys(mod)[0] ?? '(empty)'
+				throw new Boom(`chatModify: unsupported modification '${variant}'`, { statusCode: 400, data: { variant, jid } })
 			}
-		} else if ('clear' in mod) {
-			// Clear a chat's messages while keeping the chat. `lastMessages` (the
-			// message range) is ignored, same as the `delete` branch — the bridge
-			// clears the whole chat. deleteStarred/deleteMedia aren't part of the
-			// Baileys `clear` shape, so default both to false (keep starred + media).
-			if (mod.clear) {
-				await client.clearChat(jid, false, false)
-			}
-		} else {
-			// App-state-patch variants not yet exposed by bridge:
-			// disableLinkPreviews, addLabel, addChatLabel,
-			// removeChatLabel, addMessageLabel, removeMessageLabel, quickReply
-			const variant = Object.keys(mod)[0]
-			ctx.logger.warn(
-				{ variant, jid },
-				'chatModify: variant requires app-state patch support not yet available in bridge'
-			)
-		}
-	},
+		},
 
-	/**
-	 * Force re-sync of app state collections.
-	 *
-	 * In the Rust bridge architecture, app state is managed internally by the engine
-	 * and synced automatically on connect. This method is a no-op provided for API
-	 * compatibility with upstream Baileys.
-	 */
-	resyncAppState: async (_collections?: readonly WAPatchName[], _isInitialSync?: boolean) => {
-		ctx.logger.info('resyncAppState: app state is synced automatically by the Rust bridge')
+		/**
+		 * Force re-sync of app state collections.
+		 *
+		 * In the Rust bridge architecture, app state is managed internally by the engine
+		 * and synced automatically on connect. This method is a no-op provided for API
+		 * compatibility with upstream Baileys.
+		 */
+		resyncAppState: async (_collections?: readonly WAPatchName[], _isInitialSync?: boolean) => {
+			ctx.logger.info('resyncAppState: app state is synced automatically by the Rust bridge')
+		}
 	}
-})
+	return methods
+}

--- a/src/__tests__/chat-modify-compatibility.test.ts
+++ b/src/__tests__/chat-modify-compatibility.test.ts
@@ -131,6 +131,26 @@ describe('chatModify: variants that used to resolve without doing anything', () 
 	}
 })
 
+describe('chatModify: a quick reply with no usable key gets one', () => {
+	// Upstream mints a key from the clock for both, and the core rejects an
+	// empty index, so neither may reach the bridge as ''.
+	for (const [label, timestamp] of [
+		['empty', ''],
+		['absent', undefined]
+	] as const) {
+		it(`a ${label} timestamp becomes a generated key`, async () => {
+			const { calls, methods } = makeHarness()
+
+			await methods.chatModify({ quickReply: { timestamp, shortcut: 'hi', message: 'Hello' } }, CHAT)
+
+			const [name, args] = calls[0]!
+			expect(name).toBe('setQuickReply')
+			expect(typeof args[0]).toBe('string')
+			expect((args[0] as string).length > 0).toBe(true)
+		})
+	}
+})
+
 describe('chatModify: anything with no path rejects', () => {
 	it('names the variant it could not run', async () => {
 		const { calls, methods } = makeHarness()

--- a/src/__tests__/chat-modify-compatibility.test.ts
+++ b/src/__tests__/chat-modify-compatibility.test.ts
@@ -151,6 +151,41 @@ describe('chatModify: a quick reply with no usable key gets one', () => {
 	}
 })
 
+/**
+ * Both input types carry fields the bridge call has no slot for. Accepting one
+ * and dropping it is the same silent success in miniature: the caller asked for
+ * a username to be set and got a resolved promise with nothing set.
+ */
+describe('chatModify: a field the wire call cannot carry is refused, not dropped', () => {
+	for (const field of ['lidJid', 'pnJid', 'username'] as const) {
+		it(`contact.${field} rejects rather than being ignored`, async () => {
+			const { calls, methods } = makeHarness()
+
+			await expect(methods.chatModify({ contact: { fullName: 'Ada', [field]: 'something' } }, CHAT)).rejects.toThrow(
+				new RegExp(`${field} cannot be set`)
+			)
+			expect(calls).toEqual([])
+		})
+	}
+
+	it('addLabel.predefinedId rejects rather than being ignored', async () => {
+		const { calls, methods } = makeHarness()
+
+		await expect(
+			methods.chatModify({ addLabel: { id: 'lbl-1', name: 'Leads', predefinedId: 3 } }, CHAT)
+		).rejects.toThrow(/predefinedId cannot be set/)
+		expect(calls).toEqual([])
+	})
+
+	it('a delete still works with predefinedId present, since the delete carries no payload', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.chatModify({ addLabel: { id: 'lbl-1', predefinedId: 3, deleted: true } }, CHAT)
+
+		expect(calls).toEqual([['deleteLabel', ['lbl-1']]])
+	})
+})
+
 describe('chatModify: anything with no path rejects', () => {
 	it('names the variant it could not run', async () => {
 		const { calls, methods } = makeHarness()

--- a/src/__tests__/chat-modify-compatibility.test.ts
+++ b/src/__tests__/chat-modify-compatibility.test.ts
@@ -1,0 +1,293 @@
+/**
+ * `chatModify` used to end in an `else` that logged a warning and resolved, for
+ * every variant the bridge did not expose: link previews, the five label
+ * actions, quick replies. `contact: null` did the same.
+ *
+ * That is worse than a missing method. A missing method is a `TypeError` the
+ * caller sees. A call that resolves having done nothing is silent data loss:
+ * the caller believes the chat is labelled and nothing was ever synced, and
+ * neither the signature nor the type system says otherwise.
+ *
+ * So these tests come in two halves. One pins that every variant now reaches
+ * the bridge call that performs it, with the arguments in the order the bridge
+ * takes them. The other pins that anything left over rejects.
+ */
+
+import { EventEmitter } from 'node:events'
+import { describe, it } from 'node:test'
+import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+
+import { makeChatActionMethods } from '../Socket/chat-actions.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import type { ChatModification } from '../Types/index.ts'
+import type { ILogger } from '../Utils/logger.ts'
+import { expect } from './expect.ts'
+
+const CHAT = '15551230000@s.whatsapp.net'
+
+const logger = {
+	level: 'silent',
+	child: () => logger,
+	trace: () => undefined,
+	debug: () => undefined,
+	info: () => undefined,
+	warn: () => undefined,
+	error: () => undefined
+} as ILogger
+
+/** Records every bridge method the modification reaches, with its arguments. */
+const makeHarness = () => {
+	const calls: Array<[string, unknown[]]> = []
+	const record =
+		(name: string) =>
+		async (...args: unknown[]) => {
+			calls.push([name, args])
+		}
+	const client = new Proxy({} as Record<string, unknown>, {
+		// `then` has to stay undefined: a proxy that answers it is a thenable,
+		// and `await getClient()` would try to resolve the client itself.
+		get: (_target, prop) => (typeof prop === 'string' && prop !== 'then' ? record(prop) : undefined)
+	}) as unknown as WasmWhatsAppClient
+	const ctx = {
+		ev: new EventEmitter(),
+		logger,
+		getClient: async () => client
+	} as unknown as SocketContext
+	return { calls, methods: makeChatActionMethods(ctx) }
+}
+
+/**
+ * Every variant that used to fall into the silent `else`, plus `contact: null`,
+ * with the bridge call each one has to become.
+ *
+ * The argument order is the point of the table. Upstream takes
+ * `(jid, labelId)` and the bridge takes `(labelId, chatJid)`; both are strings,
+ * so a swap type checks and silently labels the wrong thing.
+ */
+const FORMERLY_SILENT: Array<{ label: string; mod: ChatModification; call: [string, unknown[]] }> = [
+	{
+		label: 'disableLinkPreviews',
+		mod: { disableLinkPreviews: { isPreviewsDisabled: true } },
+		call: ['setLinkPreviewsDisabled', [true]]
+	},
+	{
+		label: 'addLabel (create)',
+		mod: { addLabel: { id: 'lbl-1', name: 'Leads', color: 3 } },
+		call: ['createLabel', ['lbl-1', 'Leads', 3]]
+	},
+	{
+		label: 'addLabel (deleted flag routes to delete)',
+		mod: { addLabel: { id: 'lbl-1', name: 'Leads', deleted: true } },
+		call: ['deleteLabel', ['lbl-1']]
+	},
+	{
+		label: 'addChatLabel',
+		mod: { addChatLabel: { labelId: 'lbl-1' } },
+		call: ['addChatLabel', ['lbl-1', CHAT]]
+	},
+	{
+		label: 'removeChatLabel',
+		mod: { removeChatLabel: { labelId: 'lbl-1' } },
+		call: ['removeChatLabel', ['lbl-1', CHAT]]
+	},
+	{
+		label: 'addMessageLabel',
+		mod: { addMessageLabel: { labelId: 'lbl-1', messageId: 'MSG1' } },
+		call: ['addMessageLabel', ['lbl-1', CHAT, 'MSG1']]
+	},
+	{
+		label: 'removeMessageLabel',
+		mod: { removeMessageLabel: { labelId: 'lbl-1', messageId: 'MSG1' } },
+		call: ['removeMessageLabel', ['lbl-1', CHAT, 'MSG1']]
+	},
+	{
+		label: 'quickReply (create)',
+		mod: { quickReply: { timestamp: '1700000000', shortcut: 'hi', message: 'Hello', keywords: ['greet'], count: 0 } },
+		call: ['setQuickReply', ['1700000000', 'hi', 'Hello', ['greet'], 0]]
+	},
+	{
+		label: 'quickReply (deleted flag routes to delete)',
+		mod: { quickReply: { timestamp: '1700000000', deleted: true } },
+		call: ['deleteQuickReply', ['1700000000']]
+	},
+	{
+		// The one contact mutation the wire models as a Remove. A Set carrying
+		// empty fields would rename the contact to the empty string instead.
+		label: 'contact: null',
+		mod: { contact: null },
+		call: ['removeContact', [CHAT]]
+	}
+]
+
+describe('chatModify: variants that used to resolve without doing anything', () => {
+	for (const { label, mod, call } of FORMERLY_SILENT) {
+		it(`${label} reaches ${call[0]}`, async () => {
+			const { calls, methods } = makeHarness()
+
+			await methods.chatModify(mod, CHAT)
+
+			expect(calls).toEqual([call])
+		})
+	}
+})
+
+describe('chatModify: anything with no path rejects', () => {
+	it('names the variant it could not run', async () => {
+		const { calls, methods } = makeHarness()
+
+		await expect(methods.chatModify({ notARealVariant: true } as unknown as ChatModification, CHAT)).rejects.toThrow(
+			/unsupported modification 'notARealVariant'/
+		)
+		expect(calls).toEqual([])
+	})
+
+	it('an empty modification rejects rather than passing silently', async () => {
+		const { methods } = makeHarness()
+
+		await expect(methods.chatModify({} as ChatModification, CHAT)).rejects.toThrow(/unsupported modification/)
+	})
+})
+
+describe('chatModify: the variants that already worked still do', () => {
+	it('a contact with a value still saves, and carries every field', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.chatModify(
+			{ contact: { fullName: 'Ada Lovelace', firstName: 'Ada', saveOnPrimaryAddressbook: false } },
+			CHAT
+		)
+
+		expect(calls).toEqual([['saveContact', [CHAT, 'Ada Lovelace', 'Ada', false]]])
+	})
+
+	it('star iterates every message, not just the first', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.chatModify({ star: { messages: [{ id: 'A' }, { id: 'B' }, { id: 'C' }], star: true } }, CHAT)
+
+		expect(calls).toEqual([
+			['starMessage', [CHAT, 'A', true]],
+			['starMessage', [CHAT, 'B', true]],
+			['starMessage', [CHAT, 'C', true]]
+		])
+	})
+})
+
+/**
+ * The ten public methods are sugar over `chatModify`, as they are upstream. The
+ * risk they carry is their own argument order, which differs from the bridge's
+ * in every label case.
+ */
+describe('the public methods reach the same bridge calls', () => {
+	it('addChatLabel(jid, labelId) does not swap its arguments', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.addChatLabel(CHAT, 'lbl-9')
+
+		expect(calls).toEqual([['addChatLabel', ['lbl-9', CHAT]]])
+	})
+
+	it('removeChatLabel(jid, labelId) does not swap its arguments', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.removeChatLabel(CHAT, 'lbl-9')
+
+		expect(calls).toEqual([['removeChatLabel', ['lbl-9', CHAT]]])
+	})
+
+	it('addMessageLabel(jid, messageId, labelId) reorders to (labelId, jid, messageId)', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.addMessageLabel(CHAT, 'MSG7', 'lbl-9')
+
+		expect(calls).toEqual([['addMessageLabel', ['lbl-9', CHAT, 'MSG7']]])
+	})
+
+	it('removeMessageLabel(jid, messageId, labelId) reorders the same way', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.removeMessageLabel(CHAT, 'MSG7', 'lbl-9')
+
+		expect(calls).toEqual([['removeMessageLabel', ['lbl-9', CHAT, 'MSG7']]])
+	})
+
+	it('addLabel forwards the whole body', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.addLabel(CHAT, { id: 'lbl-2', name: 'VIP', color: 7 })
+
+		expect(calls).toEqual([['createLabel', ['lbl-2', 'VIP', 7]]])
+	})
+
+	it('addOrEditContact carries all three contact fields', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.addOrEditContact(CHAT, {
+			fullName: 'Grace Hopper',
+			firstName: 'Grace',
+			saveOnPrimaryAddressbook: true
+		})
+
+		expect(calls).toEqual([['saveContact', [CHAT, 'Grace Hopper', 'Grace', true]]])
+	})
+
+	it('removeContact takes the Remove path', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.removeContact(CHAT)
+
+		expect(calls).toEqual([['removeContact', [CHAT]]])
+	})
+
+	it('star forwards every message', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.star(CHAT, [{ id: 'A' }, { id: 'B' }], false)
+
+		expect(calls).toEqual([
+			['starMessage', [CHAT, 'A', false]],
+			['starMessage', [CHAT, 'B', false]]
+		])
+	})
+
+	it('addOrEditQuickReply keys the upsert by the timestamp it was given', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.addOrEditQuickReply({
+			timestamp: '1699999999',
+			shortcut: 'ty',
+			message: 'Thank you',
+			keywords: [],
+			count: 2
+		})
+
+		expect(calls).toEqual([['setQuickReply', ['1699999999', 'ty', 'Thank you', [], 2]]])
+	})
+
+	it('removeQuickReply deletes by the same key', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.removeQuickReply('1699999999')
+
+		expect(calls).toEqual([['deleteQuickReply', ['1699999999']]])
+	})
+})
+
+describe('chatModify does not swallow a bridge failure', () => {
+	it('a rejecting bridge call surfaces to the caller', async () => {
+		const client = {
+			addChatLabel: async () => {
+				throw new Error('invalid argument request: no app state sync key available')
+			}
+		} as unknown as WasmWhatsAppClient
+		const ctx = {
+			ev: new EventEmitter(),
+			logger,
+			getClient: async () => client
+		} as unknown as SocketContext
+
+		await expect(makeChatActionMethods(ctx).addChatLabel(CHAT, 'lbl-1')).rejects.toThrow(
+			/no app state sync key available/
+		)
+	})
+})

--- a/src/__tests__/chat-modify-compatibility.test.ts
+++ b/src/__tests__/chat-modify-compatibility.test.ts
@@ -13,7 +13,9 @@
  * takes them. The other pins that anything left over rejects.
  */
 
+import { readFileSync } from 'node:fs'
 import { EventEmitter } from 'node:events'
+import path from 'node:path'
 import { describe, it } from 'node:test'
 import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
 
@@ -184,6 +186,55 @@ describe('chatModify: a field the wire call cannot carry is refused, not dropped
 
 		expect(calls).toEqual([['deleteLabel', ['lbl-1']]])
 	})
+})
+
+/**
+ * The delegation tests above compare our calls against a fake, so on their own
+ * they prove we call what this file says we call and nothing more. For the
+ * label methods that is not enough: every parameter is a string, so a swapped
+ * pair type checks, and a swap made in both the code and its test would agree
+ * with itself.
+ *
+ * This reads the parameter names out of the bridge's own declarations, so the
+ * assumed order is pinned to the package rather than to us. Together the two
+ * halves mean something: we pass label first, and label is what the bridge
+ * takes first.
+ */
+describe('the argument order these tests assume is the one the bridge declares', () => {
+	const dts = readFileSync(
+		path.resolve(
+			import.meta.dirname,
+			'../../node_modules/@oxidezap/whatsapp-rust-bridge/dist/whatsapp_rust_bridge.d.ts'
+		),
+		'utf8'
+	)
+
+	const parameterNames = (method: string): string[] => {
+		const declaration = new RegExp(`^\\s{4}${method}\\((.*?)\\):`, 'm').exec(dts)
+		if (!declaration) throw new Error(`no declaration for ${method} in the bridge .d.ts`)
+		return (
+			declaration[1]!
+				.split(/,(?![^<(]*[>)])/)
+				.map(parameter => parameter.trim().split(':')[0]!.trim())
+				// The whole point is the order, so an empty parameter list has to
+				// come back empty rather than as ['']
+				.filter(name => name.length > 0)
+		)
+	}
+
+	for (const [method, expected] of [
+		['addChatLabel', ['label_id', 'chat_jid']],
+		['removeChatLabel', ['label_id', 'chat_jid']],
+		['addMessageLabel', ['label_id', 'chat_jid', 'message_id']],
+		['removeMessageLabel', ['label_id', 'chat_jid', 'message_id']],
+		['createLabel', ['label_id', 'name', 'color']],
+		['saveContact', ['jid', 'full_name', 'first_name', 'save_on_primary_addressbook']],
+		['setQuickReply', ['id', 'shortcut', 'message', 'keywords', 'count']]
+	] as const) {
+		it(`${method} takes (${expected.join(', ')})`, () => {
+			expect(parameterNames(method)).toEqual([...expected])
+		})
+	}
 })
 
 describe('chatModify: anything with no path rejects', () => {

--- a/src/__tests__/chat-modify-compatibility.test.ts
+++ b/src/__tests__/chat-modify-compatibility.test.ts
@@ -179,6 +179,21 @@ describe('chatModify: a field the wire call cannot carry is refused, not dropped
 		expect(calls).toEqual([])
 	})
 
+	// The label mutation replaces the whole action, so an omitted field is
+	// "set to nothing" rather than "leave alone". Upstream can omit one
+	// because it builds the proto itself; this call has no way to.
+	for (const [label, body] of [
+		['name', { id: 'lbl-1', color: 3 }],
+		['color', { id: 'lbl-1', name: 'Leads' }]
+	] as const) {
+		it(`addLabel without ${label} rejects rather than resetting it`, async () => {
+			const { calls, methods } = makeHarness()
+
+			await expect(methods.chatModify({ addLabel: body }, CHAT)).rejects.toThrow(/name and color are both required/)
+			expect(calls).toEqual([])
+		})
+	}
+
 	it('a delete still works with predefinedId present, since the delete carries no payload', async () => {
 		const { calls, methods } = makeHarness()
 


### PR DESCRIPTION
## Summary

`chatModify` ended in an `else` that logged a warning and resolved, for every variant the bridge did not expose: link previews, the five label actions, quick replies. `contact: null` did the same in its own branch.

Two changes, one commit each.

**The silent success is gone.** Every one of those variants now reaches the bridge call that actually performs it, so the `else` is only reachable by a modification this package does not know at all, and that rejects naming the variant.

**The ten missing public methods are here**, with upstream's signatures, each routed through `chatModify` exactly as upstream routes them: `addLabel`, `addChatLabel`, `removeChatLabel`, `addMessageLabel`, `removeMessageLabel`, `addOrEditContact`, `removeContact`, `addOrEditQuickReply`, `removeQuickReply`, `star`.

`updateDisableLinkPreviewsPrivacy` is deliberately **not** here even though it is in the privacy task's list. It is an app-state mutation, not a privacy IQ, so its `disableLinkPreviews` branch belongs to this PR. #28 records the same split from the other side so the two do not both touch that branch.

## Behavior change

A call that used to resolve now throws, and that is the point.

Before: `sock.chatModify({ addChatLabel: { labelId } }, jid)` resolved successfully, logged a warning, and synced nothing. A caller reasonably believed the chat was labelled.

After: it labels the chat. And a variant with no path at all rejects with `chatModify: unsupported modification '<name>'` rather than pretending.

Who this breaks: anyone whose code path depends, without knowing it, on those calls not throwing. Concretely, code that labels a chat inside a `try` that swallows errors will now take the catch branch. That is strictly better information than the silence it replaces, but it is a real behavior change and pre-1.0 is the moment to make it.

`contact: null` is the one worth calling out separately, because "works approximately" would have been worse than failing. It now goes to `removeContact`, not to `saveContact` with empty fields. Removal is the only contact mutation the wire models as a `Remove`; a `Set` carrying empty values is applied as a rename to the empty string. Getting that wrong corrupts the user's contact instead of deleting it.

I did not add a `CHANGELOG.md` note: the changelog here is generated by release-please from commit subjects, and the `fix(chats):` commit carries this.

## Layer classification

Everything is **(a)**, implementable here by delegation. Nothing needed the core or the bridge, and no gap prompt was opened.

| upstream variant / method | bridge call | note |
|---|---|---|
| `disableLinkPreviews` | `setLinkPreviewsDisabled(bool)` | |
| `addLabel` | `createLabel(id, name, color)` / `deleteLabel(id)` | one upstream variant, two wire actions: an edit carrying `deleted` is the delete |
| `addChatLabel` / `removeChatLabel` | same names | **arguments swap**: upstream `(jid, labelId)`, bridge `(labelId, chatJid)` |
| `addMessageLabel` / `removeMessageLabel` | same names | **arguments reorder**: upstream `(jid, messageId, labelId)`, bridge `(labelId, chatJid, messageId)` |
| `quickReply` | `setQuickReply(...)` / `deleteQuickReply(id)` | |
| `contact` (value) | `saveContact(jid, fullName, firstName, saveOnPrimaryAddressbook)` | |
| `contact: null` | `removeContact(jid)` | separate method by protocol necessity, see above |
| `star` (list) | `starMessage`, once per message | |

The two argument-order rows are the ones I would expect a reviewer to check hardest. Both sides are strings, so a swap type checks cleanly and silently labels the wrong thing. There is a test per row pinning the order.

**`star` in batch stays our work.** The wire has no batch form: the real client emits one mutation per message, and the core matches that. Iterating `starMessage` is the correct behavior, not a workaround.

## The quick reply identity question

The prompt flagged this as decisive, so I checked it rather than mapping by name. Upstream identifies a quick reply by `timestamp`; the bridge takes `id`. They are the same value.

Upstream builds the app-state index as `['quick_reply', mod.quickReply.timestamp || String(Math.floor(Date.now() / 1000))]`, so its `timestamp` is the index key, defaulted to a unix second when absent rather than being a time in its own right. The core takes the same string and passes it in the same position: `send_app_state_action(&schemas::QUICK_REPLY, &[id], &value)`.

Deleting is confirmed to be the same upsert with `deleted = true` and the payload cleared, not a `Remove`, which is why `removeQuickReply` maps onto the `quickReply` variant rather than a delete action of its own.

## Deferred

Nothing. Every item in this task had a path, so no gap prompt was written for either the bridge or the core.

Worth recording for whoever picks up the neighbouring tasks: the bridge exposes app-state actions **typed per action and no generic**. That is a deliberate boundary choice, and it is why upstream's `appPatch` still has no path. It belongs to the socket-internals task, and the answer there is likely to be a refusal.

## Coverage

`npm run compat:audit` before: **97.15% (21717/22354)**
after: **97.41% (21774/22354)**

+57 matched declarations. Missing dropped from 243 to 213 (functions) and 235 to 205 (fields).

The `chatModify` behavior change contributes nothing to that number, which is worth stating plainly: the signature was already correct, only the behavior was wrong, and no coverage metric was ever going to catch it. The audit moved because of the ten methods.

## Validation

- `npm run format`
- `npm run lint` (`tsc` plus `oxlint`)
- `npm test`: 691 tests, 0 failures, up from 666
- `npm run compat:audit`

Not run: `npm run test:e2e`, which needs a mock server this environment does not have.

**No existing test needed adapting, and that is itself a finding.** The prompt expected the current `chatModify` tests to need changing. There were none: `grep` for `chatModify` across the test suite returns only the file this PR adds. A branch that resolved without doing anything survived precisely because nothing exercised it.

Every new assertion was mutation checked by making the edit and running the suite, not by reading the assertion:

- restoring the silent `else` fails 2 tests
- swapping `addChatLabel` back to upstream's argument order fails 2 tests
- routing `contact: null` through `saveContact` with empty fields fails 2 tests

---
_Generated by [Claude Code](https://claude.ai/code/session_019n5h4gDvrNFW4nCnf2YpMw)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops silently ignoring unsupported `chatModify` variants by wiring them to the bridge and throwing on unknown ones. Adds the missing label, contact, and quick-reply APIs and tightens input validation to prevent accidental resets.

- **Bug Fixes**
  - Unknown `chatModify` variants now throw with the variant name.
  - Routed `disableLinkPreviews`, all label actions, quick replies, and `contact: null` → `removeContact`; fixed label arg order and pinned it to the bridge `.d.ts`.
  - Reject fields the wire can’t carry: `contact.lidJid`, `contact.pnJid`, `contact.username`, and `addLabel.predefinedId` (deletes unaffected).
  - Require both `name` and `color` on `addLabel` edits to avoid resetting missing fields.
  - Quick replies mint an id when `timestamp` is empty or missing.

- **New Features**
  - Added: `addLabel`, `addChatLabel`, `removeChatLabel`, `addMessageLabel`, `removeMessageLabel`, `addOrEditContact`, `removeContact`, `addOrEditQuickReply`, `removeQuickReply`, `star` (iterates per message).

<sup>Written for commit 11d150b4ca837831c8f7f9d13b9f678904458f72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contact management, including adding, editing, and removing contacts.
  * Added chat and message labeling capabilities.
  * Added message starring and quick-reply management.
  * Added link-preview updates through chat modifications.

* **Bug Fixes**
  * Unsupported chat modifications now return clear errors instead of being ignored.
  * Improved validation and error handling for chat actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->