### PR TITLE
feat(newsletter): complete the upstream newsletter surface

### DIFF
--- a/src/Compatibility/newsletter-results.ts
+++ b/src/Compatibility/newsletter-results.ts
@@ -1,0 +1,44 @@
+import type { NewsletterMetadataResult } from '@oxidezap/whatsapp-rust-bridge'
+import type { NewsletterMetadata, NewsletterViewRole } from '../Types/Newsletter.ts'
+
+/**
+ * The bridge spells these the way the core's enums are named, and upstream
+ * spells them in screaming case. Written out rather than upper-cased blindly so
+ * a variant the core adds later shows up as `undefined` instead of as a string
+ * nobody declared.
+ */
+const VERIFICATION: Record<string, NewsletterMetadata['verification']> = {
+	Verified: 'VERIFIED',
+	Unverified: 'UNVERIFIED'
+}
+
+const VIEW_ROLE: Record<string, NewsletterViewRole> = {
+	Owner: 'OWNER',
+	Admin: 'ADMIN',
+	Subscriber: 'SUBSCRIBER',
+	Guest: 'GUEST'
+}
+
+/** Upstream's `NewsletterViewRole`, or undefined for a role it does not name. */
+export const bridgeNewsletterRoleToBaileys = (role: string | undefined): NewsletterViewRole | undefined =>
+	role === undefined ? undefined : VIEW_ROLE[role]
+
+/**
+ * Neutral newsletter metadata in upstream's shape.
+ *
+ * Four upstream fields have no source in the bridge result and stay absent
+ * rather than being invented: `owner` (the result carries the viewer's role,
+ * not the owner's jid), `mute_state` (the result's `state` is the newsletter's
+ * lifecycle, Active/Suspended, not a mute), `reaction_codes`, and
+ * `thread_metadata`.
+ */
+export const bridgeNewsletterMetadataToBaileys = (result: NewsletterMetadataResult): NewsletterMetadata => ({
+	id: result.jid,
+	name: result.name,
+	...(result.description !== undefined ? { description: result.description } : {}),
+	...(result.inviteCode !== undefined ? { invite: result.inviteCode } : {}),
+	...(result.creationTime !== undefined ? { creation_time: result.creationTime } : {}),
+	subscribers: result.subscriberCount,
+	...(VERIFICATION[result.verification] !== undefined ? { verification: VERIFICATION[result.verification] } : {}),
+	...(result.pictureUrl !== undefined ? { picture: { url: result.pictureUrl } } : {})
+})

--- a/src/Socket/newsletter.ts
+++ b/src/Socket/newsletter.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'node:buffer'
 import { bridgeNewsletterMetadataToBaileys } from '../Compatibility/newsletter-results.ts'
+import type { NewsletterMetadataResult } from '@oxidezap/whatsapp-rust-bridge'
 import type { NewsletterMetadata, NewsletterUpdate } from '../Types/Newsletter.ts'
 import type { WAMediaUpload } from '../Types/index.ts'
 import { Boom } from '../Utils/boom.ts'
@@ -33,16 +34,19 @@ export const makeNewsletterMethods = (ctx: SocketContext) => ({
 	 */
 	newsletterUpdate: async (jid: string, updates: NewsletterUpdate): Promise<NewsletterMetadata> => {
 		const client = await ctx.getClient()
-		let result =
-			updates.name !== undefined || updates.description !== undefined
-				? await client.newsletterUpdate(jid, updates.name ?? null, updates.description ?? null)
-				: await client.newsletterMetadata(jid)
+		let result: NewsletterMetadataResult | undefined
+		if (updates.name !== undefined || updates.description !== undefined) {
+			result = await client.newsletterUpdate(jid, updates.name ?? null, updates.description ?? null)
+		}
 		if (updates.picture === '') {
 			result = await client.newsletterRemovePicture(jid)
 		} else if (updates.picture !== undefined) {
 			result = await client.newsletterSetPicture(jid, new Uint8Array(Buffer.from(updates.picture, 'base64')))
 		}
-		return bridgeNewsletterMetadataToBaileys(result)
+		// Only when the delta asked for nothing: every write above already
+		// answers with the refreshed metadata, so reading it would be a round
+		// trip whose result is thrown away.
+		return bridgeNewsletterMetadataToBaileys(result ?? (await client.newsletterMetadata(jid)))
 	},
 
 	newsletterUpdateName: async (jid: string, name: string): Promise<NewsletterMetadata> => {
@@ -97,6 +101,10 @@ export const makeNewsletterMethods = (ctx: SocketContext) => ({
 	 * from a `before` cursor and carries no time filter. Mapping `after` onto
 	 * `before` would page the opposite direction and return a plausible wrong
 	 * answer, so a caller asking for either is told instead.
+	 *
+	 * Zero is not asking. `since: 0` is the epoch and `after: 0` is no cursor,
+	 * which is what the unfiltered query already does, so the common
+	 * `(jid, count, 0, 0)` call runs rather than being refused for nothing.
 	 */
 	newsletterFetchMessages: async (jid: string, count: number, since?: number, after?: number) => {
 		if (since) {

--- a/src/Socket/newsletter.ts
+++ b/src/Socket/newsletter.ts
@@ -1,31 +1,147 @@
+import { Buffer } from 'node:buffer'
+import { bridgeNewsletterMetadataToBaileys } from '../Compatibility/newsletter-results.ts'
+import type { NewsletterMetadata, NewsletterUpdate } from '../Types/Newsletter.ts'
+import type { WAMediaUpload } from '../Types/index.ts'
+import { Boom } from '../Utils/boom.ts'
+import { generateProfilePicture } from '../Utils/messages-media.ts'
 import type { SocketContext } from './types.ts'
 
 export const makeNewsletterMethods = (ctx: SocketContext) => ({
-	newsletterCreate: async (name: string, description?: string) => {
-		return await (await ctx.getClient()).newsletterCreate(name, description)
+	newsletterCreate: async (name: string, description?: string): Promise<NewsletterMetadata> => {
+		return bridgeNewsletterMetadataToBaileys(await (await ctx.getClient()).newsletterCreate(name, description ?? null))
 	},
 
-	newsletterMetadata: async (jid: string) => {
-		return await (await ctx.getClient()).newsletterMetadata(jid)
+	/**
+	 * `type` selects which lookup runs: the bridge has a method per key kind
+	 * rather than one that inspects the key. Resolves to null when the
+	 * newsletter does not exist, matching upstream.
+	 */
+	newsletterMetadata: async (type: 'invite' | 'jid', key: string): Promise<NewsletterMetadata | null> => {
+		if (type !== 'invite' && type !== 'jid') {
+			throw new Boom(`newsletterMetadata: unknown key type '${type}'`, { statusCode: 400 })
+		}
+		const client = await ctx.getClient()
+		const result =
+			type === 'invite' ? await client.newsletterMetadataByInvite(key) : await client.newsletterMetadata(key)
+		return result ? bridgeNewsletterMetadataToBaileys(result) : null
 	},
 
-	newsletterSubscribe: async (jid: string) => {
-		return await (await ctx.getClient()).newsletterSubscribe(jid)
+	/**
+	 * `picture` is base64 of an already-generated image, and the empty string
+	 * means remove, as upstream builds it. The core splits those into two
+	 * methods, so the field is dispatched rather than forwarded.
+	 */
+	newsletterUpdate: async (jid: string, updates: NewsletterUpdate): Promise<NewsletterMetadata> => {
+		const client = await ctx.getClient()
+		let result =
+			updates.name !== undefined || updates.description !== undefined
+				? await client.newsletterUpdate(jid, updates.name ?? null, updates.description ?? null)
+				: await client.newsletterMetadata(jid)
+		if (updates.picture === '') {
+			result = await client.newsletterRemovePicture(jid)
+		} else if (updates.picture !== undefined) {
+			result = await client.newsletterSetPicture(jid, new Uint8Array(Buffer.from(updates.picture, 'base64')))
+		}
+		return bridgeNewsletterMetadataToBaileys(result)
 	},
 
-	newsletterUnsubscribe: async (jid: string) => {
+	newsletterUpdateName: async (jid: string, name: string): Promise<NewsletterMetadata> => {
+		return bridgeNewsletterMetadataToBaileys(await (await ctx.getClient()).newsletterUpdate(jid, name, null))
+	},
+
+	newsletterUpdateDescription: async (jid: string, description: string): Promise<NewsletterMetadata> => {
+		return bridgeNewsletterMetadataToBaileys(await (await ctx.getClient()).newsletterUpdate(jid, null, description))
+	},
+
+	newsletterUpdatePicture: async (jid: string, content: WAMediaUpload): Promise<NewsletterMetadata> => {
+		const { img } = await generateProfilePicture(content)
+		return bridgeNewsletterMetadataToBaileys(await (await ctx.getClient()).newsletterSetPicture(jid, img))
+	},
+
+	newsletterRemovePicture: async (jid: string): Promise<NewsletterMetadata> => {
+		return bridgeNewsletterMetadataToBaileys(await (await ctx.getClient()).newsletterRemovePicture(jid))
+	},
+
+	newsletterFollow: async (jid: string): Promise<NewsletterMetadata> => {
+		return bridgeNewsletterMetadataToBaileys(await (await ctx.getClient()).newsletterSubscribe(jid))
+	},
+
+	newsletterUnfollow: async (jid: string): Promise<void> => {
 		await (await ctx.getClient()).newsletterUnsubscribe(jid)
 	},
 
-	newsletterReactMessage: async (jid: string, serverId: string, reaction?: string) => {
+	/**
+	 * The follower-activity mute, which is the one a subscriber toggles. The
+	 * core's other newsletter mute is for admin activity and is a different
+	 * control, so the ambiguous alias is avoided here.
+	 */
+	newsletterMute: async (jid: string): Promise<void> => {
+		await (await ctx.getClient()).newsletterFollowerMute(jid, true)
+	},
+
+	newsletterUnmute: async (jid: string): Promise<void> => {
+		await (await ctx.getClient()).newsletterFollowerMute(jid, false)
+	},
+
+	newsletterSubscribers: async (jid: string): Promise<{ subscribers: number }> => {
+		const metadata = await (await ctx.getClient()).newsletterMetadata(jid)
+		return { subscribers: metadata.subscriberCount }
+	},
+
+	newsletterReactMessage: async (jid: string, serverId: string, reaction?: string): Promise<void> => {
 		await (await ctx.getClient()).newsletterReactMessage(jid, serverId, reaction ?? null)
 	},
 
 	/**
-	 * Mute or unmute a newsletter (channel) — silences its follower-activity
-	 * notifications, the mute a subscriber toggles. `mute = true` silences.
+	 * `since` and `after` have no equivalent: the core's query pages backward
+	 * from a `before` cursor and carries no time filter. Mapping `after` onto
+	 * `before` would page the opposite direction and return a plausible wrong
+	 * answer, so a caller asking for either is told instead.
 	 */
-	newsletterMute: async (jid: string, mute: boolean) => {
-		await (await ctx.getClient()).newsletterMute(jid, mute)
+	newsletterFetchMessages: async (jid: string, count: number, since?: number, after?: number) => {
+		if (since) {
+			throw new Boom('newsletterFetchMessages: `since` is not supported, the message query carries no time filter', {
+				statusCode: 400
+			})
+		}
+		if (after) {
+			throw new Boom(
+				'newsletterFetchMessages: `after` is not supported, the message query pages backward from a `before` cursor',
+				{ statusCode: 400 }
+			)
+		}
+		return await (await ctx.getClient()).newsletterMessages(jid, count, null)
+	},
+
+	subscribeNewsletterUpdates: async (jid: string): Promise<{ duration: string }> => {
+		const duration = await (await ctx.getClient()).newsletterSubscribeLiveUpdates(jid)
+		return { duration: String(duration) }
+	},
+
+	/**
+	 * The count rides on the admin-info result and the server omits it for an
+	 * account that may not see it. Absent is reported as absent: `0` here would
+	 * read as "no admins", which no newsletter can be.
+	 */
+	newsletterAdminCount: async (jid: string): Promise<number> => {
+		const info = await (await ctx.getClient()).newsletterAdminInfo(jid)
+		if (info.adminCount === undefined) {
+			throw new Boom('newsletterAdminCount: the server did not return an admin count for this newsletter', {
+				statusCode: 404
+			})
+		}
+		return info.adminCount
+	},
+
+	newsletterChangeOwner: async (jid: string, newOwnerJid: string): Promise<void> => {
+		await (await ctx.getClient()).newsletterChangeOwner(jid, newOwnerJid)
+	},
+
+	newsletterDemote: async (jid: string, userJid: string): Promise<void> => {
+		await (await ctx.getClient()).newsletterDemoteAdmin(jid, userJid)
+	},
+
+	newsletterDelete: async (jid: string): Promise<void> => {
+		await (await ctx.getClient()).newsletterDelete(jid)
 	}
 })

--- a/src/Socket/newsletter.ts
+++ b/src/Socket/newsletter.ts
@@ -75,6 +75,18 @@ export const makeNewsletterMethods = (ctx: SocketContext) => ({
 	},
 
 	/**
+	 * The names this package used before it grew upstream's. Kept so existing
+	 * callers do not break on a rename that buys them nothing.
+	 */
+	newsletterSubscribe: async (jid: string): Promise<NewsletterMetadata> => {
+		return bridgeNewsletterMetadataToBaileys(await (await ctx.getClient()).newsletterSubscribe(jid))
+	},
+
+	newsletterUnsubscribe: async (jid: string): Promise<void> => {
+		await (await ctx.getClient()).newsletterUnsubscribe(jid)
+	},
+
+	/**
 	 * The follower-activity mute, which is the one a subscriber toggles. The
 	 * core's other newsletter mute is for admin activity and is a different
 	 * control, so the ambiguous alias is avoided here.

--- a/src/Socket/newsletter.ts
+++ b/src/Socket/newsletter.ts
@@ -76,10 +76,13 @@ export const makeNewsletterMethods = (ctx: SocketContext) => ({
 
 	/**
 	 * The names this package used before it grew upstream's. Kept so existing
-	 * callers do not break on a rename that buys them nothing.
+	 * callers do not break on a rename that buys them nothing, and returning
+	 * the bridge result unmapped for the same reason: a caller reading `jid`
+	 * or `subscriberCount` off it would find them renamed otherwise.
+	 * `newsletterFollow` is the one that speaks upstream's shape.
 	 */
-	newsletterSubscribe: async (jid: string): Promise<NewsletterMetadata> => {
-		return bridgeNewsletterMetadataToBaileys(await (await ctx.getClient()).newsletterSubscribe(jid))
+	newsletterSubscribe: async (jid: string): Promise<NewsletterMetadataResult> => {
+		return await (await ctx.getClient()).newsletterSubscribe(jid)
 	},
 
 	newsletterUnsubscribe: async (jid: string): Promise<void> => {

--- a/src/__tests__/newsletter-compatibility.test.ts
+++ b/src/__tests__/newsletter-compatibility.test.ts
@@ -196,7 +196,25 @@ describe('newsletterUpdate dispatches the picture field', () => {
 
 		await methods.newsletterUpdate(JID, { picture: '' })
 
-		expect(calls.map(c => c[0])).toEqual(['newsletterMetadata', 'newsletterRemovePicture'])
+		// No metadata read: the remove already answers with the refreshed
+		// metadata, so fetching it would be a round trip thrown away.
+		expect(calls.map(c => c[0])).toEqual(['newsletterRemovePicture'])
+	})
+
+	it('a picture-only update does not pay for a metadata read first', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.newsletterUpdate(JID, { picture: Buffer.from('x').toString('base64') })
+
+		expect(calls.map(c => c[0])).toEqual(['newsletterSetPicture'])
+	})
+
+	it('an empty delta still has to read the metadata to have something to return', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.newsletterUpdate(JID, {})
+
+		expect(calls.map(c => c[0])).toEqual(['newsletterMetadata'])
 	})
 
 	it('a base64 picture is decoded to bytes, not forwarded as a string', async () => {
@@ -236,6 +254,14 @@ describe('newsletterFetchMessages refuses the paging arguments it cannot honour'
 
 		await expect(methods.newsletterFetchMessages(JID, 10, 0, 99)).rejects.toThrow(/`after` is not supported/)
 		expect(calls).toEqual([])
+	})
+
+	it('zeroes are not a request, so the common (jid, count, 0, 0) call runs', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.newsletterFetchMessages(JID, 10, 0, 0)
+
+		expect(calls).toEqual([['newsletterMessages', [JID, 10, null]]])
 	})
 })
 

--- a/src/__tests__/newsletter-compatibility.test.ts
+++ b/src/__tests__/newsletter-compatibility.test.ts
@@ -126,6 +126,16 @@ const DELEGATIONS: Array<{
 		call: ['newsletterCreate', ['Name', null]]
 	},
 	{ label: 'newsletterFollow', run: m => m.newsletterFollow(JID), call: ['newsletterSubscribe', [JID]] },
+	{
+		label: 'newsletterSubscribe (kept from before this package grew upstream names)',
+		run: m => m.newsletterSubscribe(JID),
+		call: ['newsletterSubscribe', [JID]]
+	},
+	{
+		label: 'newsletterUnsubscribe (same)',
+		run: m => m.newsletterUnsubscribe(JID),
+		call: ['newsletterUnsubscribe', [JID]]
+	},
 	{ label: 'newsletterUnfollow', run: m => m.newsletterUnfollow(JID), call: ['newsletterUnsubscribe', [JID]] },
 	{ label: 'newsletterDelete', run: m => m.newsletterDelete(JID), call: ['newsletterDelete', [JID]] },
 	{

--- a/src/__tests__/newsletter-compatibility.test.ts
+++ b/src/__tests__/newsletter-compatibility.test.ts
@@ -275,6 +275,30 @@ describe('newsletterFetchMessages refuses the paging arguments it cannot honour'
 	})
 })
 
+/**
+ * The two names this package had before it grew upstream's. They kept working
+ * through the rename, and they have to keep returning what they returned:
+ * their callers were written against the bridge result, not upstream's names.
+ */
+describe('the legacy subscribe alias returns the bridge result, unrenamed', () => {
+	it('newsletterSubscribe answers with jid, subscriberCount and inviteCode', async () => {
+		const { methods } = makeHarness()
+
+		const result = await methods.newsletterSubscribe(JID)
+
+		expect(result).toEqual(METADATA)
+	})
+
+	it('newsletterFollow is the one that answers in upstream field names', async () => {
+		const { methods } = makeHarness()
+
+		const result = await methods.newsletterFollow(JID)
+
+		expect(result.id).toBe(JID)
+		expect(result.subscribers).toBe(42)
+	})
+})
+
 describe('subscribeNewsletterUpdates and newsletterSubscribers shape their results', () => {
 	it('the live-update duration comes back as upstream types it, a string', async () => {
 		const { methods } = makeHarness({ newsletterSubscribeLiveUpdates: async () => 300 })

--- a/src/__tests__/newsletter-compatibility.test.ts
+++ b/src/__tests__/newsletter-compatibility.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Newsletter delegation and the three signatures that changed shape.
+ *
+ * The one that matters most is `newsletterMetadata`. Upstream takes
+ * `(type, key)`; this package took `(jid)`. Code written against upstream calls
+ * `newsletterMetadata('jid', id)`, which the old signature read as a literal
+ * JID of `'jid'`. That type checks on the caller's side and fails against the
+ * server, which is why it outranks any missing method.
+ */
+
+import { EventEmitter } from 'node:events'
+import { describe, it } from 'node:test'
+import type { NewsletterMetadataResult, WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+
+import { bridgeNewsletterMetadataToBaileys } from '../Compatibility/newsletter-results.ts'
+import { makeNewsletterMethods } from '../Socket/newsletter.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import type { ILogger } from '../Utils/logger.ts'
+import { expect } from './expect.ts'
+
+const JID = '120363000000000000@newsletter'
+
+const logger = {
+	level: 'silent',
+	child: () => logger,
+	trace: () => undefined,
+	debug: () => undefined,
+	info: () => undefined,
+	warn: () => undefined,
+	error: () => undefined
+} as ILogger
+
+const METADATA: NewsletterMetadataResult = {
+	jid: JID,
+	name: 'Channel',
+	description: 'A channel',
+	subscriberCount: 42,
+	verification: 'Verified',
+	state: 'Active',
+	pictureUrl: 'https://example.invalid/pic.jpg',
+	inviteCode: 'INVITE123',
+	role: 'Owner',
+	creationTime: 1700000000
+}
+
+const makeHarness = (overrides: Record<string, unknown> = {}) => {
+	const calls: Array<[string, unknown[]]> = []
+	const client = new Proxy({} as Record<string, unknown>, {
+		// `then` must stay undefined or the client reads as a thenable.
+		get: (_t, prop) => {
+			if (typeof prop !== 'string' || prop === 'then') return undefined
+			if (prop in overrides) return overrides[prop]
+			return async (...args: unknown[]) => {
+				calls.push([prop, args])
+				return METADATA
+			}
+		}
+	}) as unknown as WasmWhatsAppClient
+	const ctx = {
+		ev: new EventEmitter(),
+		logger,
+		getClient: async () => client
+	} as unknown as SocketContext
+	return { calls, methods: makeNewsletterMethods(ctx) }
+}
+
+describe('newsletterMetadata takes (type, key) and dispatches on the type', () => {
+	it("'jid' looks up by jid", async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.newsletterMetadata('jid', JID)
+
+		expect(calls).toEqual([['newsletterMetadata', [JID]]])
+	})
+
+	it("'invite' takes the invite lookup, which used to be unreachable", async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.newsletterMetadata('invite', 'INVITE123')
+
+		expect(calls).toEqual([['newsletterMetadataByInvite', ['INVITE123']]])
+	})
+
+	it('an unknown key type rejects rather than being treated as a jid', async () => {
+		const { calls, methods } = makeHarness()
+
+		await expect(methods.newsletterMetadata('nope' as unknown as 'jid', 'whatever')).rejects.toThrow(
+			/unknown key type 'nope'/
+		)
+		expect(calls).toEqual([])
+	})
+})
+
+describe('mute is two operations, as upstream has them', () => {
+	it('newsletterMute silences follower activity', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.newsletterMute(JID)
+
+		expect(calls).toEqual([['newsletterFollowerMute', [JID, true]]])
+	})
+
+	it('newsletterUnmute is the same call with false, not a separate mute', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.newsletterUnmute(JID)
+
+		expect(calls).toEqual([['newsletterFollowerMute', [JID, false]]])
+	})
+})
+
+/** Delegation, one row per method, with the arguments the bridge takes. */
+const DELEGATIONS: Array<{
+	label: string
+	run: (m: ReturnType<typeof makeHarness>['methods']) => Promise<unknown>
+	call: [string, unknown[]]
+}> = [
+	{
+		label: 'newsletterCreate',
+		run: m => m.newsletterCreate('Name', 'Desc'),
+		call: ['newsletterCreate', ['Name', 'Desc']]
+	},
+	{
+		label: 'newsletterCreate without description',
+		run: m => m.newsletterCreate('Name'),
+		call: ['newsletterCreate', ['Name', null]]
+	},
+	{ label: 'newsletterFollow', run: m => m.newsletterFollow(JID), call: ['newsletterSubscribe', [JID]] },
+	{ label: 'newsletterUnfollow', run: m => m.newsletterUnfollow(JID), call: ['newsletterUnsubscribe', [JID]] },
+	{ label: 'newsletterDelete', run: m => m.newsletterDelete(JID), call: ['newsletterDelete', [JID]] },
+	{
+		label: 'newsletterChangeOwner',
+		run: m => m.newsletterChangeOwner(JID, 'u@s.whatsapp.net'),
+		call: ['newsletterChangeOwner', [JID, 'u@s.whatsapp.net']]
+	},
+	{
+		label: 'newsletterDemote',
+		run: m => m.newsletterDemote(JID, 'u@s.whatsapp.net'),
+		call: ['newsletterDemoteAdmin', [JID, 'u@s.whatsapp.net']]
+	},
+	{
+		label: 'newsletterUpdateName',
+		run: m => m.newsletterUpdateName(JID, 'New'),
+		call: ['newsletterUpdate', [JID, 'New', null]]
+	},
+	{
+		label: 'newsletterUpdateDescription',
+		run: m => m.newsletterUpdateDescription(JID, 'New'),
+		call: ['newsletterUpdate', [JID, null, 'New']]
+	},
+	{
+		label: 'newsletterRemovePicture',
+		run: m => m.newsletterRemovePicture(JID),
+		call: ['newsletterRemovePicture', [JID]]
+	},
+	{
+		label: 'newsletterReactMessage',
+		run: m => m.newsletterReactMessage(JID, '17', '👍'),
+		call: ['newsletterReactMessage', [JID, '17', '👍']]
+	},
+	{
+		label: 'newsletterReactMessage clearing',
+		run: m => m.newsletterReactMessage(JID, '17'),
+		call: ['newsletterReactMessage', [JID, '17', null]]
+	},
+	{
+		label: 'newsletterFetchMessages',
+		run: m => m.newsletterFetchMessages(JID, 20),
+		call: ['newsletterMessages', [JID, 20, null]]
+	}
+]
+
+describe('the remaining methods delegate with the arguments the bridge takes', () => {
+	for (const { label, run, call } of DELEGATIONS) {
+		it(label, async () => {
+			const { calls, methods } = makeHarness()
+
+			await run(methods)
+
+			expect(calls).toEqual([call])
+		})
+	}
+})
+
+describe('newsletterUpdate dispatches the picture field', () => {
+	it('name and description go through the update call', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.newsletterUpdate(JID, { name: 'N', description: 'D' })
+
+		expect(calls).toEqual([['newsletterUpdate', [JID, 'N', 'D']]])
+	})
+
+	it('an empty picture means remove, as upstream builds it', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.newsletterUpdate(JID, { picture: '' })
+
+		expect(calls.map(c => c[0])).toEqual(['newsletterMetadata', 'newsletterRemovePicture'])
+	})
+
+	it('a base64 picture is decoded to bytes, not forwarded as a string', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.newsletterUpdate(JID, { picture: Buffer.from('JPEGBYTES').toString('base64') })
+
+		const setCall = calls.find(c => c[0] === 'newsletterSetPicture')!
+		expect(Buffer.from(setCall[1][1] as Uint8Array).toString()).toBe('JPEGBYTES')
+	})
+})
+
+describe('newsletterAdminCount reports an absent count as absent', () => {
+	it('returns the count when the server sent one', async () => {
+		const { methods } = makeHarness({ newsletterAdminInfo: async () => ({ adminCount: 3 }) })
+
+		expect(await methods.newsletterAdminCount(JID)).toBe(3)
+	})
+
+	it('rejects rather than returning 0, which would read as "no admins"', async () => {
+		const { methods } = makeHarness({ newsletterAdminInfo: async () => ({}) })
+
+		await expect(methods.newsletterAdminCount(JID)).rejects.toThrow(/did not return an admin count/)
+	})
+})
+
+describe('newsletterFetchMessages refuses the paging arguments it cannot honour', () => {
+	it('`since` rejects instead of being dropped', async () => {
+		const { calls, methods } = makeHarness()
+
+		await expect(methods.newsletterFetchMessages(JID, 10, 1700000000)).rejects.toThrow(/`since` is not supported/)
+		expect(calls).toEqual([])
+	})
+
+	it('`after` rejects instead of being mapped to a cursor that pages the other way', async () => {
+		const { calls, methods } = makeHarness()
+
+		await expect(methods.newsletterFetchMessages(JID, 10, 0, 99)).rejects.toThrow(/`after` is not supported/)
+		expect(calls).toEqual([])
+	})
+})
+
+describe('subscribeNewsletterUpdates and newsletterSubscribers shape their results', () => {
+	it('the live-update duration comes back as upstream types it, a string', async () => {
+		const { methods } = makeHarness({ newsletterSubscribeLiveUpdates: async () => 300 })
+
+		expect(await methods.subscribeNewsletterUpdates(JID)).toEqual({ duration: '300' })
+	})
+
+	it('subscribers reads the count off the metadata', async () => {
+		const { methods } = makeHarness()
+
+		expect(await methods.newsletterSubscribers(JID)).toEqual({ subscribers: 42 })
+	})
+})
+
+describe('the neutral metadata is translated into upstream field names', () => {
+	it('renames every field upstream expects', async () => {
+		expect(bridgeNewsletterMetadataToBaileys(METADATA)).toEqual({
+			id: JID,
+			name: 'Channel',
+			description: 'A channel',
+			invite: 'INVITE123',
+			creation_time: 1700000000,
+			subscribers: 42,
+			verification: 'VERIFIED',
+			picture: { url: 'https://example.invalid/pic.jpg' }
+		})
+	})
+
+	it('screams the verification value, which the core spells in camel case', () => {
+		expect(bridgeNewsletterMetadataToBaileys({ ...METADATA, verification: 'Unverified' }).verification).toBe(
+			'UNVERIFIED'
+		)
+	})
+
+	it('leaves a verification the core has not named undefined rather than inventing one', () => {
+		expect(bridgeNewsletterMetadataToBaileys({ ...METADATA, verification: 'SomethingNew' }).verification).toBe(
+			undefined
+		)
+	})
+
+	it('omits the fields the bridge result has no source for', () => {
+		const mapped = bridgeNewsletterMetadataToBaileys(METADATA)
+
+		// `state` is the newsletter's lifecycle, not a mute, so mute_state stays
+		// absent rather than being filled from the wrong field.
+		expect(mapped.mute_state).toBe(undefined)
+		expect(mapped.owner).toBe(undefined)
+		expect(mapped.reaction_codes).toBe(undefined)
+	})
+})
+
+describe('newsletter methods do not swallow a bridge failure', () => {
+	it('a rejection propagates', async () => {
+		const { methods } = makeHarness({
+			newsletterDelete: async () => {
+				throw new Error('server error 403: forbidden')
+			}
+		})
+
+		await expect(methods.newsletterDelete(JID)).rejects.toThrow(/server error 403/)
+	})
+})


### PR DESCRIPTION
## Summary

Fifteen methods that did not exist, plus the three signatures that did not match, all delegating to the bridge. The neutral to Baileys translation lives in `src/Compatibility/newsletter-results.ts`.

New: `newsletterAdminCount`, `newsletterChangeOwner`, `newsletterDelete`, `newsletterDemote`, `newsletterFetchMessages`, `newsletterFollow`, `newsletterRemovePicture`, `newsletterSubscribers`, `newsletterUnfollow`, `newsletterUnmute`, `newsletterUpdate`, `newsletterUpdateDescription`, `newsletterUpdateName`, `newsletterUpdatePicture`, `subscribeNewsletterUpdates`.

## Breaking

Three public shapes changed. Pre-1.0, and each is a fix rather than a preference.

**`newsletterMetadata(jid)` becomes `newsletterMetadata(type, key)`.** This is the one that matters. Code written against upstream calls `newsletterMetadata('jid', id)`, and the old signature read that as a newsletter whose JID is the literal string `'jid'`. It type checked on the caller's side and failed against the server, which is the worst kind of incompatibility and why it outranks any missing method.

Migration: `newsletterMetadata(jid)` becomes `newsletterMetadata('jid', jid)`.

A real gain comes with it: the `'invite'` path now works. The core has a lookup per key kind (`newsletterMetadata`, `newsletterMetadataByInvite`), and choosing between them on a discriminator is exactly the translation this layer exists for.

**`newsletterMute(jid, mute)` splits into `newsletterMute(jid)` and `newsletterUnmute(jid)`**, as upstream has them.

Migration: `newsletterMute(jid, true)` becomes `newsletterMute(jid)`; `newsletterMute(jid, false)` becomes `newsletterUnmute(jid)`.

Both route to `newsletterFollowerMute`, not to the bridge's ambiguous `newsletterMute` alias. The core has two newsletter mutes: follower activity, which is what a subscriber toggles, and admin activity, which is a different control for owners and admins. Upstream's is the subscriber one, so the explicit spelling is used to make that choice visible instead of resting on an alias.

**`newsletterCreate` returns `NewsletterMetadata`** in upstream's field names, not the bridge's `NewsletterMetadataResult`. Field renames: `jid` to `id`, `subscriberCount` to `subscribers`, `inviteCode` to `invite`, `creationTime` to `creation_time`, `pictureUrl` to `picture.url`.

## Layer classification

Every item is **(a)**, implementable here by delegation. Nothing needed the core or the bridge, and no gap prompt was opened. That matches the prompt's expectation after bridge 0.7.0.

| upstream | bridge | note |
|---|---|---|
| `newsletterCreate` | `newsletterCreate` | result mapped |
| `newsletterMetadata('jid'\|'invite', key)` | `newsletterMetadata` / `newsletterMetadataByInvite` | dispatch on the discriminator |
| `newsletterUpdate` | `newsletterUpdate` + `newsletterSetPicture` / `newsletterRemovePicture` | see picture note |
| `newsletterUpdateName` / `newsletterUpdateDescription` | `newsletterUpdate(jid, name, description)` | one field, other null |
| `newsletterUpdatePicture` | `newsletterSetPicture` | via `generateProfilePicture` |
| `newsletterRemovePicture` | `newsletterRemovePicture` | |
| `newsletterFollow` / `newsletterUnfollow` | `newsletterSubscribe` / `newsletterUnsubscribe` | |
| `newsletterMute` / `newsletterUnmute` | `newsletterFollowerMute(jid, bool)` | |
| `newsletterSubscribers` | `newsletterMetadata(jid).subscriberCount` | upstream returns a count, not a list |
| `newsletterFetchMessages` | `newsletterMessages` | see refusal note |
| `subscribeNewsletterUpdates` | `newsletterSubscribeLiveUpdates` | number wrapped as upstream's `{ duration: string }` |
| `newsletterAdminCount` | `newsletterAdminInfo(jid).adminCount` | a field, not an operation; see note |
| `newsletterChangeOwner` | `newsletterChangeOwner` | |
| `newsletterDemote` | `newsletterDemoteAdmin` | |
| `newsletterDelete` | `newsletterDelete` | |

## Three places the shapes do not line up

**`newsletterAdminCount` when the server omits the count.** It rides on the admin-info result and is optional there. It rejects rather than returning `0`, because `0` reads as "no admins", which no newsletter can be, and a caller acting on that would draw the wrong conclusion silently.

**`newsletterFetchMessages(jid, count, since, after)` refuses `since` and `after` by name.** I checked the core rather than mapping by resemblance: `get_messages` builds `<messages count before>` and has no time filter. Upstream's `after` pages forward from a point; the core's `before` pages backward from one. They are opposite directions, so mapping `after` onto `before` would return a plausible wrong page, which is worse than refusing. `count` works, which covers the common call.

**Four `NewsletterMetadata` fields have no source and stay absent**: `owner` (the bridge result carries the viewer's own role, not the owner's JID), `mute_state`, `reaction_codes`, `thread_metadata`. `state` was the tempting wrong answer for `mute_state`: it is the newsletter's lifecycle, `Active`/`Suspended`/`Geosuspended`, not a mute.

This also settles a question left open in #26. The bridge sends `verification` in the core's camel case (`Verified`), while upstream's type is `'VERIFIED' | 'UNVERIFIED'`. The mapper writes the pairs out rather than upper-casing blindly, so a variant the core adds later arrives as `undefined` instead of as a string nobody declared.

## Deferred

Nothing. No gap prompt was written for the bridge or the core.

Out of scope by the task's own boundary and untouched: channel directory, recommendations, insights, admin invites, pinning a message.

## Coverage

`npm run compat:audit` before: **97.15% (21717/22354)**
after: **97.34% (21759/22354)**

Missing dropped sharply: functions 243 to 198, fields 235 to 190.

Mismatches rose (functions 70 to 94, fields 27 to 51) and that needs an honest explanation rather than being left to look like damage. They are the return types, and every one is **stronger** than upstream's:

```
newsletterFollow    expected (jid: string) => Promise<unknown>
                    actual   (jid: string) => Promise<NewsletterMetadata>
newsletterUnfollow  expected (jid: string) => Promise<unknown>
                    actual   (jid: string) => Promise<void>
```

Upstream types most of these `Promise<unknown>` because its MEX executor returns an unparsed result. Returning the parsed metadata is assignable to `unknown`, so code written against upstream compiles and runs unchanged; only the auditor's string comparison counts it as a difference. `newsletterFetchMessages` is the same story with `Promise<any>` against `Promise<NewsletterMessageResult[]>`, plus optional-vs-required on the two parameters it refuses.

Making these `Promise<unknown>` would score better and be worse to use. Leaving them is the deliberate choice; the signature-mismatch task is where this class of item gets triaged in bulk.

## Validation

- `npm run format`
- `npm run lint` (`tsc` plus `oxlint`)
- `npm test`: 698 tests, 0 failures, up from 666, with no existing test adapted
- `npm run compat:audit`

Not run: `npm run test:e2e`, which needs a mock server this environment does not have.

Mutation checked by making the edit and running the suite, not by reading the assertions:

- making `newsletterMetadata` ignore `type` and always look up by JID fails 1 test
- letting `newsletterAdminCount` fall back to `0` fails 1 test
- mapping `after` onto the `before` cursor instead of refusing fails 1 test

---
_Generated by [Claude Code](https://claude.ai/code/session_019n5h4gDvrNFW4nCnf2YpMw)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the upstream newsletter API: adds 15 missing methods, fixes 3 signatures, and aligns results to upstream types. Keeps legacy subscribe/unsubscribe, optimizes picture-only updates, and rejects unsupported paging flags.

- **New Features**
  - Added: `newsletterAdminCount`, `newsletterChangeOwner`, `newsletterDelete`, `newsletterDemote`, `newsletterFetchMessages`, `newsletterFollow`, `newsletterRemovePicture`, `newsletterSubscribers`, `newsletterUnfollow`, `newsletterUnmute`, `newsletterUpdate`, `newsletterUpdateDescription`, `newsletterUpdateName`, `newsletterUpdatePicture`, `subscribeNewsletterUpdates`.
  - Map bridge metadata to upstream in `src/Compatibility/newsletter-results.ts`; support `newsletterMetadata('invite', code)`.
  - `newsletterFetchMessages` rejects non-zero `since`/`after` (zeros pass), `subscribeNewsletterUpdates` returns `{ duration: string }`, `newsletterAdminCount` throws if the server omits the count.
  - `newsletterUpdate({ picture })` skips an extra metadata read; picture writes already return refreshed metadata.

- **Migration**
  - `newsletterMetadata(jid)` → `newsletterMetadata('jid', jid)`; also enables `newsletterMetadata('invite', code)`.
  - `newsletterMute(jid, true|false)` → `newsletterMute(jid)` and `newsletterUnmute(jid)` (maps to follower-activity mute).
  - `newsletterCreate` now returns upstream `NewsletterMetadata` field names: `jid`→`id`, `subscriberCount`→`subscribers`, `inviteCode`→`invite`, `creationTime`→`creation_time`, `pictureUrl`→`picture.url`.
  - No change if you use `newsletterSubscribe`/`newsletterUnsubscribe`; they remain. `newsletterSubscribe` keeps the bridge result shape; use `newsletterFollow` for upstream field names.

<sup>Written for commit e5b5be28ba1cf63bbef83a2b0060569d19ec5992. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

