### PR TITLE
feat(business): add catalog and business profile surface

### DIFF
--- a/src/Socket/business.ts
+++ b/src/Socket/business.ts
@@ -1,12 +1,8 @@
-import type {
-	CatalogResult,
-	CollectionsResult,
-	OrderResult,
-	BusinessProfileUpdateInput
-} from '@oxidezap/whatsapp-rust-bridge'
-import type { GetCatalogOptions } from '../Types/Product.ts'
+import type { OrderResult, BusinessProfileUpdateInput } from '@oxidezap/whatsapp-rust-bridge'
+import type { CatalogPage, CollectionsPage, GetCatalogOptions } from '../Types/Product.ts'
 import type { UpdateBussinesProfileProps } from '../Types/Bussines.ts'
 import { Boom } from '../Utils/boom.ts'
+import { jidNormalizedUser } from '../WABinary/jid-utils.ts'
 import type { SocketContext } from './types.ts'
 
 /**
@@ -37,19 +33,34 @@ const minutesPastMidnight = (value: string, which: 'open' | 'close'): number => 
 	return minutes
 }
 
+/**
+ * Both catalog reads take an optional jid and mean "mine" without one, as
+ * upstream does. Only a socket that has not finished logging in has no
+ * identity to fall back on, and that is worth saying rather than sending an
+ * empty jid the server would reject.
+ */
+const catalogSubject = (method: string, ctx: SocketContext, jid?: string): string => {
+	const subject = jidNormalizedUser(jid || ctx.getUser()?.id)
+	if (!subject) {
+		throw new Boom(
+			`${method}: no jid was given and the socket is not logged in yet, so there is no own catalog to read`,
+			{
+				statusCode: 400
+			}
+		)
+	}
+	return subject
+}
+
 export const makeBusinessMethods = (ctx: SocketContext) => ({
-	getCatalog: async ({ jid, limit, cursor }: GetCatalogOptions): Promise<CatalogResult> => {
-		if (!jid) {
-			throw new Boom('getCatalog: jid is required', { statusCode: 400 })
-		}
-		return await (await ctx.getClient()).getCatalog(jid, { limit, after: cursor })
+	getCatalog: async ({ jid, limit, cursor }: GetCatalogOptions): Promise<CatalogPage> => {
+		const subject = catalogSubject('getCatalog', ctx, jid)
+		return await (await ctx.getClient()).getCatalog(subject, { limit, after: cursor })
 	},
 
-	getCollections: async (jid?: string, limit?: number): Promise<CollectionsResult> => {
-		if (!jid) {
-			throw new Boom('getCollections: jid is required', { statusCode: 400 })
-		}
-		return await (await ctx.getClient()).getCollections(jid, { collectionLimit: limit })
+	getCollections: async (jid?: string, limit?: number): Promise<CollectionsPage> => {
+		const subject = catalogSubject('getCollections', ctx, jid)
+		return await (await ctx.getClient()).getCollections(subject, { collectionLimit: limit })
 	},
 
 	/**

--- a/src/Socket/business.ts
+++ b/src/Socket/business.ts
@@ -35,15 +35,15 @@ const minutesPastMidnight = (value: string, which: 'open' | 'close'): number => 
 
 /**
  * Both catalog reads take an optional jid and mean "mine" without one, as
- * upstream does. Only a socket that has not finished logging in has no
- * identity to fall back on, and that is worth saying rather than sending an
- * empty jid the server would reject.
+ * upstream does. `getMe` rather than `getUser`, because it reads through to the
+ * persisted credentials, which is the same place upstream reads from and is
+ * populated before the socket finishes its own initialisation.
  */
 const catalogSubject = (method: string, ctx: SocketContext, jid?: string): string => {
-	const subject = jidNormalizedUser(jid || ctx.getUser()?.id)
+	const subject = jidNormalizedUser(jid || ctx.getMe()?.id)
 	if (!subject) {
 		throw new Boom(
-			`${method}: no jid was given and the socket is not logged in yet, so there is no own catalog to read`,
+			`${method}: no jid was given and there is no authenticated account, so there is no own catalog to read`,
 			{
 				statusCode: 400
 			}

--- a/src/Socket/business.ts
+++ b/src/Socket/business.ts
@@ -22,6 +22,21 @@ const noProductWriteRoute = (method: string): never => {
 	)
 }
 
+/**
+ * Upstream types these as strings, so an empty one is reachable from an
+ * unfilled form. `Number('')` is midnight, which would quietly rewrite the
+ * schedule instead of being refused.
+ */
+const minutesPastMidnight = (value: string, which: 'open' | 'close'): number => {
+	const minutes = Number(value)
+	if (value.trim() === '' || !Number.isInteger(minutes) || minutes < 0 || minutes > 1440) {
+		throw new Boom(`updateBussinesProfile: ${which} time '${value}' is not a count of minutes past midnight`, {
+			statusCode: 400
+		})
+	}
+	return minutes
+}
+
 export const makeBusinessMethods = (ctx: SocketContext) => ({
 	getCatalog: async ({ jid, limit, cursor }: GetCatalogOptions): Promise<CatalogResult> => {
 		if (!jid) {
@@ -68,8 +83,10 @@ export const makeBusinessMethods = (ctx: SocketContext) => ({
 							config: args.hours.days.map(day => ({
 								dayOfWeek: day.day,
 								mode: day.mode,
-								openTime: day.mode === 'specific_hours' ? Number(day.openTimeInMinutes) : undefined,
-								closeTime: day.mode === 'specific_hours' ? Number(day.closeTimeInMinutes) : undefined
+								openTime:
+									day.mode === 'specific_hours' ? minutesPastMidnight(day.openTimeInMinutes, 'open') : undefined,
+								closeTime:
+									day.mode === 'specific_hours' ? minutesPastMidnight(day.closeTimeInMinutes, 'close') : undefined
 							}))
 						}
 					}

--- a/src/Socket/business.ts
+++ b/src/Socket/business.ts
@@ -1,0 +1,103 @@
+import type {
+	CatalogResult,
+	CollectionsResult,
+	OrderResult,
+	BusinessProfileUpdateInput
+} from '@oxidezap/whatsapp-rust-bridge'
+import type { GetCatalogOptions } from '../Types/Product.ts'
+import type { UpdateBussinesProfileProps } from '../Types/Bussines.ts'
+import { Boom } from '../Utils/boom.ts'
+import type { SocketContext } from './types.ts'
+
+/**
+ * Product create, update and delete exist only in Baileys: the operations they
+ * send appear in no WhatsApp Web bundle. Declared so a migrating caller reads
+ * why instead of a bare TypeError, and rejecting because there is nothing to
+ * call.
+ */
+const noProductWriteRoute = (method: string): never => {
+	throw new Boom(
+		`${method} is not supported: the WhatsApp Web client has no product create, edit or delete operation, so there is nothing for this to call. Manage the catalog from the WhatsApp Business app.`,
+		{ statusCode: 501 }
+	)
+}
+
+export const makeBusinessMethods = (ctx: SocketContext) => ({
+	getCatalog: async ({ jid, limit, cursor }: GetCatalogOptions): Promise<CatalogResult> => {
+		if (!jid) {
+			throw new Boom('getCatalog: jid is required', { statusCode: 400 })
+		}
+		return await (await ctx.getClient()).getCatalog(jid, { limit, after: cursor })
+	},
+
+	getCollections: async (jid?: string, limit?: number): Promise<CollectionsResult> => {
+		if (!jid) {
+			throw new Boom('getCollections: jid is required', { statusCode: 400 })
+		}
+		return await (await ctx.getClient()).getCollections(jid, { collectionLimit: limit })
+	},
+
+	/**
+	 * `sellerJid` is not in upstream's signature because upstream reads orders
+	 * over the legacy `fb:thrift_iq` route, which addresses the server. The
+	 * route the real client uses is a MEX query keyed by the seller, so the JID
+	 * is required here. It is on the order message the token came from.
+	 */
+	getOrderDetails: async (orderId: string, tokenBase64: string, sellerJid?: string): Promise<OrderResult> => {
+		if (!sellerJid) {
+			throw new Boom(
+				'getOrderDetails: a third argument with the seller jid is required, because orders are read through a query keyed by the business rather than the legacy server-addressed one',
+				{ statusCode: 400 }
+			)
+		}
+		return await (await ctx.getClient()).getOrder(sellerJid, orderId, tokenBase64)
+	},
+
+	updateBussinesProfile: async (args: UpdateBussinesProfileProps): Promise<void> => {
+		const update: BusinessProfileUpdateInput = {
+			address: args.address,
+			description: args.description,
+			email: args.email,
+			websites: args.websites,
+			...(args.hours !== undefined
+				? {
+						businessHours: {
+							timezone: args.hours.timezone,
+							// Minutes past midnight as a number; upstream types the two
+							// as strings and the core rejects them on the other modes.
+							config: args.hours.days.map(day => ({
+								dayOfWeek: day.day,
+								mode: day.mode,
+								openTime: day.mode === 'specific_hours' ? Number(day.openTimeInMinutes) : undefined,
+								closeTime: day.mode === 'specific_hours' ? Number(day.closeTimeInMinutes) : undefined
+							}))
+						}
+					}
+				: {})
+		}
+		await (await ctx.getClient()).updateBusinessProfile(update)
+	},
+
+	/**
+	 * Declared but not callable end to end. The core and the bridge take the
+	 * `{fbid, meta_hmac, ts}` receipt of a cover photo upload, and this
+	 * package's upload path cannot produce one: it requires a url and a
+	 * direct path, which that endpoint does not return.
+	 */
+	updateCoverPhoto: async (_photo: unknown): Promise<never> => {
+		throw new Boom(
+			'updateCoverPhoto is not available yet: the cover photo upload returns an {fbid, meta_hmac, ts} receipt that this package cannot obtain. removeCoverPhoto works.',
+			{ statusCode: 501 }
+		)
+	},
+
+	removeCoverPhoto: async (id: string): Promise<void> => {
+		await (await ctx.getClient()).removeBusinessCoverPhoto(id)
+	},
+
+	productCreate: async (_create: unknown): Promise<never> => noProductWriteRoute('productCreate'),
+
+	productUpdate: async (_productId: string, _update: unknown): Promise<never> => noProductWriteRoute('productUpdate'),
+
+	productDelete: async (_productIds: string[]): Promise<never> => noProductWriteRoute('productDelete')
+})

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -42,6 +42,7 @@ import { wrapLegacyStore } from '../Utils/wrap-legacy-store.ts'
 import { assertNodeErrorFree } from '../WABinary/generic-utils.ts'
 import type { proto } from '../WAProto/runtime.ts'
 import { makeBlockingMethods } from './blocking.ts'
+import { makeBusinessMethods } from './business.ts'
 import { makeChatActionMethods } from './chat-actions.ts'
 import { makeContactMethods } from './contacts.ts'
 import { makeCommunityMethods } from './communities.ts'
@@ -951,6 +952,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		...makePresenceMethods(ctx),
 		...makeBlockingMethods(ctx),
 		...makeNewsletterMethods(ctx),
+		...makeBusinessMethods(ctx),
 		downloadMedia: async <T extends 'buffer' | 'stream'>(
 			message: WAMessage,
 			type: T,

--- a/src/Types/Product.ts
+++ b/src/Types/Product.ts
@@ -1,4 +1,16 @@
+import type { CatalogResult as CatalogPageResult, CollectionsResult } from '@oxidezap/whatsapp-rust-bridge'
+
 import type { WAMediaUpload } from './Message.ts'
+
+/**
+ * What `getCatalog` returns, under a name of its own. The `CatalogResult`
+ * below is the raw catalog envelope and is a different shape, so a consumer
+ * typing the call has one name to reach for and it is this one.
+ */
+export type CatalogPage = CatalogPageResult
+
+/** As `CatalogPage`, for `getCollections`. */
+export type CollectionsPage = CollectionsResult
 
 export type CatalogResult = {
 	data: {

--- a/src/__tests__/business-compatibility.test.ts
+++ b/src/__tests__/business-compatibility.test.ts
@@ -34,7 +34,7 @@ const logger = {
 	error: () => undefined
 } as ILogger
 
-const makeHarness = (overrides: Record<string, unknown> = {}) => {
+const makeHarness = (overrides: Record<string, unknown> = {}, ownId?: string) => {
 	const calls: Array<[string, unknown[]]> = []
 	const client = new Proxy({} as Record<string, unknown>, {
 		get: (_t, prop) => {
@@ -49,6 +49,7 @@ const makeHarness = (overrides: Record<string, unknown> = {}) => {
 	const ctx = {
 		ev: new EventEmitter(),
 		logger,
+		getUser: () => (ownId === undefined ? undefined : { id: ownId }),
 		getClient: async () => client
 	} as unknown as SocketContext
 	return { calls, methods: makeBusinessMethods(ctx) }
@@ -71,14 +72,27 @@ describe('the reads delegate with the options the bridge takes', () => {
 		expect(calls).toEqual([['getCollections', [SELLER, { collectionLimit: 5 }]]])
 	})
 
+	/**
+	 * Upstream reads the caller's own catalog when the jid is left out, and the
+	 * own id it falls back to carries a device suffix that the catalog query
+	 * does not take.
+	 */
 	for (const [label, run] of [
 		['getCatalog', (m: ReturnType<typeof makeHarness>['methods']) => m.getCatalog({ limit: 1 })],
 		['getCollections', (m: ReturnType<typeof makeHarness>['methods']) => m.getCollections()]
 	] as const) {
-		it(`${label} rejects without a jid rather than querying the wrong account`, async () => {
+		it(`${label} without a jid reads the account's own catalog`, async () => {
+			const { calls, methods } = makeHarness({}, '15559990000:7@s.whatsapp.net')
+
+			await run(methods)
+
+			expect(calls[0]![1][0]).toBe('15559990000@s.whatsapp.net')
+		})
+
+		it(`${label} rejects when there is no jid and no identity to fall back on`, async () => {
 			const { calls, methods } = makeHarness()
 
-			await expect(run(methods)).rejects.toThrow(/jid is required/)
+			await expect(run(methods)).rejects.toThrow(/not logged in yet/)
 			expect(calls).toEqual([])
 		})
 	}

--- a/src/__tests__/business-compatibility.test.ts
+++ b/src/__tests__/business-compatibility.test.ts
@@ -49,7 +49,7 @@ const makeHarness = (overrides: Record<string, unknown> = {}, ownId?: string) =>
 	const ctx = {
 		ev: new EventEmitter(),
 		logger,
-		getUser: () => (ownId === undefined ? undefined : { id: ownId }),
+		getMe: () => (ownId === undefined ? undefined : { id: ownId }),
 		getClient: async () => client
 	} as unknown as SocketContext
 	return { calls, methods: makeBusinessMethods(ctx) }
@@ -73,9 +73,10 @@ describe('the reads delegate with the options the bridge takes', () => {
 	})
 
 	/**
-	 * Upstream reads the caller's own catalog when the jid is left out, and the
-	 * own id it falls back to carries a device suffix that the catalog query
-	 * does not take.
+	 * Upstream reads the caller's own catalog when the jid is left out, from the
+	 * persisted credentials rather than the socket's own initialisation, so a
+	 * restored session can call it right away. The id there carries a device
+	 * suffix that the catalog query does not take.
 	 */
 	for (const [label, run] of [
 		['getCatalog', (m: ReturnType<typeof makeHarness>['methods']) => m.getCatalog({ limit: 1 })],
@@ -89,10 +90,10 @@ describe('the reads delegate with the options the bridge takes', () => {
 			expect(calls[0]![1][0]).toBe('15559990000@s.whatsapp.net')
 		})
 
-		it(`${label} rejects when there is no jid and no identity to fall back on`, async () => {
+		it(`${label} rejects when there is no jid and no account to fall back on`, async () => {
 			const { calls, methods } = makeHarness()
 
-			await expect(run(methods)).rejects.toThrow(/not logged in yet/)
+			await expect(run(methods)).rejects.toThrow(/no authenticated account/)
 			expect(calls).toEqual([])
 		})
 	}

--- a/src/__tests__/business-compatibility.test.ts
+++ b/src/__tests__/business-compatibility.test.ts
@@ -186,6 +186,29 @@ describe('updateBussinesProfile carries every field the delta has', () => {
 	})
 })
 
+describe('an unusable opening-hour time is refused, not read as midnight', () => {
+	for (const [label, open, close] of [
+		['empty', '', '1080'],
+		['blank', '   ', '1080'],
+		['not a number', 'nine', '1080'],
+		['out of range', '540', '5000']
+	] as const) {
+		it(`${label} rejects`, async () => {
+			const { calls, methods } = makeHarness()
+
+			await expect(
+				methods.updateBussinesProfile({
+					hours: {
+						timezone: 'America/Sao_Paulo',
+						days: [{ day: 'mon', mode: 'specific_hours', openTimeInMinutes: open, closeTimeInMinutes: close }]
+					}
+				})
+			).rejects.toThrow(/is not a count of minutes past midnight/)
+			expect(calls).toEqual([])
+		})
+	}
+})
+
 describe('removeCoverPhoto works and updateCoverPhoto says what is missing', () => {
 	it('remove delegates', async () => {
 		const { calls, methods } = makeHarness()

--- a/src/__tests__/business-compatibility.test.ts
+++ b/src/__tests__/business-compatibility.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Catalog, collections, orders and the business profile.
+ *
+ * Two things here are not delegation and are the reason the file exists.
+ *
+ * Money never becomes a `number`. The bridge sends `amount1000` as a decimal
+ * string of thousandths, and above 2^53 thousandths a `number` stops being
+ * exact. Upstream types price as `number`; matching that would make a large
+ * order silently wrong, so the string travels through untouched.
+ *
+ * The three product write methods reject. Not "not ported yet": the operations
+ * upstream sends for them appear in no WhatsApp Web bundle, so there is no
+ * route to delegate to and there never will be.
+ */
+
+import { EventEmitter } from 'node:events'
+import { describe, it } from 'node:test'
+import type { CatalogResult, OrderResult, WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+
+import { makeBusinessMethods } from '../Socket/business.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import type { ILogger } from '../Utils/logger.ts'
+import { expect } from './expect.ts'
+
+const SELLER = '15551230000@s.whatsapp.net'
+
+const logger = {
+	level: 'silent',
+	child: () => logger,
+	trace: () => undefined,
+	debug: () => undefined,
+	info: () => undefined,
+	warn: () => undefined,
+	error: () => undefined
+} as ILogger
+
+const makeHarness = (overrides: Record<string, unknown> = {}) => {
+	const calls: Array<[string, unknown[]]> = []
+	const client = new Proxy({} as Record<string, unknown>, {
+		get: (_t, prop) => {
+			if (typeof prop !== 'string' || prop === 'then') return undefined
+			if (prop in overrides) return overrides[prop]
+			return async (...args: unknown[]) => {
+				calls.push([prop, args])
+				return undefined
+			}
+		}
+	}) as unknown as WasmWhatsAppClient
+	const ctx = {
+		ev: new EventEmitter(),
+		logger,
+		getClient: async () => client
+	} as unknown as SocketContext
+	return { calls, methods: makeBusinessMethods(ctx) }
+}
+
+describe('the reads delegate with the options the bridge takes', () => {
+	it('getCatalog maps upstream cursor onto the after cursor', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.getCatalog({ jid: SELLER, limit: 10, cursor: 'CURSOR1' })
+
+		expect(calls).toEqual([['getCatalog', [SELLER, { limit: 10, after: 'CURSOR1' }]]])
+	})
+
+	it('getCollections maps limit onto the collection limit', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.getCollections(SELLER, 5)
+
+		expect(calls).toEqual([['getCollections', [SELLER, { collectionLimit: 5 }]]])
+	})
+
+	for (const [label, run] of [
+		['getCatalog', (m: ReturnType<typeof makeHarness>['methods']) => m.getCatalog({ limit: 1 })],
+		['getCollections', (m: ReturnType<typeof makeHarness>['methods']) => m.getCollections()]
+	] as const) {
+		it(`${label} rejects without a jid rather than querying the wrong account`, async () => {
+			const { calls, methods } = makeHarness()
+
+			await expect(run(methods)).rejects.toThrow(/jid is required/)
+			expect(calls).toEqual([])
+		})
+	}
+})
+
+/**
+ * Upstream reads an order over the legacy server-addressed route, so its
+ * signature has no seller. The route the real client uses is keyed by the
+ * business, so the JID is needed and the shortfall is reported rather than
+ * guessed at.
+ */
+describe('getOrderDetails needs the seller the modern route is keyed by', () => {
+	it('passes seller, order and token in the order the bridge takes them', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.getOrderDetails('ORDER1', 'TOKEN1', SELLER)
+
+		expect(calls).toEqual([['getOrder', [SELLER, 'ORDER1', 'TOKEN1']]])
+	})
+
+	it('rejects when called with only upstream two arguments, and says why', async () => {
+		const { calls, methods } = makeHarness()
+
+		await expect(methods.getOrderDetails('ORDER1', 'TOKEN1')).rejects.toThrow(/seller jid is required/)
+		expect(calls).toEqual([])
+	})
+})
+
+describe('money crosses as a string and stays one', () => {
+	// 9007199254740993 thousandths is 2^53 + 1: the first integer a double
+	// cannot represent, so a Number() anywhere on this path loses it.
+	const UNSAFE = '9007199254740993'
+
+	it('a catalog price survives a value that a number could not hold', async () => {
+		const catalog: CatalogResult = {
+			products: [{ id: 'p1', price: { amount1000: UNSAFE, currency: 'BRL' }, images: [], videos: [] }]
+		}
+		const { methods } = makeHarness({ getCatalog: async () => catalog })
+
+		const result = await methods.getCatalog({ jid: SELLER })
+
+		expect(result.products[0]!.price!.amount1000).toBe(UNSAFE)
+		expect(typeof result.products[0]!.price!.amount1000).toBe('string')
+		// The round trip a Number() would have made lossy.
+		expect(String(Number(UNSAFE))).toBe('9007199254740992')
+	})
+
+	it('an order total survives the same value', async () => {
+		const order: OrderResult = {
+			products: [],
+			priceDetails: { currency: 'BRL', total: { amount1000: UNSAFE, currency: 'BRL' } }
+		}
+		const { methods } = makeHarness({ getOrder: async () => order })
+
+		const result = await methods.getOrderDetails('ORDER1', 'TOKEN1', SELLER)
+
+		expect(result.priceDetails!.total!.amount1000).toBe(UNSAFE)
+	})
+})
+
+describe('updateBussinesProfile carries every field the delta has', () => {
+	it('forwards the plain fields', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.updateBussinesProfile({
+			address: 'Rua 1',
+			description: 'Loja',
+			email: 'a@b.invalid',
+			websites: ['https://example.invalid']
+		})
+
+		expect(calls).toEqual([
+			[
+				'updateBusinessProfile',
+				[
+					{
+						address: 'Rua 1',
+						description: 'Loja',
+						email: 'a@b.invalid',
+						websites: ['https://example.invalid']
+					}
+				]
+			]
+		])
+	})
+
+	it('converts opening hours, and sends times only for the mode that takes them', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.updateBussinesProfile({
+			hours: {
+				timezone: 'America/Sao_Paulo',
+				days: [
+					{ day: 'mon', mode: 'specific_hours', openTimeInMinutes: '540', closeTimeInMinutes: '1080' },
+					{ day: 'sun', mode: 'open_24h' }
+				]
+			}
+		})
+
+		const update = (calls[0]![1][0] as { businessHours: { config: unknown[] } }).businessHours
+		expect(update.config).toEqual([
+			{ dayOfWeek: 'mon', mode: 'specific_hours', openTime: 540, closeTime: 1080 },
+			{ dayOfWeek: 'sun', mode: 'open_24h', openTime: undefined, closeTime: undefined }
+		])
+	})
+})
+
+describe('removeCoverPhoto works and updateCoverPhoto says what is missing', () => {
+	it('remove delegates', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.removeCoverPhoto('COVER1')
+
+		expect(calls).toEqual([['removeBusinessCoverPhoto', ['COVER1']]])
+	})
+
+	it('update rejects naming the receipt this package cannot obtain', async () => {
+		const { calls, methods } = makeHarness()
+
+		await expect(methods.updateCoverPhoto(Buffer.from('jpeg'))).rejects.toThrow(/meta_hmac/)
+		expect(calls).toEqual([])
+	})
+})
+
+/**
+ * These three are not pending work. `product_catalog_add`, `_edit` and
+ * `_delete` appear in no WhatsApp Web bundle, so the message has to say "will
+ * not" rather than "not yet", or the next reader files it as a gap to close.
+ */
+describe('the product write methods reject, and say the route does not exist', () => {
+	for (const [label, run] of [
+		['productCreate', (m: ReturnType<typeof makeHarness>['methods']) => m.productCreate({})],
+		['productUpdate', (m: ReturnType<typeof makeHarness>['methods']) => m.productUpdate('p1', {})],
+		['productDelete', (m: ReturnType<typeof makeHarness>['methods']) => m.productDelete(['p1'])]
+	] as const) {
+		it(`${label} rejects`, async () => {
+			const { calls, methods } = makeHarness()
+
+			await expect(run(methods)).rejects.toThrow(/has no product create, edit or delete operation/)
+			expect(calls).toEqual([])
+		})
+	}
+})
+
+describe('business methods do not swallow a bridge failure', () => {
+	it('a rejection propagates', async () => {
+		const { methods } = makeHarness({
+			getCatalog: async () => {
+				throw new Error('server error 403: forbidden')
+			}
+		})
+
+		await expect(methods.getCatalog({ jid: SELLER })).rejects.toThrow(/server error 403/)
+	})
+})


### PR DESCRIPTION
## Summary

Six of the nine methods delegate to the bridge. Three reject, because there is nothing to delegate to and never will be.

Working: `getCatalog`, `getCollections`, `getOrderDetails`, `updateBussinesProfile` (upstream's spelling), `removeCoverPhoto`.
Declared and rejecting: `productCreate`, `productUpdate`, `productDelete`, `updateCoverPhoto`.

## Layer classification

| method | class | note |
|---|---|---|
| `getCatalog` | **(a)** | `getCatalog(jid, {limit, after})` |
| `getCollections` | **(a)** | `getCollections(jid, {collectionLimit})` |
| `getOrderDetails` | **(a)**, signature widened | `getOrder(sellerJid, orderId, token)`, see below |
| `updateBussinesProfile` | **(a)** | `updateBusinessProfile(delta)`, including opening hours |
| `removeCoverPhoto` | **(a)** | `removeBusinessCoverPhoto(id)` |
| `updateCoverPhoto` | **blocked** | the bridge and core are complete; this package cannot produce the upload receipt |
| `productCreate` / `productUpdate` / `productDelete` | **no route exists** | not a gap |

No gap prompt was written, for either the bridge or the core. The one genuinely missing piece is an upload leg, described below, and it is in this package rather than below it.

## Design

### Money stays a string

The bridge sends `PriceResult { amount1000: string, currency? }`: thousandths of a currency unit, as a decimal string, so `"1990"` is 1.99. Upstream types `Product.price` and `OrderPrice.total` as `number`.

I did not convert. Past 2^53 thousandths a double stops being exact, and an order large enough to hit that would come back quietly wrong, which is the worst failure mode a price can have. So the string travels through untouched and the return types diverge from upstream's here. That divergence is the deliberate part of this PR.

There is a test with `9007199254740993` thousandths, the first integer a double cannot represent, asserting both that the value survives and that `Number()` would have changed it to `...992`.

The consequence for the reader: `getCatalog` and `getOrderDetails` return the bridge's result shapes rather than upstream's `Product` and `OrderDetails`. Matching upstream's field names would have meant matching its `number`, and the two cannot both be satisfied.

### `getOrderDetails` takes a third argument

Upstream's signature is `(orderId, tokenBase64)` because it reads orders over the legacy `fb:thrift_iq` route, which addresses the server rather than the business. The route the real client uses is a query keyed by the seller, and the core's `get_order` takes the seller JID for that reason.

So the two-argument signature has no way to carry something the modern route requires. The third argument is optional in the type, so upstream-shaped code compiles; calling without it rejects and explains why, instead of guessing a JID and querying the wrong thing. The JID is on the order message that carried the token, so a caller has it.

### The three product methods are not pending work

`product_catalog_add`, `_edit` and `_delete` appear in no WhatsApp Web bundle. They are operations only Baileys implements, with no backing in the real client.

That changes what the rejection should say. "Not yet supported" invites the next reader to file it as a gap and wait for it; the message says the client has no such operation and points at the WhatsApp Business app. I did not open a gap prompt asking the core to implement them, and I would push back on one: the absence is a conclusion from evidence, not a backlog item.

### `updateCoverPhoto` is blocked in this package, not below it

The core and the bridge are complete: `setBusinessCoverPhoto` takes an `{fbid, meta_hmac, ts}` receipt. This package's upload path cannot produce one, because it requires a URL and a direct path that the cover-photo endpoint does not return. The rejection names the receipt so the reader knows where the missing leg is. `removeCoverPhoto` needs no upload and works.

## Coverage

`npm run compat:audit` before: **97.15% (21717/22354)**
after: **97.20% (21729/22354)**

Modest for nine methods, and the reason is the deliberate divergences rather than anything missing. `getCatalog` returning `CatalogResult` instead of `{products: Product[], nextPageCursor}`, and the four rejecting methods returning `Promise<never>` against upstream's `Promise<Product>` and friends, all count as mismatches rather than matches.

Scoring better here would mean either converting money to `number` or pretending the product methods return a `Product`. Both are worse than the number.

## Validation

- `npm run format`
- `npm run lint` (`tsc` plus `oxlint`)
- `npm test`: 714 tests, 0 failures, up from 666, with no existing test adapted
- `npm run compat:audit`

Not run: `npm run test:e2e`, which needs a mock server this environment does not have.

Mutation checked by making the edit and running the suite:

- letting `getOrderDetails` fall back to a server JID instead of rejecting fails 1 test
- letting `productCreate` resolve instead of rejecting fails 1 test
- sending opening-hours times for every mode rather than only `specific_hours` fails 1 test

---
_Generated by [Claude Code](https://claude.ai/code/session_019n5h4gDvrNFW4nCnf2YpMw)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds business catalog and profile APIs backed by `@oxidezap/whatsapp-rust-bridge`, with money kept as strings and stricter input validation. Catalog reads now default to the caller’s JID from persisted credentials (`getMe`), normalize device-suffixed JIDs, and use named return types to avoid clashes.

- **New Features**
  - Adds `getCatalog`, `getCollections`, `getOrderDetails(orderId, tokenBase64, sellerJid)`, `updateBussinesProfile`, `removeCoverPhoto` (delegated to `@oxidezap/whatsapp-rust-bridge`).
  - `getCatalog`/`getCollections` default to the caller’s catalog when no `jid`; fallback uses persisted creds (`getMe`) and works before socket init; device-suffixed JIDs normalized; rejects if not logged in.
  - Rejects unsupported ops with 501: `productCreate`, `productUpdate`, `productDelete` (no WhatsApp Web route) and `updateCoverPhoto` (missing `{fbid, meta_hmac, ts}` receipt).
  - Money stays a string (`amount1000`); `getCatalog` returns `CatalogPage` and `getCollections` returns `CollectionsPage`; opening-hour times are validated and bad inputs reject with 400.

- **Migration**
  - `getOrderDetails` now requires a third argument with the seller JID; two-arg calls throw with a helpful message.
  - Consumers should handle string thousandths (`amount1000`) and the new result type names `CatalogPage`/`CollectionsPage`.

<sup>Written for commit ad90986cc41faaf15c45bf505bc29090b36fd4cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

