### PR TITLE
feat(socket): add the remaining server-side query wrappers

### DIFF
--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -55,6 +55,7 @@ import { makeNewsletterMethods } from './newsletter.ts'
 import { makePreKeyMethods } from './prekeys.ts'
 import { makePresenceMethods } from './presence.ts'
 import { makePrivacyMethods } from './privacy.ts'
+import { makeServerQueryMethods } from './server-queries.ts'
 import { makeProfileMethods } from './profile.ts'
 import { mapReachoutTimelock } from './reachout.ts'
 import { makeHttpClient, makeTransport } from './transport.ts'
@@ -953,6 +954,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		...makeBlockingMethods(ctx),
 		...makeNewsletterMethods(ctx),
 		...makeBusinessMethods(ctx),
+		...makeServerQueryMethods(ctx),
 		downloadMedia: async <T extends 'buffer' | 'stream'>(
 			message: WAMessage,
 			type: T,

--- a/src/Socket/server-queries.ts
+++ b/src/Socket/server-queries.ts
@@ -1,0 +1,117 @@
+import type { BotListResult, NewChatMessageCappingResult } from '@oxidezap/whatsapp-rust-bridge'
+import type { BotListInfo } from '../Types/Chat.ts'
+import type { NewChatMessageCapInfo } from '../Types/State.ts'
+import type { MediaConnInfo } from '../Types/Message.ts'
+import { Boom } from '../Utils/boom.ts'
+import type { SocketContext } from './types.ts'
+
+/**
+ * Every section, flattened and deduplicated, rather than only the section the
+ * server types `all`.
+ *
+ * Upstream reads that one section, and the core deliberately refused to: the
+ * real client walks every section and uses the type only for layout, so a bot
+ * that appears solely under a category is dropped by the narrower reading. A
+ * caller iterating this list handles the extra entries; one that silently lost
+ * a bot has no way to notice.
+ */
+const flattenBotList = (list: BotListResult): BotListInfo[] => {
+	const seen = new Set<string>()
+	const bots: BotListInfo[] = []
+	for (const section of list.sections) {
+		for (const bot of section.bots) {
+			if (seen.has(bot.jid)) continue
+			seen.add(bot.jid)
+			bots.push({ jid: bot.jid, personaId: bot.personaId })
+		}
+	}
+	return bots
+}
+
+/**
+ * Upstream names these in snake case and types the three timestamps as
+ * strings. Every field is optional because the server omits whatever does not
+ * apply to the account's tier, and an absent quota stays absent: `0` here means
+ * the quota is spent.
+ */
+const toCapInfo = (result: NewChatMessageCappingResult): NewChatMessageCapInfo & { remaining_quota?: number } => ({
+	...(result.totalQuota !== undefined ? { total_quota: result.totalQuota } : {}),
+	...(result.usedQuota !== undefined ? { used_quota: result.usedQuota } : {}),
+	...(result.remainingQuota !== undefined ? { remaining_quota: result.remainingQuota } : {}),
+	...(result.cycleStartTimestamp !== undefined ? { cycle_start_timestamp: String(result.cycleStartTimestamp) } : {}),
+	...(result.cycleEndTimestamp !== undefined ? { cycle_end_timestamp: String(result.cycleEndTimestamp) } : {}),
+	...(result.serverSentTimestamp !== undefined ? { server_sent_timestamp: String(result.serverSentTimestamp) } : {}),
+	...(result.oteStatus !== undefined ? { ote_status: result.oteStatus as NewChatMessageCapInfo['ote_status'] } : {}),
+	...(result.mvStatus !== undefined ? { mv_status: result.mvStatus as NewChatMessageCapInfo['mv_status'] } : {}),
+	...(result.cappingStatus !== undefined
+		? { capping_status: result.cappingStatus as NewChatMessageCapInfo['capping_status'] }
+		: {})
+})
+
+export const makeServerQueryMethods = (ctx: SocketContext) => {
+	/** Last host seen, so the synchronous accessor upstream exposes can answer. */
+	let mediaHost = ''
+
+	return {
+		/**
+		 * `maxContentLengthBytes` is absent by design: the core's hosts carry
+		 * nothing but a hostname, so the field upstream declares has no source
+		 * and is not invented here.
+		 */
+		refreshMediaConn: async (
+			forceGet = false
+		): Promise<Omit<MediaConnInfo, 'hosts'> & { hosts: { hostname: string }[] }> => {
+			const conn = await (await ctx.getClient()).getMediaConn(forceGet)
+			mediaHost = conn.hosts[0]?.hostname ?? mediaHost
+			return { auth: conn.auth, ttl: conn.ttl, hosts: conn.hosts, fetchDate: new Date() }
+		},
+
+		/** Synchronous, as upstream has it, so it reads what the last refresh saw. */
+		getMediaHost: (): string => mediaHost,
+
+		getBotListV2: async (): Promise<BotListInfo[]> => {
+			return flattenBotList(await (await ctx.getClient()).getBotList())
+		},
+
+		fetchNewChatMessageCap: async () => {
+			return toCapInfo(await (await ctx.getClient()).fetchNewChatMessageCappingInfo())
+		},
+
+		cleanDirtyBits: async (type: 'account_sync' | 'groups', fromTimestamp?: number | string): Promise<void> => {
+			let timestamp: number | null = null
+			if (fromTimestamp !== undefined) {
+				timestamp = typeof fromTimestamp === 'string' ? Number(fromTimestamp) : fromTimestamp
+				if (!Number.isFinite(timestamp)) {
+					throw new Boom(`cleanDirtyBits: fromTimestamp '${fromTimestamp}' is not a number`, { statusCode: 400 })
+				}
+			}
+			await (await ctx.getClient()).cleanDirtyBits(type, timestamp)
+		},
+
+		/**
+		 * Refused rather than wired up. The core already fires a peer data
+		 * request itself when a message fails to decrypt, with its own age
+		 * policy, so a second one here would duplicate it. The request a
+		 * consumer actually drives, asking for history, is `fetchMessageHistory`.
+		 */
+		sendPeerDataOperationMessage: async (_pdoMessage: unknown): Promise<never> => {
+			throw new Boom(
+				'sendPeerDataOperationMessage is not supported: use fetchMessageHistory to request history, and note the engine issues its own peer data request when a message fails to decrypt',
+				{ statusCode: 501 }
+			)
+		},
+
+		/**
+		 * Refused one layer down, as a build decision. `create_call_link` exists
+		 * in the core behind its voip feature, and the bridge pins the core with
+		 * default features off, so it is not compiled into the wasm artifact at
+		 * all. Reaching it would pull the webrtc stack into the bundle.
+		 */
+		createCallLink: async (_type: 'audio' | 'video', _event?: unknown, _timeoutMs?: number): Promise<never> => {
+			throw new Boom(
+				'createCallLink is not available: the call-link operation sits behind the core voip feature, which is not compiled into the wasm bridge',
+				{ statusCode: 501 }
+			)
+		}
+	}
+}

--- a/src/Socket/server-queries.ts
+++ b/src/Socket/server-queries.ts
@@ -74,11 +74,14 @@ export const makeServerQueryMethods = (ctx: SocketContext) => {
 		refreshMediaConn: async (
 			forceGet = false
 		): Promise<Omit<MediaConnInfo, 'hosts'> & { hosts: { hostname: string }[] }> => {
-			const conn = await (await ctx.getClient()).getMediaConn(forceGet)
+			// Forced on the first call, as upstream's first call is: the engine may
+			// already hold a connection acquired by an upload, and stamping that
+			// one as fetched now would report it fresher than it is.
+			const held = fetched
+			const conn = await (await ctx.getClient()).getMediaConn(forceGet || !held)
 			mediaHost = conn.hosts[0]?.hostname ?? mediaHost
-			if (forceGet || !fetched || fetched.auth !== conn.auth || !isLive(fetched)) {
-				fetched = { auth: conn.auth, ttl: conn.ttl, at: new Date() }
-			}
+			const isFetch = forceGet || !held || held.auth !== conn.auth || !isLive(held)
+			fetched = isFetch ? { auth: conn.auth, ttl: conn.ttl, at: new Date() } : held
 			// A copy: the stored instant decides when the next call restamps, and a
 			// consumer holding the same Date could move it.
 			return { auth: conn.auth, ttl: conn.ttl, hosts: conn.hosts, fetchDate: new Date(fetched.at) }

--- a/src/Socket/server-queries.ts
+++ b/src/Socket/server-queries.ts
@@ -75,7 +75,9 @@ export const makeServerQueryMethods = (ctx: SocketContext) => {
 			if (forceGet || !fetched || fetched.auth !== conn.auth) {
 				fetched = { auth: conn.auth, at: new Date() }
 			}
-			return { auth: conn.auth, ttl: conn.ttl, hosts: conn.hosts, fetchDate: fetched.at }
+			// A copy: the stored instant decides when the next call restamps, and a
+			// consumer holding the same Date could move it.
+			return { auth: conn.auth, ttl: conn.ttl, hosts: conn.hosts, fetchDate: new Date(fetched.at) }
 		},
 
 		/** Synchronous, as upstream has it, so it reads what the last refresh saw. */
@@ -92,8 +94,12 @@ export const makeServerQueryMethods = (ctx: SocketContext) => {
 		cleanDirtyBits: async (type: 'account_sync' | 'groups', fromTimestamp?: number | string): Promise<void> => {
 			let timestamp: number | null = null
 			if (fromTimestamp !== undefined) {
+				// A blank string is not a timestamp, and `Number('')` is the epoch,
+				// so without this a caller meaning "no timestamp" would ask the
+				// server to clean from the beginning of time.
+				const blank = typeof fromTimestamp === 'string' && fromTimestamp.trim() === ''
 				timestamp = typeof fromTimestamp === 'string' ? Number(fromTimestamp) : fromTimestamp
-				if (!Number.isFinite(timestamp)) {
+				if (blank || !Number.isFinite(timestamp)) {
 					throw new Boom(`cleanDirtyBits: fromTimestamp '${fromTimestamp}' is not a number`, { statusCode: 400 })
 				}
 			}

--- a/src/Socket/server-queries.ts
+++ b/src/Socket/server-queries.ts
@@ -55,7 +55,9 @@ export const makeServerQueryMethods = (ctx: SocketContext) => {
 	 * When the credentials were obtained, not when they were last handed out.
 	 * The engine serves a live connection from its cache, and upstream only
 	 * stamps a new date on an actual fetch, so a caller renewing on
-	 * `fetchDate + ttl` has to see the fetch it is measuring from.
+	 * `fetchDate + ttl` has to see the fetch it is measuring from. A forced
+	 * call is a fetch whatever comes back, including the same auth with a
+	 * renewed ttl.
 	 */
 	let fetched: { auth: string; at: Date } | undefined
 
@@ -70,7 +72,7 @@ export const makeServerQueryMethods = (ctx: SocketContext) => {
 		): Promise<Omit<MediaConnInfo, 'hosts'> & { hosts: { hostname: string }[] }> => {
 			const conn = await (await ctx.getClient()).getMediaConn(forceGet)
 			mediaHost = conn.hosts[0]?.hostname ?? mediaHost
-			if (!fetched || fetched.auth !== conn.auth) {
+			if (forceGet || !fetched || fetched.auth !== conn.auth) {
 				fetched = { auth: conn.auth, at: new Date() }
 			}
 			return { auth: conn.auth, ttl: conn.ttl, hosts: conn.hosts, fetchDate: fetched.at }

--- a/src/Socket/server-queries.ts
+++ b/src/Socket/server-queries.ts
@@ -53,13 +53,17 @@ export const makeServerQueryMethods = (ctx: SocketContext) => {
 	let mediaHost = ''
 	/**
 	 * When the credentials were obtained, not when they were last handed out.
-	 * The engine serves a live connection from its cache, and upstream only
-	 * stamps a new date on an actual fetch, so a caller renewing on
-	 * `fetchDate + ttl` has to see the fetch it is measuring from. A forced
-	 * call is a fetch whatever comes back, including the same auth with a
-	 * renewed ttl.
+	 * The engine serves a live connection from its cache and gives no signal
+	 * for which calls were actual fetches, so the stamp is kept only while the
+	 * connection it describes is still live: past its own ttl, on a forced
+	 * call, or on rotated credentials, whatever comes back is a fetch.
+	 *
+	 * A caller renewing on `fetchDate + ttl` needs both halves of that. Always
+	 * restamping would push its deadline forward forever; never restamping
+	 * would leave it renewing against a moment that has already passed.
 	 */
-	let fetched: { auth: string; at: Date } | undefined
+	let fetched: { auth: string; ttl: number; at: Date } | undefined
+	const isLive = (held: { ttl: number; at: Date }) => Date.now() - held.at.getTime() < held.ttl * 1000
 
 	return {
 		/**
@@ -72,8 +76,8 @@ export const makeServerQueryMethods = (ctx: SocketContext) => {
 		): Promise<Omit<MediaConnInfo, 'hosts'> & { hosts: { hostname: string }[] }> => {
 			const conn = await (await ctx.getClient()).getMediaConn(forceGet)
 			mediaHost = conn.hosts[0]?.hostname ?? mediaHost
-			if (forceGet || !fetched || fetched.auth !== conn.auth) {
-				fetched = { auth: conn.auth, at: new Date() }
+			if (forceGet || !fetched || fetched.auth !== conn.auth || !isLive(fetched)) {
+				fetched = { auth: conn.auth, ttl: conn.ttl, at: new Date() }
 			}
 			// A copy: the stored instant decides when the next call restamps, and a
 			// consumer holding the same Date could move it.

--- a/src/Socket/server-queries.ts
+++ b/src/Socket/server-queries.ts
@@ -51,6 +51,13 @@ const toCapInfo = (result: NewChatMessageCappingResult): NewChatMessageCapInfo &
 export const makeServerQueryMethods = (ctx: SocketContext) => {
 	/** Last host seen, so the synchronous accessor upstream exposes can answer. */
 	let mediaHost = ''
+	/**
+	 * When the credentials were obtained, not when they were last handed out.
+	 * The engine serves a live connection from its cache, and upstream only
+	 * stamps a new date on an actual fetch, so a caller renewing on
+	 * `fetchDate + ttl` has to see the fetch it is measuring from.
+	 */
+	let fetched: { auth: string; at: Date } | undefined
 
 	return {
 		/**
@@ -63,7 +70,10 @@ export const makeServerQueryMethods = (ctx: SocketContext) => {
 		): Promise<Omit<MediaConnInfo, 'hosts'> & { hosts: { hostname: string }[] }> => {
 			const conn = await (await ctx.getClient()).getMediaConn(forceGet)
 			mediaHost = conn.hosts[0]?.hostname ?? mediaHost
-			return { auth: conn.auth, ttl: conn.ttl, hosts: conn.hosts, fetchDate: new Date() }
+			if (!fetched || fetched.auth !== conn.auth) {
+				fetched = { auth: conn.auth, at: new Date() }
+			}
+			return { auth: conn.auth, ttl: conn.ttl, hosts: conn.hosts, fetchDate: fetched.at }
 		},
 
 		/** Synchronous, as upstream has it, so it reads what the last refresh saw. */

--- a/src/__tests__/server-queries-compatibility.test.ts
+++ b/src/__tests__/server-queries-compatibility.test.ts
@@ -223,6 +223,19 @@ describe('refreshMediaConn forwards the force flag and feeds getMediaHost', () =
 		expect(second.fetchDate.getTime()).toBe(first.fetchDate.getTime())
 	})
 
+	// The engine gives no signal for which calls were actual fetches, so a
+	// connection past its own ttl is treated as refetched: leaving the old date
+	// would leave the caller renewing against a moment already gone.
+	it('a connection past its ttl is restamped even unforced', async () => {
+		const { methods } = makeHarness({ getMediaConn: async () => ({ ...conn, ttl: 0 }) })
+
+		const first = await methods.refreshMediaConn()
+		await delay(5)
+		const second = await methods.refreshMediaConn()
+
+		expect(second.fetchDate.getTime() > first.fetchDate.getTime()).toBe(true)
+	})
+
 	it('a forced call restamps even when the same credentials come back', async () => {
 		const { methods } = makeHarness({ getMediaConn: async () => conn })
 

--- a/src/__tests__/server-queries-compatibility.test.ts
+++ b/src/__tests__/server-queries-compatibility.test.ts
@@ -114,13 +114,27 @@ describe('fetchNewChatMessageCap renames to upstream fields and keeps absences a
 		})
 	})
 
-	it('an omitted quota stays omitted, because zero here means the quota is spent', async () => {
+	it('an omitted quota stays omitted', async () => {
 		const { methods } = makeHarness({ fetchNewChatMessageCappingInfo: async () => ({ cappingStatus: 'NONE' }) })
 
 		const info = await methods.fetchNewChatMessageCap()
 
 		expect(info).toEqual({ capping_status: 'NONE' })
 		expect('total_quota' in info).toBe(false)
+	})
+
+	// Omission and zero mean different things, and only the presence check
+	// tells them apart: zero is a quota that exists and is spent.
+	it('a zero quota is carried, because zero means the quota is spent', async () => {
+		const { methods } = makeHarness({
+			fetchNewChatMessageCappingInfo: async () => ({ totalQuota: 0, usedQuota: 0, cappingStatus: 'NONE' })
+		})
+
+		const info = await methods.fetchNewChatMessageCap()
+
+		expect('total_quota' in info).toBe(true)
+		expect(info.total_quota).toBe(0)
+		expect(info.used_quota).toBe(0)
 	})
 })
 
@@ -139,6 +153,15 @@ describe('cleanDirtyBits passes the type through and normalises the timestamp', 
 		await methods.cleanDirtyBits('groups', '1700000000')
 
 		expect(calls).toEqual([['cleanDirtyBits', ['groups', 1700000000]]])
+	})
+
+	// `Number('   ')` is the epoch, so a caller meaning "no timestamp" would
+	// otherwise ask the server to clean from the beginning of time.
+	it('rejects a blank string, which Number() would turn into the epoch', async () => {
+		const { calls, methods } = makeHarness()
+
+		await expect(methods.cleanDirtyBits('groups', '   ')).rejects.toThrow(/is not a number/)
+		expect(calls).toEqual([])
 	})
 
 	it('rejects a string that is not a number instead of sending NaN', async () => {

--- a/src/__tests__/server-queries-compatibility.test.ts
+++ b/src/__tests__/server-queries-compatibility.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Loose ends: bot list, message cap, dirty bits, media connection, and two
+ * refusals.
+ *
+ * The bot list is the one with a real choice in it. Upstream reads only the
+ * section the server types `all`; the core refused that reading because the
+ * real client walks every section and uses the type for layout, so a bot that
+ * appears solely under a category is dropped. This returns everything, and the
+ * test proves a category-only bot survives.
+ */
+
+import { EventEmitter } from 'node:events'
+import { describe, it } from 'node:test'
+import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+
+import { makeServerQueryMethods } from '../Socket/server-queries.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import type { ILogger } from '../Utils/logger.ts'
+import { expect } from './expect.ts'
+
+const logger = {
+	level: 'silent',
+	child: () => logger,
+	trace: () => undefined,
+	debug: () => undefined,
+	info: () => undefined,
+	warn: () => undefined,
+	error: () => undefined
+} as ILogger
+
+const makeHarness = (overrides: Record<string, unknown> = {}) => {
+	const calls: Array<[string, unknown[]]> = []
+	const client = new Proxy({} as Record<string, unknown>, {
+		get: (_t, prop) => {
+			if (typeof prop !== 'string' || prop === 'then') return undefined
+			if (prop in overrides) return overrides[prop]
+			return async (...args: unknown[]) => {
+				calls.push([prop, args])
+				return undefined
+			}
+		}
+	}) as unknown as WasmWhatsAppClient
+	const ctx = {
+		ev: new EventEmitter(),
+		logger,
+		getClient: async () => client
+	} as unknown as SocketContext
+	return { calls, methods: makeServerQueryMethods(ctx) }
+}
+
+describe('getBotListV2 keeps every section rather than only the one typed all', () => {
+	const list = {
+		version: '3',
+		sections: [
+			{ sectionType: 'all', bots: [{ jid: 'a@bot', personaId: 'pa', themes: [] }] },
+			{
+				sectionType: 'category',
+				bots: [
+					{ jid: 'b@bot', personaId: 'pb', themes: [] },
+					// Also in `all`: the same bot, not a second one.
+					{ jid: 'a@bot', personaId: 'pa', themes: [] }
+				]
+			}
+		]
+	}
+
+	it('a bot that appears only under a category is not dropped', async () => {
+		const { methods } = makeHarness({ getBotList: async () => list })
+
+		const bots = await methods.getBotListV2()
+
+		expect(bots).toEqual([
+			{ jid: 'a@bot', personaId: 'pa' },
+			{ jid: 'b@bot', personaId: 'pb' }
+		])
+	})
+
+	it('a bot listed in two sections appears once', async () => {
+		const { methods } = makeHarness({ getBotList: async () => list })
+
+		const bots = await methods.getBotListV2()
+
+		expect(bots.filter(bot => bot.jid === 'a@bot').length).toBe(1)
+	})
+})
+
+describe('fetchNewChatMessageCap renames to upstream fields and keeps absences absent', () => {
+	it('renames, and stringifies the three timestamps upstream types as strings', async () => {
+		const { methods } = makeHarness({
+			fetchNewChatMessageCappingInfo: async () => ({
+				cappingStatus: 'FIRST_WARNING',
+				oteStatus: 'ELIGIBLE',
+				mvStatus: 'ACTIVE',
+				totalQuota: 100,
+				usedQuota: 40,
+				remainingQuota: 60,
+				cycleStartTimestamp: 1700000000,
+				cycleEndTimestamp: 1702000000,
+				serverSentTimestamp: 1701000000
+			})
+		})
+
+		expect(await methods.fetchNewChatMessageCap()).toEqual({
+			capping_status: 'FIRST_WARNING',
+			ote_status: 'ELIGIBLE',
+			mv_status: 'ACTIVE',
+			total_quota: 100,
+			used_quota: 40,
+			remaining_quota: 60,
+			cycle_start_timestamp: '1700000000',
+			cycle_end_timestamp: '1702000000',
+			server_sent_timestamp: '1701000000'
+		})
+	})
+
+	it('an omitted quota stays omitted, because zero here means the quota is spent', async () => {
+		const { methods } = makeHarness({ fetchNewChatMessageCappingInfo: async () => ({ cappingStatus: 'NONE' }) })
+
+		const info = await methods.fetchNewChatMessageCap()
+
+		expect(info).toEqual({ capping_status: 'NONE' })
+		expect('total_quota' in info).toBe(false)
+	})
+})
+
+describe('cleanDirtyBits passes the type through and normalises the timestamp', () => {
+	it('sends null when no timestamp was given', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.cleanDirtyBits('account_sync')
+
+		expect(calls).toEqual([['cleanDirtyBits', ['account_sync', null]]])
+	})
+
+	it('accepts the string form upstream allows', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.cleanDirtyBits('groups', '1700000000')
+
+		expect(calls).toEqual([['cleanDirtyBits', ['groups', 1700000000]]])
+	})
+
+	it('rejects a string that is not a number instead of sending NaN', async () => {
+		const { calls, methods } = makeHarness()
+
+		await expect(methods.cleanDirtyBits('groups', 'yesterday')).rejects.toThrow(/is not a number/)
+		expect(calls).toEqual([])
+	})
+})
+
+describe('refreshMediaConn forwards the force flag and feeds getMediaHost', () => {
+	const conn = { auth: 'AUTH', ttl: 3600, hosts: [{ hostname: 'mmg.whatsapp.net' }] }
+
+	it('forcing and not forcing take different arguments', async () => {
+		const seen: boolean[] = []
+		const { methods } = makeHarness({
+			getMediaConn: async (force: boolean) => {
+				seen.push(force)
+				return conn
+			}
+		})
+
+		await methods.refreshMediaConn()
+		await methods.refreshMediaConn(true)
+
+		expect(seen).toEqual([false, true])
+	})
+
+	it('getMediaHost is empty until a refresh, then reports the host', async () => {
+		const { methods } = makeHarness({ getMediaConn: async () => conn })
+
+		expect(methods.getMediaHost()).toBe('')
+		await methods.refreshMediaConn()
+		expect(methods.getMediaHost()).toBe('mmg.whatsapp.net')
+	})
+
+	it('carries auth, ttl and a fetch date', async () => {
+		const { methods } = makeHarness({ getMediaConn: async () => conn })
+
+		const info = await methods.refreshMediaConn()
+
+		expect(info.auth).toBe('AUTH')
+		expect(info.ttl).toBe(3600)
+		expect(info.fetchDate instanceof Date).toBe(true)
+	})
+})
+
+describe('the two refusals say which layer refused and why', () => {
+	it('createCallLink names the build decision, not a missing wrapper', async () => {
+		const { calls, methods } = makeHarness()
+
+		await expect(methods.createCallLink('audio')).rejects.toThrow(/voip feature, which is not compiled/)
+		expect(calls).toEqual([])
+	})
+
+	it('sendPeerDataOperationMessage points at fetchMessageHistory', async () => {
+		const { calls, methods } = makeHarness()
+
+		await expect(methods.sendPeerDataOperationMessage({})).rejects.toThrow(/use fetchMessageHistory/)
+		expect(calls).toEqual([])
+	})
+})
+
+describe('server queries do not swallow a bridge failure', () => {
+	it('a rejection propagates', async () => {
+		const { methods } = makeHarness({
+			getBotList: async () => {
+				throw new Error('server error 500: internal')
+			}
+		})
+
+		await expect(methods.getBotListV2()).rejects.toThrow(/server error 500/)
+	})
+})

--- a/src/__tests__/server-queries-compatibility.test.ts
+++ b/src/__tests__/server-queries-compatibility.test.ts
@@ -175,7 +175,10 @@ describe('cleanDirtyBits passes the type through and normalises the timestamp', 
 describe('refreshMediaConn forwards the force flag and feeds getMediaHost', () => {
 	const conn = { auth: 'AUTH', ttl: 3600, hosts: [{ hostname: 'mmg.whatsapp.net' }] }
 
-	it('forcing and not forcing take different arguments', async () => {
+	// The engine may already hold a connection an upload acquired, and it gives
+	// no signal for how old that one is, so the first call fetches rather than
+	// stamping whatever comes back as fresh. Upstream's first call queries too.
+	it('the first call fetches, and after that forcing is what the caller asked for', async () => {
 		const seen: boolean[] = []
 		const { methods } = makeHarness({
 			getMediaConn: async (force: boolean) => {
@@ -185,9 +188,10 @@ describe('refreshMediaConn forwards the force flag and feeds getMediaHost', () =
 		})
 
 		await methods.refreshMediaConn()
+		await methods.refreshMediaConn()
 		await methods.refreshMediaConn(true)
 
-		expect(seen).toEqual([false, true])
+		expect(seen).toEqual([true, false, true])
 	})
 
 	it('getMediaHost is empty until a refresh, then reports the host', async () => {

--- a/src/__tests__/server-queries-compatibility.test.ts
+++ b/src/__tests__/server-queries-compatibility.test.ts
@@ -15,6 +15,7 @@ import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
 
 import { makeServerQueryMethods } from '../Socket/server-queries.ts'
 import type { SocketContext } from '../Socket/types.ts'
+import { delay } from '../Utils/generics.ts'
 import type { ILogger } from '../Utils/logger.ts'
 import { expect } from './expect.ts'
 
@@ -182,6 +183,33 @@ describe('refreshMediaConn forwards the force flag and feeds getMediaHost', () =
 		expect(info.auth).toBe('AUTH')
 		expect(info.ttl).toBe(3600)
 		expect(info.fetchDate instanceof Date).toBe(true)
+	})
+
+	/**
+	 * The engine serves a live connection from its own cache, so a second call
+	 * is not a second fetch. Restamping it would let a caller renewing on
+	 * `fetchDate + ttl` carry expired credentials for another full ttl.
+	 */
+	it('a connection served from the cache keeps the date it was fetched on', async () => {
+		const { methods } = makeHarness({ getMediaConn: async () => conn })
+
+		const first = await methods.refreshMediaConn()
+		await delay(5)
+		const second = await methods.refreshMediaConn()
+
+		expect(second.fetchDate.getTime()).toBe(first.fetchDate.getTime())
+	})
+
+	it('new credentials are stamped with the moment they arrived', async () => {
+		let auth = 'AUTH'
+		const { methods } = makeHarness({ getMediaConn: async () => ({ ...conn, auth }) })
+
+		const first = await methods.refreshMediaConn()
+		await delay(5)
+		auth = 'AUTH2'
+		const second = await methods.refreshMediaConn(true)
+
+		expect(second.fetchDate.getTime() > first.fetchDate.getTime()).toBe(true)
 	})
 })
 

--- a/src/__tests__/server-queries-compatibility.test.ts
+++ b/src/__tests__/server-queries-compatibility.test.ts
@@ -200,6 +200,16 @@ describe('refreshMediaConn forwards the force flag and feeds getMediaHost', () =
 		expect(second.fetchDate.getTime()).toBe(first.fetchDate.getTime())
 	})
 
+	it('a forced call restamps even when the same credentials come back', async () => {
+		const { methods } = makeHarness({ getMediaConn: async () => conn })
+
+		const first = await methods.refreshMediaConn()
+		await delay(5)
+		const forced = await methods.refreshMediaConn(true)
+
+		expect(forced.fetchDate.getTime() > first.fetchDate.getTime()).toBe(true)
+	})
+
 	it('new credentials are stamped with the moment they arrived', async () => {
 		let auth = 'AUTH'
 		const { methods } = makeHarness({ getMediaConn: async () => ({ ...conn, auth }) })


### PR DESCRIPTION
## Summary

Five wrappers land, two refuse. The items have nothing in common but their shape, so this is a set of loose ends rather than a domain.

In: `getBotListV2`, `fetchNewChatMessageCap`, `cleanDirtyBits`, `refreshMediaConn`, `getMediaHost`.
Refusing: `createCallLink`, `sendPeerDataOperationMessage`.

## Layer classification

| item | class | note |
|---|---|---|
| `getBotListV2` | **(a)** | `getBotList()`, flattened; see the choice below |
| `fetchNewChatMessageCap` | **(a)** | `fetchNewChatMessageCappingInfo()`, renamed to upstream's snake case |
| `cleanDirtyBits` | **(a)** | `cleanDirtyBits(type, timestamp)` |
| `refreshMediaConn` | **(a)** | `getMediaConn(force)`, which already took the flag |
| `getMediaHost` | **(a)** | reads what the last refresh saw |
| `createCallLink` | **refused below this layer** | a build decision, not a missing wrapper |
| `sendPeerDataOperationMessage` | **refused, and would duplicate the engine** | |

No gap prompt was opened. Neither refusal is a gap: one is a deliberate dependency decision in the bridge, the other is an operation the engine already performs.

## Design

### The bot list has a real choice in it, and I took the wider one

Upstream reads only the section the server types `all`, and extracts `jid` and `persona_id`. The core deliberately refused that filter: the real client walks every section and uses `type`/`display_type` only for layout, so a bot appearing solely under a category section is dropped by the narrow reading.

I return every section, flattened and deduplicated by JID, under upstream's signature.

Both readings are defensible, and this is why I picked this one: a caller iterating a bot list copes with more entries than it expected, while a caller that silently lost a bot has no way to notice it happened. The cost is that a consumer replicating upstream's exact set will see extras. There is a test for a category-only bot surviving, and for a bot listed twice appearing once.

### Zero is not "unknown"

`fetchNewChatMessageCap` renames to upstream's `total_quota`, `used_quota` and friends, and stringifies the three timestamps it types as strings. Every field is optional because the server omits what does not apply to the account's tier.

An absent quota stays absent. `0` in this API means the quota is spent, so defaulting an unknown to `0` would tell the caller the opposite of the truth. The core's own `remainingQuota` derivation is carried through as `remaining_quota`, an extra field beyond upstream's type.

### `maxContentLengthBytes` is not invented

`MediaConnInfo` declares it upstream. The core's hosts carry a hostname and nothing else, which #26 already established when the bridge corrected its own stale doc comment. So the field is absent here and the return type diverges, rather than being filled with a number nobody sent.

`getMediaHost` stays synchronous as upstream has it, reading the host the last `refreshMediaConn` saw. That is a cache of a value we fetched ourselves, one field wide, not a shadow of protocol state the core owns.

The prompt's note that `getMediaConn` already accepted the force flag is correct: the earlier claim that it was missing was wrong, and there was nothing to add below this layer. There is a test that forcing and not forcing reach the bridge with different arguments, since a silently ignored flag is exactly the kind of thing nobody notices.

### The two refusals name which layer refused

`createCallLink` is not a forgotten wrapper. `create_call_link` exists in the core behind its `voip-runtime` feature, and the bridge pins the core with default features off, so the method is not compiled into the wasm artifact at all. Reaching it means pulling `webrtc-dtls`, `webrtc-sctp`, `webrtc-data` and `rustls` into a wasm bundle. That is a size and dependency decision someone has to take deliberately, so the message says so rather than implying a missing binding.

`sendPeerDataOperationMessage` is refused on the merits. The core already fires a peer data request when a message fails to decrypt, with its own age policy, so a second one from here would duplicate it. And the PDO a consumer actually drives, asking for history, is already `fetchMessageHistory`. The message points there.

## Deferred

Nothing, and that is a claim rather than an omission: both open items are answered decisions rather than pending work. If the voip build question is ever revisited, it belongs in the bridge, not here.

## Coverage

`npm run compat:audit` before: **97.15% (21717/22354)**
after: **97.26% (21741/22354)**

The two refusals and the `MediaConnInfo` divergence do not score. `refreshMediaConn` returns hosts without `maxContentLengthBytes`, and `createCallLink`/`sendPeerDataOperationMessage` return `Promise<never>` against upstream's declared results, so all three count as mismatches. Scoring them would mean inventing a byte limit and pretending two operations exist.

## Validation

- `npm run format`
- `npm run lint` (`tsc` plus `oxlint`)
- `npm test`: 711 tests, 0 failures, up from 666, with no existing test adapted
- `npm run compat:audit`

Not run: `npm run test:e2e`, which needs a mock server this environment does not have.

Mutation checked by making the edit and running the suite:

- filtering the bot list to the `all` section fails 1 test
- dropping the `getMediaHost` update fails 1 test

---
_Generated by [Claude Code](https://claude.ai/code/session_019n5h4gDvrNFW4nCnf2YpMw)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the remaining server-side query wrappers, clarifies two unsupported operations, and hardens media connection handling by forcing a real fetch on the first call and stamping the actual fetch time.

- **New Features**
  - `getBotListV2`: returns bots from all sections; flattened and deduped by JID.
  - `fetchNewChatMessageCap`: snake_case fields; timestamps as strings; preserves omissions; adds `remaining_quota`.
  - `cleanDirtyBits`: forwards type; accepts number or string timestamp; rejects non-numeric or blank strings (400).
  - `refreshMediaConn`: forwards `force`; first call forces a fetch; omits `maxContentLengthBytes`; returns `fetchDate` when credentials were fetched; restamps on force, credential change, or TTL expiry; returns `fetchDate` by value; updates cached host for `getMediaHost`.
  - `getMediaHost`: sync; returns the last host seen by `refreshMediaConn`.

- **Migration**
  - `createCallLink`: not available; requires the core VOIP feature in the wasm bridge.
  - `sendPeerDataOperationMessage`: not supported; use `fetchMessageHistory`. The engine already issues its own peer data request on decryption failures.

<sup>Written for commit f5c1de01d4fe14a726a18ba4d66b145b63b29d13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

