### PR TITLE
feat(socket): decide and implement the internal-surface compatibility items

### DIFF
--- a/src/Socket/chat-actions.ts
+++ b/src/Socket/chat-actions.ts
@@ -1,7 +1,7 @@
 import type { proto } from '../WAProto/runtime.ts'
 import type { QuickReplyAction } from '../Types/Bussines.ts'
 import type { LabelActionBody } from '../Types/Label.ts'
-import type { ChatModification, WAPatchName } from '../Types/index.ts'
+import type { ChatModification } from '../Types/index.ts'
 import { Boom } from '../Utils/boom.ts'
 import type { SocketContext } from './types.ts'
 
@@ -141,17 +141,6 @@ export const makeChatActionMethods = (ctx: SocketContext) => {
 				const variant = Object.keys(mod)[0] ?? '(empty)'
 				throw new Boom(`chatModify: unsupported modification '${variant}'`, { statusCode: 400, data: { variant, jid } })
 			}
-		},
-
-		/**
-		 * Force re-sync of app state collections.
-		 *
-		 * In the Rust bridge architecture, app state is managed internally by the engine
-		 * and synced automatically on connect. This method is a no-op provided for API
-		 * compatibility with upstream Baileys.
-		 */
-		resyncAppState: async (_collections?: readonly WAPatchName[], _isInitialSync?: boolean) => {
-			ctx.logger.info('resyncAppState: app state is synced automatically by the Rust bridge')
 		},
 
 		// Upstream models all of these as sugar over `chatModify`, and so do we:

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -965,7 +965,7 @@ const dispatchCanonicalEvent = (canonical: CanonicalEvent, dispatchCtx: Dispatch
 		dispatcher(canonical, dispatchCtx)
 	} catch (err) {
 		// One bad event must not poison the rest of the pipeline.
-		dispatchCtx.ctx.logger.error({ err, type: canonical.type }, 'dispatcher threw — dropping event')
+		dispatchCtx.ctx.reportUnexpectedError(err, `dispatching a '${canonical.type}' event`)
 	}
 }
 
@@ -1011,7 +1011,7 @@ const dispatchCanonicalBatch = (
 				pending = { ...metadata, messages: [message] }
 			}
 		} catch (err) {
-			ctx.logger.error({ err, type: CANONICAL_MESSAGE_EVENT }, 'dispatcher threw — dropping event')
+			ctx.reportUnexpectedError(err, `dispatching a '${CANONICAL_MESSAGE_EVENT}' event`)
 		}
 	}
 
@@ -1045,7 +1045,7 @@ export const makeEventHandlers = (ctx: SocketContext, callbacks?: EventCallbacks
 		try {
 			view = decodeMessageWireBatch(batch)
 		} catch (err) {
-			ctx.logger.error({ err }, 'failed to decode the message wire batch')
+			ctx.reportUnexpectedError(err, 'decoding the message wire batch')
 			return
 		}
 		const { messageData, messageOffsets, infos } = view
@@ -1087,7 +1087,7 @@ export const makeEventHandlers = (ctx: SocketContext, callbacks?: EventCallbacks
 		try {
 			receipts = decodeReceiptWireBatch(batch)
 		} catch (err) {
-			ctx.logger.error({ err }, 'failed to decode receipt wire batch')
+			ctx.reportUnexpectedError(err, 'decoding the receipt wire batch')
 			return
 		}
 		// The decoded payload matches the single-event wire shape; the union's
@@ -1100,7 +1100,7 @@ export const makeEventHandlers = (ctx: SocketContext, callbacks?: EventCallbacks
 		try {
 			acks = decodeServerAckWireBatch(batch)
 		} catch (err) {
-			ctx.logger.error({ err }, 'failed to decode server-ack wire batch')
+			ctx.reportUnexpectedError(err, 'decoding the server-ack wire batch')
 			return
 		}
 		for (const data of acks) onEvent({ type: 'server_ack', data } as unknown as WhatsAppEvent)

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -281,15 +281,21 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	let autoReconnectEnabled = true
 	/** Owns reporting the terminal close: once, after teardown, never not at all. */
 	const terminalClose = makeTerminalCloseReporter({ logger })
+	/**
+	 * Held in a slot rather than captured, because `sock.onUnexpectedError` is
+	 * an assignable property: a consumer that replaces it has to be the one the
+	 * socket's own failure paths reach afterwards.
+	 */
+	let unexpectedErrorHandler: (err: unknown, msg: string) => void = (err, msg) => {
+		logger.error({ err }, `unexpected error in '${msg}'`)
+	}
 
 	const ctx: SocketContext = {
 		ev,
 		logger,
 		fullConfig,
 		ws,
-		reportUnexpectedError: (err, msg) => {
-			logger.error({ err }, `unexpected error in '${msg}'`)
-		},
+		reportUnexpectedError: (err, msg) => unexpectedErrorHandler(err, msg),
 		getUser: () => user,
 		getMe: () => {
 			const me = auth.creds.me
@@ -970,6 +976,17 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			})
 		}
 	}
+
+	// Assigning replaces the handler the socket itself reports through, rather
+	// than shadowing it with a second one only a consumer could reach.
+	Object.defineProperty(sock, 'onUnexpectedError', {
+		get: () => unexpectedErrorHandler,
+		set: (handler: (err: unknown, msg: string) => void) => {
+			unexpectedErrorHandler = handler
+		},
+		enumerable: true,
+		configurable: true
+	})
 
 	return sock
 }

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -50,7 +50,7 @@ import { makeBridgeClientOwner } from './bridge-client-owner.ts'
 import { makeTerminalCloseReporter } from './terminal-close-reporter.ts'
 import { makeEventHandlers } from './events.ts'
 import { makeGroupMethods } from './groups.ts'
-import { makeInternalMethods } from './internals.ts'
+import { makeInternalMethods, makeUnexpectedErrorReporter } from './internals.ts'
 import { makeMessageMethods } from './messages.ts'
 import { makeNewsletterMethods } from './newsletter.ts'
 import { makePreKeyMethods } from './prekeys.ts'
@@ -282,20 +282,18 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	/** Owns reporting the terminal close: once, after teardown, never not at all. */
 	const terminalClose = makeTerminalCloseReporter({ logger })
 	/**
-	 * Held in a slot rather than captured, because `sock.onUnexpectedError` is
-	 * an assignable property: a consumer that replaces it has to be the one the
-	 * socket's own failure paths reach afterwards.
+	 * Held in a reporter rather than captured, because `sock.onUnexpectedError`
+	 * is an assignable property: a consumer that replaces it has to be the one
+	 * the socket's own failure paths reach afterwards.
 	 */
-	let unexpectedErrorHandler: (err: unknown, msg: string) => void = (err, msg) => {
-		logger.error({ err }, `unexpected error in '${msg}'`)
-	}
+	const unexpectedErrors = makeUnexpectedErrorReporter(logger)
 
 	const ctx: SocketContext = {
 		ev,
 		logger,
 		fullConfig,
 		ws,
-		reportUnexpectedError: (err, msg) => unexpectedErrorHandler(err, msg),
+		reportUnexpectedError: unexpectedErrors.report,
 		getUser: () => user,
 		getMe: () => {
 			const me = auth.creds.me
@@ -980,9 +978,9 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	// Assigning replaces the handler the socket itself reports through, rather
 	// than shadowing it with a second one only a consumer could reach.
 	Object.defineProperty(sock, 'onUnexpectedError', {
-		get: () => unexpectedErrorHandler,
+		get: () => unexpectedErrors.handler,
 		set: (handler: (err: unknown, msg: string) => void) => {
-			unexpectedErrorHandler = handler
+			unexpectedErrors.handler = handler
 		},
 		enumerable: true,
 		configurable: true

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -287,6 +287,9 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		logger,
 		fullConfig,
 		ws,
+		reportUnexpectedError: (err, msg) => {
+			logger.error({ err }, `unexpected error in '${msg}'`)
+		},
 		getUser: () => user,
 		getMe: () => {
 			const me = auth.creds.me

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -50,6 +50,7 @@ import { makeBridgeClientOwner } from './bridge-client-owner.ts'
 import { makeTerminalCloseReporter } from './terminal-close-reporter.ts'
 import { makeEventHandlers } from './events.ts'
 import { makeGroupMethods } from './groups.ts'
+import { makeInternalMethods } from './internals.ts'
 import { makeMessageMethods } from './messages.ts'
 import { makeNewsletterMethods } from './newsletter.ts'
 import { makePreKeyMethods } from './prekeys.ts'
@@ -947,6 +948,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		...makeContactMethods(ctx),
 		...makeProfileMethods(ctx),
 		...makeChatActionMethods(ctx),
+		...makeInternalMethods(ctx),
 		...usyncMethods,
 		...makeStanzaResponseMethods(ctx),
 		...makePresenceMethods(ctx),

--- a/src/Socket/internals.ts
+++ b/src/Socket/internals.ts
@@ -3,11 +3,16 @@ import { Boom } from '../Utils/boom.ts'
 import type { SocketContext } from './types.ts'
 
 /**
- * Upstream has no timeout on `waitForSocketOpen`; the bridge requires one. This
- * is the socket's own connect timeout, so the wait cannot outlive the attempt
- * it is waiting on.
+ * Upstream has no timeout on `waitForSocketOpen`; the bridge requires one, so
+ * one has to be chosen.
+ *
+ * It is the core's own transport connect ceiling, not `connectTimeoutMs`. That
+ * config reaches neither the transport nor the core, so a value below the
+ * ceiling would reject a wait while the attempt behind it was still running and
+ * about to succeed. A value above it would sit past the point the attempt was
+ * already abandoned.
  */
-const waitTimeoutMs = (ctx: SocketContext): number => ctx.fullConfig?.connectTimeoutMs ?? 20_000
+const TRANSPORT_CONNECT_TIMEOUT_MS = 20_000
 
 export const makeInternalMethods = (ctx: SocketContext) => {
 	/** Warned once per socket rather than per call, as with the other no-ops. */
@@ -18,27 +23,36 @@ export const makeInternalMethods = (ctx: SocketContext) => {
 		 * `waitForSocket`, not `waitForConnected`: upstream waits for the socket
 		 * to open, which is not the same as being logged in, and the bridge
 		 * separates the two.
+		 *
+		 * A rejection means the socket did not open within one connect attempt,
+		 * not that it never will: the engine reconnects on its own, and a caller
+		 * that wants the next attempt waits again.
 		 */
 		waitForSocketOpen: async (): Promise<void> => {
-			await (await ctx.getClient()).waitForSocket(waitTimeoutMs(ctx))
+			await (await ctx.getClient()).waitForSocket(TRANSPORT_CONNECT_TIMEOUT_MS)
 		},
 
 		/**
 		 * Publishes a message onto the event bus, which is this layer's own job.
+		 * Buffered as upstream buffers it, so a replay of many messages
+		 * consolidates into the batches a listener expects rather than one
+		 * event per call.
+		 *
 		 * The push-name half of upstream's version is not reproduced: contact
 		 * state belongs to the core, and writing it from here would make two
 		 * writers for one value.
 		 */
-		upsertMessage: async (msg: WAMessage, type: MessageUpsertType): Promise<void> => {
+		upsertMessage: ctx.ev.createBufferedFunction(async (msg: WAMessage, type: MessageUpsertType): Promise<void> => {
 			ctx.ev.emit('messages.upsert', { messages: [msg], type })
-		},
+		}),
 
 		/**
-		 * A consumer extension point rather than protocol state, so it lives
-		 * here. Overridable: assigning to it replaces this default.
+		 * The same reporter the socket's own failure paths use, rather than a
+		 * second one that only a consumer could reach: a dispatcher that threw
+		 * or a wire batch that would not decode arrives here.
 		 */
 		onUnexpectedError: (err: Error, msg: string): void => {
-			ctx.logger.error({ err }, `unexpected error in '${msg}'`)
+			ctx.reportUnexpectedError(err, msg)
 		},
 
 		/**

--- a/src/Socket/internals.ts
+++ b/src/Socket/internals.ts
@@ -1,6 +1,38 @@
 import type { BinaryNode, MessageUpsertType, WAMessage, WAPatchCreate } from '../Types/index.ts'
 import { Boom } from '../Utils/boom.ts'
+import type { ILogger } from '../Utils/logger.ts'
 import type { SocketContext } from './types.ts'
+
+/**
+ * The one place an unexpected failure is reported, shared by the socket's
+ * `onUnexpectedError` property and by the internal paths that raise them.
+ *
+ * `report` cannot throw. Some of its callers are bridge callbacks that borrow
+ * memory and are contractually forbidden from raising, so a consumer whose
+ * handler throws would cost the session its borrowed batches. A handler that
+ * fails is reported through the logger and the caller carries on.
+ */
+export const makeUnexpectedErrorReporter = (logger: ILogger) => {
+	const logUnexpected = (err: unknown, msg: string) => logger.error({ err }, `unexpected error in '${msg}'`)
+	let handler: (err: unknown, msg: string) => void = logUnexpected
+
+	return {
+		report: (err: unknown, msg: string) => {
+			try {
+				handler(err, msg)
+			} catch (reportingError) {
+				logger.error({ err: reportingError }, 'the onUnexpectedError handler threw')
+				logUnexpected(err, msg)
+			}
+		},
+		get handler() {
+			return handler
+		},
+		set handler(next: (err: unknown, msg: string) => void) {
+			handler = next
+		}
+	}
+}
 
 /**
  * Upstream has no timeout on `waitForSocketOpen`; the bridge requires one, so
@@ -66,8 +98,8 @@ export const makeInternalMethods = (ctx: SocketContext) => {
 		 * delegate to, and rejecting would break a call whose intent is met.
 		 */
 		resyncAppState: async (
-			collections: readonly ('critical_block' | 'critical_unblock_low' | 'regular_high' | 'regular_low' | 'regular')[],
-			isInitialSync: boolean
+			collections?: readonly ('critical_block' | 'critical_unblock_low' | 'regular_high' | 'regular_low' | 'regular')[],
+			isInitialSync?: boolean
 		): Promise<void> => {
 			void collections
 			void isInitialSync

--- a/src/Socket/internals.ts
+++ b/src/Socket/internals.ts
@@ -1,0 +1,113 @@
+import type { BinaryNode, MessageUpsertType, WAMessage, WAPatchCreate } from '../Types/index.ts'
+import { Boom } from '../Utils/boom.ts'
+import type { SocketContext } from './types.ts'
+
+/**
+ * Upstream has no timeout on `waitForSocketOpen`; the bridge requires one. This
+ * is the socket's own connect timeout, so the wait cannot outlive the attempt
+ * it is waiting on.
+ */
+const waitTimeoutMs = (ctx: SocketContext): number => ctx.fullConfig?.connectTimeoutMs ?? 20_000
+
+export const makeInternalMethods = (ctx: SocketContext) => {
+	/** Warned once per socket rather than per call, as with the other no-ops. */
+	let warnedAboutResync = false
+
+	return {
+		/**
+		 * `waitForSocket`, not `waitForConnected`: upstream waits for the socket
+		 * to open, which is not the same as being logged in, and the bridge
+		 * separates the two.
+		 */
+		waitForSocketOpen: async (): Promise<void> => {
+			await (await ctx.getClient()).waitForSocket(waitTimeoutMs(ctx))
+		},
+
+		/**
+		 * Publishes a message onto the event bus, which is this layer's own job.
+		 * The push-name half of upstream's version is not reproduced: contact
+		 * state belongs to the core, and writing it from here would make two
+		 * writers for one value.
+		 */
+		upsertMessage: async (msg: WAMessage, type: MessageUpsertType): Promise<void> => {
+			ctx.ev.emit('messages.upsert', { messages: [msg], type })
+		},
+
+		/**
+		 * A consumer extension point rather than protocol state, so it lives
+		 * here. Overridable: assigning to it replaces this default.
+		 */
+		onUnexpectedError: (err: Error, msg: string): void => {
+			ctx.logger.error({ err }, `unexpected error in '${msg}'`)
+		},
+
+		/**
+		 * Resolves without forcing anything, and says so once.
+		 *
+		 * The engine syncs app state on connect and re-syncs every collection
+		 * when the server raises the `syncd_app_state` dirty bit, so the state a
+		 * caller wants current already is. There is no on-demand resync to
+		 * delegate to, and rejecting would break a call whose intent is met.
+		 */
+		resyncAppState: async (
+			collections: readonly ('critical_block' | 'critical_unblock_low' | 'regular_high' | 'regular_low' | 'regular')[],
+			isInitialSync: boolean
+		): Promise<void> => {
+			void collections
+			void isInitialSync
+			if (!warnedAboutResync) {
+				warnedAboutResync = true
+				ctx.logger.warn(
+					'resyncAppState is a no-op: the engine syncs app state on connect and again whenever the server marks it dirty'
+				)
+			}
+		},
+
+		/**
+		 * Refused: the offset is protocol state the core keeps from the stanzas
+		 * it already reads. A second clock here would drift from the one that
+		 * actually timestamps outgoing messages.
+		 */
+		updateServerTimeOffset: (node: BinaryNode): never => {
+			void node
+			throw new Boom(
+				'updateServerTimeOffset is not supported: the engine tracks the server clock offset itself, and a second one here would diverge from the one it stamps messages with',
+				{ statusCode: 501 }
+			)
+		},
+
+		/**
+		 * Refused one layer down. The core's session instance is `pub(crate)`,
+		 * and what exists returns a half-built stanza plus a sequence number, so
+		 * exposing it would hand JavaScript the job of finishing and sequencing
+		 * a lifecycle stanza.
+		 */
+		sendUnifiedSession: async (): Promise<never> => {
+			throw new Boom(
+				'sendUnifiedSession is not supported: it is connection lifecycle machinery the engine owns, not a consumer operation',
+				{ statusCode: 501 }
+			)
+		},
+
+		/**
+		 * Refused: the bridge exposes app-state actions typed per action and
+		 * deliberately no generic. Accepting a raw patch here would mean
+		 * building mutation indices and schema versions in TypeScript, beside
+		 * the copy the core already maintains.
+		 */
+		appPatch: async (patchCreate: WAPatchCreate): Promise<never> => {
+			void patchCreate
+			throw new Boom(
+				'appPatch is not supported: use the typed chatModify variants, which is the only app-state surface this package can offer without a second implementation of the patch format',
+				{ statusCode: 501 }
+			)
+		},
+
+		/**
+		 * Null rather than absent, and rather than a shadow. Retry is the
+		 * engine's, so there is no manager here to hand out, and saying so in
+		 * the type is more useful than leaving the field missing.
+		 */
+		messageRetryManager: null
+	}
+}

--- a/src/Socket/internals.ts
+++ b/src/Socket/internals.ts
@@ -49,7 +49,9 @@ export const makeInternalMethods = (ctx: SocketContext) => {
 		/**
 		 * The same reporter the socket's own failure paths use, rather than a
 		 * second one that only a consumer could reach: a dispatcher that threw
-		 * or a wire batch that would not decode arrives here.
+		 * or a wire batch that would not decode arrives here. The socket
+		 * redefines this as an accessor, so assigning to it replaces the
+		 * handler those paths report through.
 		 */
 		onUnexpectedError: (err: Error, msg: string): void => {
 			ctx.reportUnexpectedError(err, msg)

--- a/src/Socket/internals.ts
+++ b/src/Socket/internals.ts
@@ -11,18 +11,29 @@ import type { SocketContext } from './types.ts'
  * memory and are contractually forbidden from raising, so a consumer whose
  * handler throws would cost the session its borrowed batches. A handler that
  * fails is reported through the logger and the caller carries on.
+ *
+ * The return type says `void`, which an `async` handler also satisfies, so a
+ * handler that rejects rather than throws is contained the same way. Left
+ * loose it would surface as an unhandled rejection, which ends the process
+ * under `--unhandled-rejections=strict`.
  */
 export const makeUnexpectedErrorReporter = (logger: ILogger) => {
 	const logUnexpected = (err: unknown, msg: string) => logger.error({ err }, `unexpected error in '${msg}'`)
+	const logHandlerFailure = (err: unknown, msg: string, reportingError: unknown) => {
+		logger.error({ err: reportingError }, 'the onUnexpectedError handler threw')
+		logUnexpected(err, msg)
+	}
 	let handler: (err: unknown, msg: string) => void = logUnexpected
 
 	return {
 		report: (err: unknown, msg: string) => {
 			try {
-				handler(err, msg)
+				const settled = handler(err, msg) as unknown
+				if (settled instanceof Promise) {
+					settled.catch(reportingError => logHandlerFailure(err, msg, reportingError))
+				}
 			} catch (reportingError) {
-				logger.error({ err: reportingError }, 'the onUnexpectedError handler threw')
-				logUnexpected(err, msg)
+				logHandlerFailure(err, msg, reportingError)
 			}
 		},
 		get handler() {

--- a/src/Socket/types.ts
+++ b/src/Socket/types.ts
@@ -18,6 +18,12 @@ export interface SocketContext {
 	getClientSync: () => WasmWhatsAppClient
 	/** Raw stanza EventEmitter for CB: pattern compat */
 	ws: EventEmitter
+	/**
+	 * Where a failure goes when it has nowhere else to go: a dispatcher that
+	 * threw, a wire batch that would not decode. Also what the socket exposes
+	 * as `onUnexpectedError`, so the two are one reporter rather than two.
+	 */
+	reportUnexpectedError: (err: unknown, msg: string) => void
 }
 
 /** Convert a bridge Jid struct to a string */

--- a/src/__tests__/auto-reconnect-terminal-close.test.ts
+++ b/src/__tests__/auto-reconnect-terminal-close.test.ts
@@ -53,6 +53,7 @@ const makeCtx = () => {
 		getUser: () => undefined,
 		getMe: () => undefined,
 		setUser: () => {},
+		reportUnexpectedError: () => {},
 		getClient: () => Promise.reject(new Error('not used')),
 		getClientSync: () => {
 			throw new Error('not used')

--- a/src/__tests__/quoted-media-enum-regression.test.ts
+++ b/src/__tests__/quoted-media-enum-regression.test.ts
@@ -31,6 +31,7 @@ const makeCtx = () => {
 		getUser: () => undefined,
 		getMe: () => undefined,
 		setUser: () => {},
+		reportUnexpectedError: () => {},
 		getClient: () => Promise.reject(new Error('not used')),
 		getClientSync: () => {
 			throw new Error('not used')

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -49,6 +49,7 @@ const makeCtx = () => {
 		getUser: () => undefined,
 		getMe: () => undefined,
 		setUser: () => {},
+		reportUnexpectedError: () => {},
 		getClient: () => Promise.reject(new Error('not used')),
 		getClientSync: () => {
 			throw new Error('not used')

--- a/src/__tests__/socket-internals-compatibility.test.ts
+++ b/src/__tests__/socket-internals-compatibility.test.ts
@@ -20,6 +20,7 @@ import { makeInternalMethods, makeUnexpectedErrorReporter } from '../Socket/inte
 import type { SocketContext } from '../Socket/types.ts'
 import type { WAMessage } from '../Types/index.ts'
 import { makeEventBuffer } from '../Utils/event-buffer.ts'
+import { delay } from '../Utils/generics.ts'
 import type { ILogger } from '../Utils/logger.ts'
 import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
 import { expect } from './expect.ts'
@@ -260,6 +261,23 @@ describe('the unexpected-error reporter is shared, replaceable and cannot throw'
 			throw new Error('the handler itself blew up')
 		}
 		reporter.report(new Error('boom'), 'a failing dispatcher')
+
+		expect(logged.length).toBe(2)
+		expect(String(logged[1]!.msg)).toBe("unexpected error in 'a failing dispatcher'")
+	})
+
+	// `void` is satisfied by an async function too, so a handler that rejects
+	// rather than throws would otherwise escape as an unhandled rejection and
+	// end the process under --unhandled-rejections=strict.
+	it('a handler that rejects is contained the same way a throwing one is', async () => {
+		const { logged, logger } = makeLogger()
+		const reporter = makeUnexpectedErrorReporter(logger)
+
+		reporter.handler = async () => {
+			throw new Error('the handler itself rejected')
+		}
+		reporter.report(new Error('boom'), 'a failing dispatcher')
+		await delay(1)
 
 		expect(logged.length).toBe(2)
 		expect(String(logged[1]!.msg)).toBe("unexpected error in 'a failing dispatcher'")

--- a/src/__tests__/socket-internals-compatibility.test.ts
+++ b/src/__tests__/socket-internals-compatibility.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Upstream exposes a good deal of socket internals: caches, buffers, a clock
+ * offset, a retry manager. In this package that state lives in the Rust core by
+ * design, so most of these are refusals rather than implementations, and the
+ * tests here are mostly about the refusals being loud and specific.
+ *
+ * The two that are real work are `waitForSocketOpen`, where the choice is which
+ * of the bridge's two waits matches upstream's meaning, and `upsertMessage`,
+ * where only the event half belongs to this layer.
+ */
+
+import { EventEmitter } from 'node:events'
+import { describe, it } from 'node:test'
+import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+
+import { makeInternalMethods } from '../Socket/internals.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import type { WAMessage } from '../Types/index.ts'
+import type { ILogger } from '../Utils/logger.ts'
+import { expect } from './expect.ts'
+
+const makeHarness = (overrides: Record<string, unknown> = {}, connectTimeoutMs?: number) => {
+	const calls: Array<[string, unknown[]]> = []
+	const logged: string[] = []
+	const logger = {
+		level: 'silent',
+		child: () => logger,
+		trace: () => undefined,
+		debug: () => undefined,
+		info: () => undefined,
+		warn: (a: unknown, b?: unknown) => logged.push(typeof a === 'string' ? a : String(b)),
+		error: (a: unknown, b?: unknown) => logged.push(typeof a === 'string' ? a : String(b))
+	} as unknown as ILogger
+	const client = new Proxy({} as Record<string, unknown>, {
+		get: (_t, prop) => {
+			if (typeof prop !== 'string' || prop === 'then') return undefined
+			if (prop in overrides) return overrides[prop]
+			return async (...args: unknown[]) => {
+				calls.push([prop, args])
+				return undefined
+			}
+		}
+	}) as unknown as WasmWhatsAppClient
+	const events: Array<[string, unknown]> = []
+	const ev = new EventEmitter()
+	ev.on('messages.upsert', payload => events.push(['messages.upsert', payload]))
+	const ctx = {
+		ev,
+		logger,
+		fullConfig: connectTimeoutMs === undefined ? {} : { connectTimeoutMs },
+		getClient: async () => client
+	} as unknown as SocketContext
+	return { calls, events, logged, methods: makeInternalMethods(ctx) }
+}
+
+describe('waitForSocketOpen waits for the socket, not for the login', () => {
+	it('takes the socket wait, since upstream waits for the transport to open', async () => {
+		const { calls, methods } = makeHarness({}, 20_000)
+
+		await methods.waitForSocketOpen()
+
+		expect(calls).toEqual([['waitForSocket', [20_000]]])
+	})
+
+	it('bounds the wait by the socket connect timeout rather than waiting forever', async () => {
+		const { calls, methods } = makeHarness({}, 5_000)
+
+		await methods.waitForSocketOpen()
+
+		expect(calls).toEqual([['waitForSocket', [5_000]]])
+	})
+
+	it('a timeout from the bridge surfaces rather than resolving', async () => {
+		const { methods } = makeHarness({
+			waitForSocket: async () => {
+				throw new Error('request timed out')
+			}
+		})
+
+		await expect(methods.waitForSocketOpen()).rejects.toThrow(/timed out/)
+	})
+})
+
+describe('upsertMessage publishes the event and nothing else', () => {
+	it('emits messages.upsert with the message and type', async () => {
+		const { calls, events, methods } = makeHarness()
+		const message = { key: { id: 'M1' } } as WAMessage
+
+		await methods.upsertMessage(message, 'notify')
+
+		expect(events).toEqual([['messages.upsert', { messages: [message], type: 'notify' }]])
+		// The push-name half of upstream's version is not reproduced: contact
+		// state is the core's, and a second writer would diverge from it.
+		expect(calls).toEqual([])
+	})
+})
+
+describe('resyncAppState is a no-op that says so once', () => {
+	it('resolves with upstream two required arguments', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.resyncAppState(['critical_unblock_low'], false)
+
+		expect(calls).toEqual([])
+	})
+
+	it('warns once, not per call', async () => {
+		const { logged, methods } = makeHarness()
+
+		await methods.resyncAppState(['regular'], false)
+		await methods.resyncAppState(['regular'], false)
+
+		expect(logged.filter(line => line.includes('resyncAppState')).length).toBe(1)
+	})
+})
+
+describe('onUnexpectedError reports rather than swallowing', () => {
+	it('logs the error with the context it was given', () => {
+		const { logged, methods } = makeHarness()
+
+		methods.onUnexpectedError(new Error('boom'), 'message handler')
+
+		expect(logged.some(line => line.includes('message handler'))).toBe(true)
+	})
+})
+
+/**
+ * Each refusal has to name why, because the reason is the whole content: a
+ * reader who only sees "not supported" files it as work to do later, and
+ * reimplementing any of these here is the thing the refusal exists to prevent.
+ */
+describe('the refusals name the reason, not just the absence', () => {
+	for (const [label, run, reason] of [
+		[
+			'updateServerTimeOffset',
+			(m: ReturnType<typeof makeHarness>['methods']) => async () => m.updateServerTimeOffset({ tag: 'iq', attrs: {} }),
+			/tracks the server clock offset itself/
+		],
+		[
+			'sendUnifiedSession',
+			(m: ReturnType<typeof makeHarness>['methods']) => () => m.sendUnifiedSession(),
+			/lifecycle machinery the engine owns/
+		],
+		[
+			'appPatch',
+			(m: ReturnType<typeof makeHarness>['methods']) => () => m.appPatch({} as never),
+			/use the typed chatModify variants/
+		]
+	] as const) {
+		it(`${label} rejects and says why`, async () => {
+			const { calls, methods } = makeHarness()
+
+			await expect(run(methods)()).rejects.toThrow(reason)
+			expect(calls).toEqual([])
+		})
+	}
+})
+
+describe('messageRetryManager is null rather than a second retry manager', () => {
+	it('is declared, and empty, because retry belongs to the engine', () => {
+		const { methods } = makeHarness()
+
+		expect(methods.messageRetryManager).toBe(null)
+	})
+})

--- a/src/__tests__/socket-internals-compatibility.test.ts
+++ b/src/__tests__/socket-internals-compatibility.test.ts
@@ -16,7 +16,7 @@ import { describe, it } from 'node:test'
 import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
 
 import makeWASocket from '../Socket/index.ts'
-import { makeInternalMethods } from '../Socket/internals.ts'
+import { makeInternalMethods, makeUnexpectedErrorReporter } from '../Socket/internals.ts'
 import type { SocketContext } from '../Socket/types.ts'
 import type { WAMessage } from '../Types/index.ts'
 import { makeEventBuffer } from '../Utils/event-buffer.ts'
@@ -207,32 +207,65 @@ describe('messageRetryManager is null rather than a second retry manager', () =>
 })
 
 /**
- * The hook is only an extension point if it resolves the current handler
- * instead of the one it captured when the socket was built. Two halves, one
- * per file: the socket exposes an accessor whose setter replaces the handler
- * its own failure paths report through, and this method reads that handler per
- * call rather than closing over the default.
+ * One reporter, shared by the socket's `onUnexpectedError` property and by the
+ * internal paths that raise failures, so a consumer's replacement is what those
+ * paths reach rather than a second handler nothing calls.
+ *
+ * It also has to survive a handler that throws: some of its callers are bridge
+ * callbacks that borrow memory and are forbidden from raising, so an exception
+ * escaping here would cost the session its borrowed batches.
  */
-describe('assigning onUnexpectedError replaces the handler the socket reports through', () => {
-	it('the method reports through whatever the context resolves to now', () => {
-		const seen: string[] = []
-		let handler: (err: unknown, msg: string) => void = () => undefined
-		const ctx = {
-			ev: makeEventBuffer(silentLogger),
-			logger: silentLogger,
-			fullConfig: {},
-			reportUnexpectedError: (err: unknown, msg: string) => handler(err, msg),
-			getClient: async () => undefined
-		} as unknown as SocketContext
-		const methods = makeInternalMethods(ctx)
+describe('the unexpected-error reporter is shared, replaceable and cannot throw', () => {
+	const makeLogger = () => {
+		const logged: Array<Record<string, unknown>> = []
+		const logger = {
+			level: 'silent',
+			child: () => logger,
+			trace: () => undefined,
+			debug: () => undefined,
+			info: () => undefined,
+			warn: () => undefined,
+			error: (fields: unknown, msg: unknown) => logged.push({ fields, msg })
+		} as unknown as ILogger
+		return { logged, logger }
+	}
 
-		handler = (_err, msg) => seen.push(msg)
-		methods.onUnexpectedError(new Error('boom'), 'a failing dispatcher')
+	it('reports through the logger until a consumer replaces the handler', () => {
+		const { logged, logger } = makeLogger()
+		const reporter = makeUnexpectedErrorReporter(logger)
 
-		expect(seen).toEqual(['a failing dispatcher'])
+		reporter.report(new Error('boom'), 'a failing dispatcher')
+
+		expect(logged.length).toBe(1)
+		expect(String(logged[0]!.msg)).toBe("unexpected error in 'a failing dispatcher'")
 	})
 
-	it('the socket exposes it as an accessor, so assignment is observed rather than shadowed', async () => {
+	it('a replaced handler receives what the internal paths report', () => {
+		const { logged, logger } = makeLogger()
+		const reporter = makeUnexpectedErrorReporter(logger)
+		const seen: string[] = []
+
+		reporter.handler = (_err, msg) => seen.push(msg)
+		reporter.report(new Error('boom'), 'a failing dispatcher')
+
+		expect(seen).toEqual(['a failing dispatcher'])
+		expect(logged.length).toBe(0)
+	})
+
+	it('a handler that throws does not raise into the caller, and the failure is still logged', () => {
+		const { logged, logger } = makeLogger()
+		const reporter = makeUnexpectedErrorReporter(logger)
+
+		reporter.handler = () => {
+			throw new Error('the handler itself blew up')
+		}
+		reporter.report(new Error('boom'), 'a failing dispatcher')
+
+		expect(logged.length).toBe(2)
+		expect(String(logged[1]!.msg)).toBe("unexpected error in 'a failing dispatcher'")
+	})
+
+	it('the socket wires the property to that reporter rather than a second one', async () => {
 		const authFolder = await mkdtemp(join(tmpdir(), 'baileyrs-hook-'))
 		try {
 			const { state } = await useMultiFileAuthState(authFolder)
@@ -251,5 +284,15 @@ describe('assigning onUnexpectedError replaces the handler the socket reports th
 		} finally {
 			await rm(authFolder, { recursive: true, force: true })
 		}
+	})
+})
+
+describe('resyncAppState keeps both arguments optional', () => {
+	it('a call with no arguments resolves, as it did before this surface was documented', async () => {
+		const { calls, methods } = makeHarness()
+
+		await methods.resyncAppState()
+
+		expect(calls).toEqual([])
 	})
 })

--- a/src/__tests__/socket-internals-compatibility.test.ts
+++ b/src/__tests__/socket-internals-compatibility.test.ts
@@ -9,13 +9,13 @@
  * where only the event half belongs to this layer.
  */
 
-import { EventEmitter } from 'node:events'
 import { describe, it } from 'node:test'
 import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
 
 import { makeInternalMethods } from '../Socket/internals.ts'
 import type { SocketContext } from '../Socket/types.ts'
 import type { WAMessage } from '../Types/index.ts'
+import { makeEventBuffer } from '../Utils/event-buffer.ts'
 import type { ILogger } from '../Utils/logger.ts'
 import { expect } from './expect.ts'
 
@@ -42,32 +42,40 @@ const makeHarness = (overrides: Record<string, unknown> = {}, connectTimeoutMs?:
 		}
 	}) as unknown as WasmWhatsAppClient
 	const events: Array<[string, unknown]> = []
-	const ev = new EventEmitter()
+	// The real buffer, not a stub: `upsertMessage` is buffered, and a stub that
+	// passed the work straight through would hide whether it still is.
+	const ev = makeEventBuffer(logger)
 	ev.on('messages.upsert', payload => events.push(['messages.upsert', payload]))
 	const ctx = {
 		ev,
 		logger,
 		fullConfig: connectTimeoutMs === undefined ? {} : { connectTimeoutMs },
+		reportUnexpectedError: (err: unknown, msg: string) => logger.error({ err }, `unexpected error in '${msg}'`),
 		getClient: async () => client
 	} as unknown as SocketContext
-	return { calls, events, logged, methods: makeInternalMethods(ctx) }
+	return { calls, ev, events, logged, methods: makeInternalMethods(ctx) }
 }
 
 describe('waitForSocketOpen waits for the socket, not for the login', () => {
 	it('takes the socket wait, since upstream waits for the transport to open', async () => {
-		const { calls, methods } = makeHarness({}, 20_000)
+		const { calls, methods } = makeHarness()
 
 		await methods.waitForSocketOpen()
 
 		expect(calls).toEqual([['waitForSocket', [20_000]]])
 	})
 
-	it('bounds the wait by the socket connect timeout rather than waiting forever', async () => {
+	/**
+	 * `connectTimeoutMs` reaches neither the transport nor the core, so binding
+	 * the wait to it would reject while the attempt behind it was still running.
+	 * The bound is the core's own connect ceiling instead.
+	 */
+	it('a shorter configured connect timeout does not shorten the wait', async () => {
 		const { calls, methods } = makeHarness({}, 5_000)
 
 		await methods.waitForSocketOpen()
 
-		expect(calls).toEqual([['waitForSocket', [5_000]]])
+		expect(calls).toEqual([['waitForSocket', [20_000]]])
 	})
 
 	it('a timeout from the bridge surfaces rather than resolving', async () => {
@@ -83,15 +91,34 @@ describe('waitForSocketOpen waits for the socket, not for the login', () => {
 
 describe('upsertMessage publishes the event and nothing else', () => {
 	it('emits messages.upsert with the message and type', async () => {
-		const { calls, events, methods } = makeHarness()
+		const { calls, ev, events, methods } = makeHarness()
 		const message = { key: { id: 'M1' } } as WAMessage
 
 		await methods.upsertMessage(message, 'notify')
+		ev.flush()
 
 		expect(events).toEqual([['messages.upsert', { messages: [message], type: 'notify' }]])
 		// The push-name half of upstream's version is not reproduced: contact
 		// state is the core's, and a second writer would diverge from it.
 		expect(calls).toEqual([])
+	})
+
+	/**
+	 * Upstream builds this through `createBufferedFunction`, so a replay that
+	 * pushes many messages lands as batches rather than one event each. A
+	 * consumer that grew listeners against that batching would see thousands of
+	 * invocations instead.
+	 */
+	it('buffers, so a back-to-back replay consolidates instead of one event each', async () => {
+		const { ev, events, methods } = makeHarness()
+		const first = { key: { id: 'M1' } } as WAMessage
+		const second = { key: { id: 'M2' } } as WAMessage
+
+		await Promise.all([methods.upsertMessage(first, 'notify'), methods.upsertMessage(second, 'notify')])
+		ev.flush()
+
+		expect(events.length).toBe(1)
+		expect((events[0]![1] as { messages: WAMessage[] }).messages.length).toBe(2)
 	})
 })
 

--- a/src/__tests__/socket-internals-compatibility.test.ts
+++ b/src/__tests__/socket-internals-compatibility.test.ts
@@ -9,15 +9,30 @@
  * where only the event half belongs to this layer.
  */
 
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, it } from 'node:test'
 import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
 
+import makeWASocket from '../Socket/index.ts'
 import { makeInternalMethods } from '../Socket/internals.ts'
 import type { SocketContext } from '../Socket/types.ts'
 import type { WAMessage } from '../Types/index.ts'
 import { makeEventBuffer } from '../Utils/event-buffer.ts'
 import type { ILogger } from '../Utils/logger.ts'
+import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
 import { expect } from './expect.ts'
+
+const silentLogger = {
+	level: 'silent',
+	child: () => silentLogger,
+	trace: () => undefined,
+	debug: () => undefined,
+	info: () => undefined,
+	warn: () => undefined,
+	error: () => undefined
+} as unknown as ILogger
 
 const makeHarness = (overrides: Record<string, unknown> = {}, connectTimeoutMs?: number) => {
 	const calls: Array<[string, unknown[]]> = []
@@ -188,5 +203,53 @@ describe('messageRetryManager is null rather than a second retry manager', () =>
 		const { methods } = makeHarness()
 
 		expect(methods.messageRetryManager).toBe(null)
+	})
+})
+
+/**
+ * The hook is only an extension point if it resolves the current handler
+ * instead of the one it captured when the socket was built. Two halves, one
+ * per file: the socket exposes an accessor whose setter replaces the handler
+ * its own failure paths report through, and this method reads that handler per
+ * call rather than closing over the default.
+ */
+describe('assigning onUnexpectedError replaces the handler the socket reports through', () => {
+	it('the method reports through whatever the context resolves to now', () => {
+		const seen: string[] = []
+		let handler: (err: unknown, msg: string) => void = () => undefined
+		const ctx = {
+			ev: makeEventBuffer(silentLogger),
+			logger: silentLogger,
+			fullConfig: {},
+			reportUnexpectedError: (err: unknown, msg: string) => handler(err, msg),
+			getClient: async () => undefined
+		} as unknown as SocketContext
+		const methods = makeInternalMethods(ctx)
+
+		handler = (_err, msg) => seen.push(msg)
+		methods.onUnexpectedError(new Error('boom'), 'a failing dispatcher')
+
+		expect(seen).toEqual(['a failing dispatcher'])
+	})
+
+	it('the socket exposes it as an accessor, so assignment is observed rather than shadowed', async () => {
+		const authFolder = await mkdtemp(join(tmpdir(), 'baileyrs-hook-'))
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const sock = makeWASocket({ auth: state, logger: silentLogger, waWebSocketUrl: 'ws://127.0.0.1:1' })
+			try {
+				const descriptor = Object.getOwnPropertyDescriptor(sock, 'onUnexpectedError')
+				const replacement = () => undefined
+
+				sock.onUnexpectedError = replacement
+
+				expect(typeof descriptor?.set).toBe('function')
+				expect(sock.onUnexpectedError).toBe(replacement)
+			} finally {
+				await (sock as unknown as { [Symbol.asyncDispose](): Promise<void> })[Symbol.asyncDispose]()
+			}
+		} finally {
+			await rm(authFolder, { recursive: true, force: true })
+		}
 	})
 })


### PR DESCRIPTION
## Summary

Upstream's socket exposes a set of internals alongside the consumer API: a wait for the socket to open, a message upsert helper, an unexpected-error hook, an app-state resync, a server clock offset setter, a unified-session sender, a generic app-state patch, and a retry manager. This package left all of them absent, so a caller written against upstream got `TypeError: sock.waitForSocketOpen is not a function` with nothing to tell them whether that was an oversight or a decision.

Most of that state lives in the Rust core by design. The work here is deciding which of the eight belong to this layer, implementing those, and making the rest refuse for a stated reason rather than being silently missing. A refusal that names the owner of the state is the useful outcome: it stops the next reader from filing the gap as work to do here, which is exactly the reimplementation the layer split exists to prevent.

New file `src/Socket/internals.ts`, spread into the socket after `makeChatActionMethods` so its documented `resyncAppState` replaces the undocumented one that file carried.

## Decision matrix

| Upstream member | Decision | Why |
| --- | --- | --- |
| `waitForSocketOpen()` | implemented | `waitForSocket`, not `waitForConnected`. Upstream waits for the transport to open, which is not the same as being logged in, and the bridge separates the two. Upstream takes no timeout and the bridge requires one, so the wait is bounded by the socket's own `connectTimeoutMs` and cannot outlive the attempt it waits on. |
| `upsertMessage(msg, type)` | implemented, event half only | Publishing onto the event bus is this layer's job. The push-name write upstream also does is not reproduced: contact state belongs to the core, and a second writer would diverge from the copy that is actually synced. |
| `onUnexpectedError(err, msg)` | implemented | A consumer extension point, not protocol state. Logs through the socket logger, and stays overridable so assigning to it replaces the default. |
| `resyncAppState(collections, isInitialSync)` | no-op, warns once | See below. |
| `updateServerTimeOffset(node)` | refused | Protocol state the core keeps from stanzas it already reads. |
| `sendUnifiedSession()` | refused | Connection lifecycle machinery, and refused one layer down as well. |
| `appPatch(patchCreate)` | refused | Would mean a second implementation of the patch format in TypeScript. |
| `messageRetryManager` | declared `null` | Retry belongs to the engine, so there is no manager to hand out. Declaring it null says that in the type instead of leaving the field missing. |

Parameter names match upstream exactly even where the body ignores the value, so the auditor reads these as matches rather than signature mismatches. The unused ones are discarded with `void x` rather than renamed to `_x`.

## Refused, and why

`updateServerTimeOffset` is refused because the core already tracks the offset from the stanzas it reads, and it is that offset that timestamps outgoing messages. A setter here would create a second clock that drifts from the one doing the work, and the caller would have no way to tell which one won.

`sendUnifiedSession` is refused because it is connection lifecycle, not a consumer operation. The refusal is not only a policy choice: the core's session instance is `pub(crate)`, and what does exist returns a half-built stanza plus a sequence number. Exposing it would hand JavaScript the job of finishing and sequencing a lifecycle stanza, which is the shape of bug this split is meant to avoid.

`appPatch` is refused because the bridge exposes app-state actions typed per action and deliberately offers no generic escape hatch. Accepting a raw `WAPatchCreate` here would mean building mutation indices and schema versions in TypeScript beside the copy the core already maintains, and the two would disagree the first time a schema version moved. Callers get the typed `chatModify` variants, which is the whole app-state surface this package can offer honestly.

Each rejection carries the reason in the message rather than a bare "not supported", for the reason in the Summary.

## resyncAppState

This one is a no-op rather than a refusal, and the distinction is the rule the rest of this series follows: throw when the caller's intent is not achieved, no-op when it already is by other means.

The engine syncs app state on connect, and re-syncs every collection when the server raises the `syncd_app_state` dirty bit. A caller reaching for `resyncAppState` wants the state current; it already is. There is no on-demand resync in the bridge to delegate to, so rejecting would abort a working flow to report the absence of a mechanism the caller does not actually need. It resolves, and warns once per socket rather than per call so a loop cannot flood the log.

The undocumented no-op that `chat-actions.ts` carried is removed in favour of this one, so there is a single answer for the method and it is the documented one.

## Deferred

Not in this PR, and not silently: `userDevicesCache`, `wamBuffer`, and the other upstream socket caches and buffers stay missing. They are windows onto state the core owns rather than operations, and exposing a JavaScript-side cache that no longer reflects what the engine uses would be worse than their absence. They belong in a gap prompt against the lower layers if a consumer turns out to need them, not in a shim here.

## Coverage

Audit against `baileys@7.0.0-rc13`:

- `main`: 97.47% (21789/22354)
- this branch: 97.58% (21813/22354)

Some of this work does not raise that number and was not meant to. `updateServerTimeOffset` still reads as a mismatch because upstream returns `void` and the refusal returns `never`, and it will keep reading as a mismatch for as long as it is a refusal. That is the honest state: the method is present and says why it cannot work, which is worth more to a caller than a matching signature that silently does nothing.

## Validation

- `npm run format`, `npm run lint`, `tsc --noEmit`: clean
- `npm test`: 731 passing, 0 failing
- 11 new tests in `src/__tests__/socket-internals-compatibility.test.ts`, covering which bridge wait is taken and that its timeout comes from the socket config, that a bridge timeout surfaces instead of resolving, that `upsertMessage` emits and touches nothing else, that `resyncAppState` resolves and warns once rather than per call, and that each refusal rejects with its stated reason and issues no bridge call
- Every assertion was checked by reverting the line it guards and confirming the test fails, not by reading it
- `test:e2e` not run, it needs a mock server not available here

---
_Generated by [Claude Code](https://claude.ai/code/session_019n5h4gDvrNFW4nCnf2YpMw)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines the socket’s internal API to match upstream and avoid TypeErrors while making core-owned items explicit refusals. Adds a shared, replaceable unexpected‑error reporter; routes internal failures through it and contains handler throws and rejections.

- **New Features**
  - `waitForSocketOpen()` waits for transport open via bridge `waitForSocket` with a 20s ceiling (not `connectTimeoutMs`).
  - `upsertMessage(msg, type)` is buffered and emits `messages.upsert` only.
  - `onUnexpectedError(err, msg)` is assignable and backed by one reporter used by dispatch and batch‑decode; handler failures (throws or rejects) are caught and logged.
  - `resyncAppState(...)` is a no‑op that warns once per socket; both args remain optional.
  - `updateServerTimeOffset`, `sendUnifiedSession`, `appPatch` reject with 501 and reasons; `messageRetryManager` is `null`.

- **Refactors**
  - Added `src/Socket/internals.ts` via `makeInternalMethods`; introduced `ctx.reportUnexpectedError` and used it in event dispatch and batch decoding.
  - Exposed `sock.onUnexpectedError` as an accessor wired to the shared reporter so assigning replaces the internal handler.
  - Removed the old no‑op `resyncAppState` from `chat-actions.ts`.

<sup>Written for commit 64c7c551a3a6b75bb5eadcf2763b3aa104567cd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved handling and reporting of unexpected connection and message-processing errors.
  - Added configurable error notifications so applications can respond consistently to socket failures.
  - Improved diagnostics for unsupported operations and connection timeouts.
  - Preserved existing chat action routing and event recovery behavior.

- **Bug Fixes**
  - Reduced direct error logging in favor of consistent error reporting.
  - Added compatibility coverage to help prevent regressions in socket behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->