### PR TITLE
fix(messages): stop dropping messageContextInfo on relay

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "compat:audit:json": "npm run build --silent && node scripts/compatibility/audit.ts --format=json",
     "compat:audit:missing": "npm run build --silent && node scripts/compatibility/audit.ts --only-missing",
     "compat:audit:proto": "node scripts/compatibility/proto-runtime-audit.ts --details --strict",
+    "compat:audit:wire": "node scripts/compatibility/wire-fidelity-audit.ts --details --strict",
     "compat:audit:strict": "npm run build --silent && node scripts/compatibility/audit.ts --strict --only-missing",
     "compat:sync-waproto": "node scripts/compatibility/waproto-facade.ts --sync",
     "compat:check-waproto": "node scripts/compatibility/waproto-facade.ts --check",

--- a/scripts/compatibility/__tests__/wire-fidelity.test.ts
+++ b/scripts/compatibility/__tests__/wire-fidelity.test.ts
@@ -58,12 +58,28 @@ describe('send-path wire fidelity auditor', () => {
 		)
 		assert.ok(dropped.has('messageContextInfo.messageAssociation'))
 		assert.ok(dropped.has('messageContextInfo.messageAddOnDurationInSecs'))
-		assert.equal(dropped.size, contextInfoFields.length + 1, 'every context field plus the container must be reported')
+		// The container case from the Message sweep plus one case per nested field.
+		const expected = ['messageContextInfo', ...contextInfoFields.map(field => `messageContextInfo.${field}`)]
+		assert.deepEqual([...dropped].toSorted(), expected.toSorted())
+	})
+
+	it('fails when the send path throws instead of reporting the case as skipped', async () => {
+		const report = await auditWireFidelity(buildFieldCases().slice(0, 3), async () => {
+			throw new Error('relay API regression')
+		})
+		assert.ok(fidelityAuditFailed(report))
+		assert.equal(report.summary.errored, 3)
+		assert.equal(report.summary.skipped, 0)
 	})
 
 	it('separates the known codec divergence from send-path findings', async () => {
 		const report = await auditWireFidelity(buildFieldCases())
 		assert.deepEqual(divergentPaths(report).toSorted(), KNOWN_DIVERGENT.toSorted())
+	})
+
+	it('rejects a zero seed rather than running a different one', async () => {
+		await assert.rejects(() => runCli(['--seed=0']), /non-zero integer/u)
+		assert.throws(() => buildFuzzCases(0, 1), /non-zero integer/u)
 	})
 
 	it('runs clean under --strict and prints the seed', async () => {

--- a/scripts/compatibility/__tests__/wire-fidelity.test.ts
+++ b/scripts/compatibility/__tests__/wire-fidelity.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { encodeProto } from '@oxidezap/whatsapp-rust-bridge'
+import { PROTO_MESSAGE_SCHEMAS } from '../../../src/WAProto/compatibility-schema.ts'
+import {
+	auditWireFidelity,
+	buildFieldCases,
+	buildFuzzCases,
+	divergentPaths,
+	fidelityAuditFailed,
+	renderFidelityReport
+} from '../wire-fidelity-core.ts'
+import { runCli } from '../wire-fidelity-audit.ts'
+
+const SEED = 20260808
+
+/**
+ * `pollResultSnapshotMessageV3` sits at field 115 in the bridge proto and 114 in
+ * baileys 7.0.0-rc13. Both codecs read their own bytes, so it is a schema gap
+ * rather than a send-path one; pinned here so a second divergence fails.
+ */
+const KNOWN_DIVERGENT = ['pollResultSnapshotMessageV3']
+
+const contextInfoFields = (
+	PROTO_MESSAGE_SCHEMAS.find(([path]) => path === 'MessageContextInfo')?.[1] ?? []
+).map(field => field[0])
+
+describe('send-path wire fidelity auditor', () => {
+	it('finds nothing dropped or altered on the current send path', async () => {
+		const report = await auditWireFidelity([...buildFieldCases(), ...buildFuzzCases(SEED, 200)])
+		assert.equal(report.summary.dropped, 0, renderFidelityReport(report, true))
+		assert.equal(report.summary.altered, 0, renderFidelityReport(report, true))
+		assert.equal(fidelityAuditFailed(report), false)
+		assert.ok(report.summary.preserved > 500)
+	})
+
+	it('exercises every messageContextInfo field', async () => {
+		const report = await auditWireFidelity(buildFieldCases())
+		const preserved = new Set(
+			report.findings.filter(finding => finding.status === 'preserved').map(finding => finding.path)
+		)
+		for (const field of contextInfoFields) {
+			assert.ok(preserved.has(`messageContextInfo.${field}`), `messageContextInfo.${field} was not exercised`)
+		}
+	})
+
+	// The auditor exists to catch the send path deleting messageContextInfo, so
+	// it has to fail when handed a sender that does exactly that.
+	it('reports a sender that deletes messageContextInfo', async () => {
+		const report = await auditWireFidelity(buildFieldCases(), async message => {
+			const copy = structuredClone(message)
+			delete copy.messageContextInfo
+			return encodeProto('Message', copy)
+		})
+		assert.ok(fidelityAuditFailed(report))
+		const dropped = new Set(
+			report.findings.filter(finding => finding.status === 'dropped').map(finding => finding.path)
+		)
+		assert.ok(dropped.has('messageContextInfo.messageAssociation'))
+		assert.ok(dropped.has('messageContextInfo.messageAddOnDurationInSecs'))
+		assert.equal(dropped.size, contextInfoFields.length + 1, 'every context field plus the container must be reported')
+	})
+
+	it('separates the known codec divergence from send-path findings', async () => {
+		const report = await auditWireFidelity(buildFieldCases())
+		assert.deepEqual(divergentPaths(report).toSorted(), KNOWN_DIVERGENT.toSorted())
+	})
+
+	it('runs clean under --strict and prints the seed', async () => {
+		const written: string[] = []
+		const write = process.stdout.write.bind(process.stdout)
+		process.stdout.write = (chunk: string | Uint8Array) => {
+			written.push(String(chunk))
+			return true
+		}
+		try {
+			assert.equal(await runCli(['--fuzz=25', `--seed=${SEED}`, '--strict']), 0)
+		} finally {
+			process.stdout.write = write
+		}
+		assert.match(written.join(''), /fuzz seed: 20260808/u)
+	})
+})

--- a/scripts/compatibility/tsconfig.json
+++ b/scripts/compatibility/tsconfig.json
@@ -5,5 +5,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["./**/*.ts", "./__tests__/fixtures/*.d.ts", "../clean-build.ts"]
+  "include": ["./**/*.ts", "./__tests__/fixtures/*.d.ts", "../clean-build.ts", "../../src/Types/globals.d.ts"]
 }

--- a/scripts/compatibility/wire-fidelity-audit.ts
+++ b/scripts/compatibility/wire-fidelity-audit.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
+import {
+	auditWireFidelity,
+	buildFieldCases,
+	buildFuzzCases,
+	fidelityAuditFailed,
+	renderFidelityReport
+} from './wire-fidelity-core.ts'
+
+const usage = `Baileyrs send-path wire fidelity auditor
+
+Checks that every proto field a caller sets reaches the bridge unchanged. The
+declaration auditor cannot see this: relayMessage keeps its upstream signature
+whatever the send path does to the bytes.
+
+Usage:
+  node scripts/compatibility/wire-fidelity-audit.ts [options]
+
+Options:
+  --seed <number>    Fuzz seed (default: 20260808)
+  --fuzz <number>    Fuzz cases on top of the schema sweep (default: 200)
+  --details          List skipped cases too
+  --strict           Exit 1 when a field is dropped or altered
+  --help             Show this help
+`
+
+export const runCli = async (argv: string[]): Promise<number> => {
+	let seed = 20260808
+	let fuzz = 200
+	let details = false
+	let strict = false
+
+	for (let index = 0; index < argv.length; index++) {
+		const option = argv[index]!
+		const [name, inline] = option.includes('=') ? [option.slice(0, option.indexOf('=')), option.slice(option.indexOf('=') + 1)] : [option, undefined]
+		const takeValue = () => {
+			if (inline !== undefined) return inline
+			const value = argv[index + 1]
+			if (!value || value.startsWith('--')) throw new Error(`${name} requires a value`)
+			index++
+			return value
+		}
+		switch (name) {
+			case '--help':
+			case '-h':
+				process.stdout.write(usage)
+				return 0
+			case '--details':
+				details = true
+				break
+			case '--strict':
+				strict = true
+				break
+			case '--seed':
+				seed = Number(takeValue())
+				break
+			case '--fuzz':
+				fuzz = Number(takeValue())
+				break
+			default:
+				throw new Error(`unknown option: ${option}`)
+		}
+	}
+
+	if (!Number.isInteger(seed) || !Number.isInteger(fuzz) || fuzz < 0) {
+		throw new Error('--seed and --fuzz must be integers, and --fuzz must not be negative')
+	}
+
+	const report = await auditWireFidelity([...buildFieldCases(), ...buildFuzzCases(seed, fuzz)])
+	process.stdout.write(`${renderFidelityReport(report, details)}\nfuzz seed: ${seed}\n`)
+	return strict && fidelityAuditFailed(report) ? 1 : 0
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	try {
+		process.exitCode = await runCli(process.argv.slice(2))
+	} catch (error) {
+		process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+		process.exitCode = 2
+	}
+}

--- a/scripts/compatibility/wire-fidelity-audit.ts
+++ b/scripts/compatibility/wire-fidelity-audit.ts
@@ -20,10 +20,10 @@ Usage:
   node scripts/compatibility/wire-fidelity-audit.ts [options]
 
 Options:
-  --seed <number>    Fuzz seed (default: 20260808)
+  --seed <number>    Fuzz seed, non-zero (default: 20260808)
   --fuzz <number>    Fuzz cases on top of the schema sweep (default: 200)
   --details          List skipped cases too
-  --strict           Exit 1 when a field is dropped or altered
+  --strict           Exit 1 when a field is dropped, altered, or the send path throws
   --help             Show this help
 `
 
@@ -65,9 +65,8 @@ export const runCli = async (argv: string[]): Promise<number> => {
 		}
 	}
 
-	if (!Number.isInteger(seed) || !Number.isInteger(fuzz) || fuzz < 0) {
-		throw new Error('--seed and --fuzz must be integers, and --fuzz must not be negative')
-	}
+	if (!Number.isInteger(seed) || seed === 0) throw new Error('--seed must be a non-zero integer')
+	if (!Number.isInteger(fuzz) || fuzz < 0) throw new Error('--fuzz must be a non-negative integer')
 
 	const report = await auditWireFidelity([...buildFieldCases(), ...buildFuzzCases(seed, fuzz)])
 	process.stdout.write(`${renderFidelityReport(report, details)}\nfuzz seed: ${seed}\n`)

--- a/scripts/compatibility/wire-fidelity-core.ts
+++ b/scripts/compatibility/wire-fidelity-core.ts
@@ -23,7 +23,7 @@ import {
  * other side.
  */
 
-export type FidelityStatus = 'preserved' | 'dropped' | 'altered' | 'divergent' | 'skipped'
+export type FidelityStatus = 'preserved' | 'dropped' | 'altered' | 'divergent' | 'errored' | 'skipped'
 
 export interface FidelityCase {
 	label: string
@@ -147,8 +147,11 @@ export const buildFieldCases = (): FidelityCase[] => {
 }
 
 // xorshift32: a seeded generator keeps a failing fuzz case reproducible from its seed alone.
+// Zero is rejected rather than remapped: it is a fixed point of the shift, and a
+// silently substituted seed would not reproduce the run it is printed with.
 const randomSource = (seed: number) => {
-	let state = seed || 1
+	if (!Number.isInteger(seed) || seed === 0) throw new Error('fuzz seed must be a non-zero integer')
+	let state = seed
 	return () => {
 		state ^= state << 13
 		state ^= state >>> 17
@@ -267,11 +270,13 @@ export const auditWireFidelity = async (
 			sentBytes = await send(testCase.message)
 			sent = decodeProto('Message', sentBytes)
 		} catch (error) {
+			// A send path that throws produces no auditable bytes at all, which is a
+			// harder failure than a dropped field, not a reason to skip the case.
 			for (const path of testCase.paths) {
 				findings.push({
 					label: testCase.label,
 					path,
-					status: 'skipped',
+					status: 'errored',
 					detail: error instanceof Error ? error.message : String(error)
 				})
 			}
@@ -301,13 +306,13 @@ export const auditWireFidelity = async (
 		}
 	}
 
-	const summary = { cases: cases.length, preserved: 0, dropped: 0, altered: 0, divergent: 0, skipped: 0 }
+	const summary = { cases: cases.length, preserved: 0, dropped: 0, altered: 0, divergent: 0, errored: 0, skipped: 0 }
 	for (const finding of findings) summary[finding.status]++
 	return { findings, summary }
 }
 
 export const fidelityAuditFailed = (report: FidelityReport): boolean =>
-	report.summary.dropped > 0 || report.summary.altered > 0
+	report.summary.dropped > 0 || report.summary.altered > 0 || report.summary.errored > 0
 
 /** Fields both codecs accept but place at different numbers; a codec gap, not a send-path one. */
 export const divergentPaths = (report: FidelityReport): string[] => [
@@ -318,7 +323,7 @@ export const renderFidelityReport = (report: FidelityReport, details = false): s
 	const lines = [
 		'send-path wire fidelity',
 		`cases: ${report.summary.cases}`,
-		`preserved: ${report.summary.preserved}  dropped: ${report.summary.dropped}  altered: ${report.summary.altered}  divergent: ${report.summary.divergent}  skipped: ${report.summary.skipped}`
+		`preserved: ${report.summary.preserved}  dropped: ${report.summary.dropped}  altered: ${report.summary.altered}  divergent: ${report.summary.divergent}  errored: ${report.summary.errored}  skipped: ${report.summary.skipped}`
 	]
 	for (const finding of report.findings) {
 		if (finding.status === 'preserved') continue

--- a/scripts/compatibility/wire-fidelity-core.ts
+++ b/scripts/compatibility/wire-fidelity-core.ts
@@ -1,0 +1,329 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { proto as upstreamProto } from 'baileys'
+import { decodeProto, encodeProto, type WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+import { makeMessageMethods } from '../../src/Socket/messages.ts'
+import type { SocketContext } from '../../src/Socket/types.ts'
+import type { WAProto } from '../../src/Types/index.ts'
+import {
+	PROTO_ENUM_SCHEMAS,
+	PROTO_FIELD_FLAG,
+	PROTO_FIELD_KIND,
+	PROTO_MESSAGE_SCHEMAS,
+	type ProtoFieldSchema,
+	type ProtoMessageSchema
+} from '../../src/WAProto/compatibility-schema.ts'
+
+/**
+ * Behavioural companion to the declaration auditor. That auditor compares
+ * `.d.ts` shapes, so a send path that quietly deletes a proto field scores 100%
+ * compatible: the signature is identical and only the bytes differ. This one
+ * plants proto fields on a message, pushes it through the real send path with a
+ * capturing bridge client, and reports every field that does not come out the
+ * other side.
+ */
+
+export type FidelityStatus = 'preserved' | 'dropped' | 'altered' | 'divergent' | 'skipped'
+
+export interface FidelityCase {
+	label: string
+	message: Record<string, unknown>
+	/** Dotted paths planted on the message; each must survive the send path. */
+	paths: string[]
+}
+
+export interface FidelityFinding {
+	label: string
+	path: string
+	status: FidelityStatus
+	detail?: string
+}
+
+export interface FidelityReport {
+	findings: FidelityFinding[]
+	summary: Record<FidelityStatus, number> & { cases: number }
+}
+
+const messageSchemas = PROTO_MESSAGE_SCHEMAS as readonly ProtoMessageSchema[]
+const enumSchemas = PROTO_ENUM_SCHEMAS as readonly (readonly [string, readonly (string | number)[]])[]
+
+const schemaByPath = new Map(messageSchemas.map(entry => [entry[0], entry] as const))
+
+const fieldsOf = (path: string): readonly ProtoFieldSchema[] => schemaByPath.get(path)?.[1] ?? []
+
+const isRepeated = (field: ProtoFieldSchema) => (field[3] & PROTO_FIELD_FLAG.repeated) !== 0
+const isMap = (field: ProtoFieldSchema) => (field[3] & PROTO_FIELD_FLAG.map) !== 0
+
+/** First non-zero member, so the sample is never a proto3 default that the encoder omits. */
+const enumSample = (reference: number): number | undefined => {
+	const entries = enumSchemas[reference]?.[1] ?? []
+	for (let index = 0; index + 1 < entries.length; index += 2) {
+		const value = entries[index + 1]
+		if (typeof value === 'number' && value > 0) return value
+	}
+	return undefined
+}
+
+const scalarSample = (field: ProtoFieldSchema): unknown => {
+	switch (field[1]) {
+		case PROTO_FIELD_KIND.string:
+			return 'fidelity'
+		case PROTO_FIELD_KIND.bool:
+			return true
+		case PROTO_FIELD_KIND.bytes:
+			return new Uint8Array([1, 2, 3, 4])
+		case PROTO_FIELD_KIND.float:
+			return 1.5
+		case PROTO_FIELD_KIND.enum:
+			return enumSample(field[2])
+		default:
+			return 7
+	}
+}
+
+const messageSample = (reference: number, depth: number): Record<string, unknown> | undefined => {
+	const schema = messageSchemas[reference]
+	if (!schema) return undefined
+	const sample: Record<string, unknown> = {}
+	for (const field of schema[1]) {
+		if (isMap(field) || isRepeated(field)) continue
+		const value =
+			field[1] === PROTO_FIELD_KIND.message
+				? depth > 0
+					? messageSample(field[2], depth - 1)
+					: undefined
+				: scalarSample(field)
+		if (value === undefined) continue
+		sample[field[0]] = value
+		// A couple of populated members is enough to prove the subtree travels.
+		if (Object.keys(sample).length === 2) break
+	}
+	return sample
+}
+
+const fieldSample = (field: ProtoFieldSchema, depth = 2): unknown => {
+	const value = field[1] === PROTO_FIELD_KIND.message ? messageSample(field[2], depth) : scalarSample(field)
+	if (value === undefined) return undefined
+	return isRepeated(field) ? [value] : value
+}
+
+const valueAt = (target: unknown, path: string): unknown => {
+	let cursor = target
+	for (const key of path.split('.')) {
+		if (cursor === null || typeof cursor !== 'object') return undefined
+		cursor = (cursor as Record<string, unknown>)[key]
+	}
+	return cursor
+}
+
+const plant = (container: Record<string, unknown>, path: string, value: unknown) => {
+	const keys = path.split('.')
+	const leaf = keys.pop()!
+	let cursor = container
+	for (const key of keys) {
+		cursor[key] ??= {}
+		cursor = cursor[key] as Record<string, unknown>
+	}
+	cursor[leaf] = value
+}
+
+/** One case per field of `Message` and of `MessageContextInfo`, straight from the upstream-derived schema. */
+export const buildFieldCases = (): FidelityCase[] => {
+	const cases: FidelityCase[] = []
+	const sweep = (owner: string, prefix: string) => {
+		for (const field of fieldsOf(owner)) {
+			if (isMap(field)) continue
+			const sample = fieldSample(field)
+			if (sample === undefined) continue
+			const path = prefix ? `${prefix}.${field[0]}` : field[0]
+			const message: Record<string, unknown> = {}
+			plant(message, path, sample)
+			cases.push({ label: `${owner}.${field[0]}`, message, paths: [path] })
+		}
+	}
+	sweep('Message', '')
+	sweep('MessageContextInfo', 'messageContextInfo')
+	return cases
+}
+
+// xorshift32: a seeded generator keeps a failing fuzz case reproducible from its seed alone.
+const randomSource = (seed: number) => {
+	let state = seed || 1
+	return () => {
+		state ^= state << 13
+		state ^= state >>> 17
+		state ^= state << 5
+		return ((state >>> 0) % 1_000_000) / 1_000_000
+	}
+}
+
+/**
+ * Random field combinations rather than one field at a time: a send path can
+ * preserve every field alone and still lose one when a neighbour is present.
+ */
+export const buildFuzzCases = (seed: number, count: number): FidelityCase[] => {
+	const random = randomSource(seed)
+	const contentFields = fieldsOf('Message').filter(field => !isMap(field) && field[0] !== 'messageContextInfo')
+	const contextFields = fieldsOf('MessageContextInfo').filter(field => !isMap(field))
+	const cases: FidelityCase[] = []
+
+	for (let index = 0; index < count; index++) {
+		const message: Record<string, unknown> = {}
+		const paths: string[] = []
+		const content = contentFields[Math.floor(random() * contentFields.length)]
+		if (content) {
+			const sample = fieldSample(content)
+			if (sample !== undefined) {
+				plant(message, content[0], sample)
+				paths.push(content[0])
+			}
+		}
+		for (const field of contextFields) {
+			if (random() < 0.5) continue
+			const sample = fieldSample(field)
+			if (sample === undefined) continue
+			const path = `messageContextInfo.${field[0]}`
+			plant(message, path, sample)
+			paths.push(path)
+		}
+		if (!paths.length) continue
+		cases.push({ label: `fuzz#${index}`, message, paths })
+	}
+	return cases
+}
+
+const capturingContext = (captured: Uint8Array[]): SocketContext => {
+	const client = {
+		relayMessageBytesWithOptions: async (_jid: string, bytes: Uint8Array, messageId: string) => {
+			captured.push(bytes)
+			return messageId
+		}
+	} as unknown as WasmWhatsAppClient
+	const logger = {
+		level: 'silent',
+		child: () => logger,
+		trace: () => undefined,
+		debug: () => undefined,
+		info: () => undefined,
+		warn: () => undefined,
+		error: () => undefined
+	}
+	return {
+		ev: Object.assign(new EventEmitter(), {
+			createBufferedFunction: <Args extends unknown[], Result>(work: (...args: Args) => Promise<Result>) => work
+		}),
+		logger,
+		fullConfig: { options: {}, emitOwnEvents: false },
+		getUser: () => ({ id: '15550000000@s.whatsapp.net', lid: '100000000000000@lid' }),
+		getMe: () => ({ id: '15550000000@s.whatsapp.net', lid: '100000000000000@lid' }),
+		getClient: async () => client
+	} as unknown as SocketContext
+}
+
+export type WireSender = (message: Record<string, unknown>) => Promise<Uint8Array>
+
+export const relayedBytes: WireSender = async message => {
+	const captured: Uint8Array[] = []
+	const ctx = capturingContext(captured)
+	await makeMessageMethods(ctx).relayMessage(
+		'120363000000000000@g.us',
+		structuredClone(message) as WAProto.IMessage,
+		{ messageId: '3EB0FIDELITY000000' }
+	)
+	const bytes = captured[0]
+	if (!bytes) throw new Error('the send path handed no bytes to the bridge')
+	return bytes
+}
+
+const upstreamSees = (bytes: Uint8Array, path: string): boolean => {
+	const decoded = upstreamProto.Message.toObject(upstreamProto.Message.decode(bytes), {
+		longs: Number,
+		enums: Number,
+		bytes: Uint8Array,
+		defaults: false,
+		arrays: false,
+		objects: false,
+		oneofs: false
+	}) as Record<string, unknown>
+	return valueAt(decoded, path) !== undefined
+}
+
+/**
+ * Runs every case through `relayMessage` and compares what the bridge received
+ * with a plain encode of the same input. Same encoder on both sides, so any
+ * difference is the send path's doing.
+ */
+export const auditWireFidelity = async (
+	cases: readonly FidelityCase[],
+	send: WireSender = relayedBytes
+): Promise<FidelityReport> => {
+	const findings: FidelityFinding[] = []
+
+	for (const testCase of cases) {
+		const reference = decodeProto('Message', encodeProto('Message', testCase.message))
+		let sent: unknown
+		let sentBytes: Uint8Array
+		try {
+			sentBytes = await send(testCase.message)
+			sent = decodeProto('Message', sentBytes)
+		} catch (error) {
+			for (const path of testCase.paths) {
+				findings.push({
+					label: testCase.label,
+					path,
+					status: 'skipped',
+					detail: error instanceof Error ? error.message : String(error)
+				})
+			}
+			continue
+		}
+
+		for (const path of testCase.paths) {
+			if (valueAt(reference, path) === undefined) {
+				findings.push({ label: testCase.label, path, status: 'skipped', detail: 'sample does not survive the codec' })
+				continue
+			}
+			if (valueAt(sent, path) === undefined) {
+				findings.push({ label: testCase.label, path, status: 'dropped', detail: 'absent from the bytes sent to the bridge' })
+				continue
+			}
+			try {
+				assert.deepStrictEqual(valueAt(sent, path), valueAt(reference, path))
+			} catch {
+				findings.push({ label: testCase.label, path, status: 'altered', detail: 'value differs from a plain encode' })
+				continue
+			}
+			if (!upstreamSees(sentBytes, path)) {
+				findings.push({ label: testCase.label, path, status: 'divergent', detail: 'upstream protobufjs reads this field at another number' })
+				continue
+			}
+			findings.push({ label: testCase.label, path, status: 'preserved' })
+		}
+	}
+
+	const summary = { cases: cases.length, preserved: 0, dropped: 0, altered: 0, divergent: 0, skipped: 0 }
+	for (const finding of findings) summary[finding.status]++
+	return { findings, summary }
+}
+
+export const fidelityAuditFailed = (report: FidelityReport): boolean =>
+	report.summary.dropped > 0 || report.summary.altered > 0
+
+/** Fields both codecs accept but place at different numbers; a codec gap, not a send-path one. */
+export const divergentPaths = (report: FidelityReport): string[] => [
+	...new Set(report.findings.filter(finding => finding.status === 'divergent').map(finding => finding.path))
+]
+
+export const renderFidelityReport = (report: FidelityReport, details = false): string => {
+	const lines = [
+		'send-path wire fidelity',
+		`cases: ${report.summary.cases}`,
+		`preserved: ${report.summary.preserved}  dropped: ${report.summary.dropped}  altered: ${report.summary.altered}  divergent: ${report.summary.divergent}  skipped: ${report.summary.skipped}`
+	]
+	for (const finding of report.findings) {
+		if (finding.status === 'preserved') continue
+		if (finding.status === 'skipped' && !details) continue
+		lines.push(`- [${finding.status}] ${finding.label} :: ${finding.path}${finding.detail ? ` (${finding.detail})` : ''}`)
+	}
+	return lines.join('\n')
+}

--- a/src/Socket/messages.ts
+++ b/src/Socket/messages.ts
@@ -28,28 +28,6 @@ function getMediaContent(content: WAMessageContent | null | undefined) {
 	)
 }
 
-/**
- * Drop `messageContextInfo` before handing the proto to the Rust bridge so the
- * bridge can fill in its own `messageSecret` / `reportingTokenVersion`.
- *
- * Exception: pin messages need `messageAddOnDurationInSecs` (86400 / 604800 /
- * 2592000 to pin, 0 to unpin). The bridge does not set this field, so we save
- * it across the delete and restore it on a fresh contextInfo.
- *
- * Mutates `msg` in place.
- *
- * `contentType` is a parameter so the send path can hand over the type it has
- * already resolved rather than have it scanned out of `msg` a second time.
- */
-export function stripContextInfoForBridge(msg: WAMessageContent, contentType = getContentType(msg)): void {
-	const pinAddOnDuration =
-		contentType === 'pinInChatMessage' ? msg.messageContextInfo?.messageAddOnDurationInSecs : undefined
-	delete (msg as Record<string, unknown>).messageContextInfo
-	if (pinAddOnDuration !== undefined && pinAddOnDuration !== null) {
-		msg.messageContextInfo = { messageAddOnDurationInSecs: pinAddOnDuration }
-	}
-}
-
 type NormalizedUserJid = { userId: string; jid: string }
 const normalizedUserJids = new WeakMap<SocketContext, NormalizedUserJid>()
 
@@ -117,8 +95,6 @@ export const makeMessageMethods = (ctx: SocketContext) => ({
 				return fullMsg
 			}
 		}
-
-		stripContextInfoForBridge(msg, contentType)
 
 		let msgId: string
 		const msgBytes = encodeProto('Message', msg as Record<string, unknown>)
@@ -208,8 +184,9 @@ export const makeMessageMethods = (ctx: SocketContext) => ({
 			'relayMessage compatibility plan'
 		)
 
-		stripContextInfoForBridge(message as WAMessageContent)
-
+		// The message goes to the bridge as the caller built it: the core merges
+		// its own messageSecret / reportingTokenVersion over whatever arrives, so
+		// nothing in messageContextInfo has to be dropped on this side.
 		const bytes = encodeProto('Message', message)
 		if (plan.kind === 'retransmission') {
 			await client.retransmitMessageBytes(jid, bytes, plan.input)

--- a/src/Socket/messages.ts
+++ b/src/Socket/messages.ts
@@ -184,9 +184,9 @@ export const makeMessageMethods = (ctx: SocketContext) => ({
 			'relayMessage compatibility plan'
 		)
 
-		// The message goes to the bridge as the caller built it: the core merges
-		// its own messageSecret / reportingTokenVersion over whatever arrives, so
-		// nothing in messageContextInfo has to be dropped on this side.
+		// The message goes to the bridge as the caller built it: the core settles
+		// messageSecret / reportingTokenVersion itself, reusing a caller-set secret
+		// rather than replacing it, so nothing here has to be dropped.
 		const bytes = encodeProto('Message', message)
 		if (plan.kind === 'retransmission') {
 			await client.retransmitMessageBytes(jid, bytes, plan.input)

--- a/src/__tests__/content-type-resolution.test.ts
+++ b/src/__tests__/content-type-resolution.test.ts
@@ -1,6 +1,5 @@
 import { describe, it } from 'node:test'
 import { PROTO_MESSAGE_SCHEMAS } from '../WAProto/compatibility-schema.ts'
-import { stripContextInfoForBridge } from '../Socket/messages.ts'
 import type { WAMessage, WAMessageContent } from '../Types/index.ts'
 import { WAProto } from '../Types/index.ts'
 import { proto } from '../WAProto/runtime.ts'
@@ -158,30 +157,5 @@ describe('generateWAMessageFromContent — content key branches', () => {
 			ephemeralExpiration: 86400
 		})
 		expect(wm.message?.extendedTextMessage?.contextInfo).toBeFalsy()
-	})
-})
-
-describe('stripContextInfoForBridge — caller-supplied content type', () => {
-	const pinContent = () =>
-		WAProto.Message.create({
-			pinInChatMessage: { type: proto.PinInChat.Type.PIN_FOR_ALL, senderTimestampMs: 1700000000000 },
-			messageContextInfo: { messageAddOnDurationInSecs: 604800, messageSecret: new Uint8Array(32) }
-		}) as WAMessageContent
-
-	it('matches the type it would have resolved on its own', () => {
-		const resolved = pinContent()
-		const passed = pinContent()
-		stripContextInfoForBridge(resolved)
-		stripContextInfoForBridge(passed, getContentType(passed))
-		expect(passed.messageContextInfo?.messageAddOnDurationInSecs).toBe(
-			resolved.messageContextInfo?.messageAddOnDurationInSecs
-		)
-		expect(passed.messageContextInfo?.messageAddOnDurationInSecs).toBe(604800)
-	})
-
-	it('honours a caller that says the message is not a pin', () => {
-		const msg = pinContent()
-		stripContextInfoForBridge(msg, 'conversation')
-		expect(Object.hasOwn(msg, 'messageContextInfo')).toBe(false)
 	})
 })

--- a/src/__tests__/pin-message.test.ts
+++ b/src/__tests__/pin-message.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from 'node:test'
 import { decodeProto, encodeProto } from '@oxidezap/whatsapp-rust-bridge'
 import { proto } from '@oxidezap/whatsapp-rust-bridge/proto-types'
-import { stripContextInfoForBridge } from '../Socket/messages.ts'
 import type { WAMessageContent } from '../Types/index.ts'
 import { generateWAMessageContent } from '../Utils/messages.ts'
 import { expect } from './expect.ts'
@@ -16,15 +15,12 @@ import { expect } from './expect.ts'
  *   - 0       → unpin
  *
  * The Rust bridge fills its own `messageSecret` / `reportingTokenVersion`
- * inside `messageContextInfo`, so the JS side strips the field before sending
- * — but for pins we have to keep `messageAddOnDurationInSecs` or the server
- * silently ignores the pin. The bridge merges fields it does not own
- * (verified in `wacore/src/reporting_token.rs::prepare_message_with_context`),
- * so passing the field through is safe.
+ * inside `messageContextInfo` by merging them over what it receives, so the JS
+ * side hands the field over untouched and the duration reaches the server.
  *
- * The `stripContextInfoForBridge` block exercises the actual send path: it
- * runs the helper and then encodes/decodes via the bridge so a regression
- * in either the strip logic OR the proto encoder fails the test.
+ * The codec block below encodes/decodes via the bridge so a regression in the
+ * proto encoder fails the test; the send path itself is covered in
+ * `relay-message-context-info.test.ts`.
  */
 
 const stubKey = {
@@ -41,8 +37,6 @@ interface DecodedMessage {
 		senderTimestampMs?: number
 	}
 	messageContextInfo?: { messageAddOnDurationInSecs?: number }
-	conversation?: string
-	extendedTextMessage?: { text?: string }
 }
 
 type PinTime = 86400 | 604800 | 2592000
@@ -51,7 +45,6 @@ function buildPin(extra: { type: proto.PinInChat.Type; time?: PinTime }): Promis
 }
 
 function bridgeRoundtrip(msg: WAMessageContent): DecodedMessage {
-	stripContextInfoForBridge(msg)
 	const bytes = encodeProto('Message', msg as unknown as Record<string, unknown>)
 	return decodeProto('Message', bytes) as DecodedMessage
 }
@@ -99,7 +92,7 @@ describe('generateWAMessageContent — pin message', () => {
 	})
 })
 
-describe('stripContextInfoForBridge — actual send-path behaviour', () => {
+describe('pin duration survives the proto codec', () => {
 	it('preserves pin duration through encodeProto roundtrip (PIN_FOR_ALL, 7d)', async () => {
 		const m = await buildPin({ type: proto.PinInChat.Type.PIN_FOR_ALL, time: 604800 })
 		const decoded = bridgeRoundtrip(m)
@@ -119,45 +112,5 @@ describe('stripContextInfoForBridge — actual send-path behaviour', () => {
 		const m = await buildPin({ type: proto.PinInChat.Type.UNPIN_FOR_ALL })
 		const decoded = bridgeRoundtrip(m)
 		expect(decoded.messageContextInfo?.messageAddOnDurationInSecs).toBe(0)
-	})
-
-	it('strips messageContextInfo entirely from non-pin messages (field absent on the wire)', async () => {
-		const m = await generateWAMessageContent({ text: 'hello' }, noopOptions)
-		// Plant a stale field to prove it gets stripped.
-		;(m as { messageContextInfo?: unknown }).messageContextInfo = {
-			messageSecret: new Uint8Array(32),
-			messageAddOnDurationInSecs: 999
-		}
-		stripContextInfoForBridge(m)
-		// The own field is gone, so the encoder will not emit it. A generated
-		// protobuf class still exposes upstream's inherited `null` default.
-		expect(Object.hasOwn(m, 'messageContextInfo')).toBe(false)
-		expect((m as { messageContextInfo?: unknown }).messageContextInfo).toBe(null)
-
-		// Sanity: the rest of the message still encodes/decodes.
-		const decoded = decodeProto(
-			'Message',
-			encodeProto('Message', m as unknown as Record<string, unknown>)
-		) as DecodedMessage
-		expect(decoded.extendedTextMessage?.text).toBe('hello')
-	})
-
-	it('strips bridge-owned fields on pins, keeping ONLY messageAddOnDurationInSecs', async () => {
-		const m = await buildPin({ type: proto.PinInChat.Type.PIN_FOR_ALL, time: 604800 })
-		// Plant fields the bridge owns; they must not survive the strip.
-		;(m as { messageContextInfo?: Record<string, unknown> }).messageContextInfo = {
-			messageAddOnDurationInSecs: 604800,
-			messageSecret: new Uint8Array(32).fill(0xab),
-			reportingTokenVersion: 7
-		}
-		stripContextInfoForBridge(m)
-		// Inspect the live JS object: the strip must have replaced the contextInfo
-		// with a fresh one that contains only the duration. The proto3 wire format
-		// can't tell "absent bytes" from "empty bytes" on decode, so we assert
-		// against the in-memory object that the encoder will see.
-		const ctx = m.messageContextInfo as Record<string, unknown> | undefined
-		expect(ctx).toBeDefined()
-		expect(Object.keys(ctx as object).toSorted()).toEqual(['messageAddOnDurationInSecs'])
-		expect(ctx?.messageAddOnDurationInSecs).toBe(604800)
 	})
 })

--- a/src/__tests__/quoted-media-enum-regression.test.ts
+++ b/src/__tests__/quoted-media-enum-regression.test.ts
@@ -5,7 +5,6 @@ import { decodeProto, encodeMessageWireBatch, encodeProto } from '@oxidezap/what
 import { proto } from '@oxidezap/whatsapp-rust-bridge/proto-types'
 
 import { makeEventHandlers } from '../Socket/events.ts'
-import { stripContextInfoForBridge } from '../Socket/messages.ts'
 import type { SocketContext } from '../Socket/types.ts'
 import type { BaileysEventMap, WAMessage } from '../Types/index.ts'
 import { generateWAMessageContent, generateWAMessageFromContent } from '../Utils/messages.ts'
@@ -119,8 +118,6 @@ describe('quoted media enum regression', () => {
 			userJid: 'fixture-bot@lid',
 			timestamp: new Date(1_750_000_100_000)
 		})
-		stripContextInfoForBridge(outgoing.message!)
-
 		// This was the failing production boundary: the old reflected event
 		// transport produced the string "IMAGE", which ts-proto coerced to NaN.
 		const outgoingBytes = encodeProto('Message', outgoing.message as Record<string, unknown>)

--- a/src/__tests__/relay-message-context-info.test.ts
+++ b/src/__tests__/relay-message-context-info.test.ts
@@ -1,0 +1,215 @@
+import { EventEmitter } from 'node:events'
+import { describe, it } from 'node:test'
+import { decodeProto, type WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+import { proto } from '@oxidezap/whatsapp-rust-bridge/proto-types'
+import { makeMessageMethods } from '../Socket/messages.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import type { WAProto } from '../Types/index.ts'
+import type { ILogger } from '../Utils/logger.ts'
+import { expect } from './expect.ts'
+
+/**
+ * `messageContextInfo` is where a caller puts everything the protocol keeps
+ * beside the content: the album association that binds each image to its album
+ * parent, device list metadata, bot metadata, padding, add-on expiry, and the
+ * poll secret. The send path must hand all of it to the bridge, which owns
+ * `messageSecret` / `reportingTokenVersion` and merges its own values over
+ * whatever arrives, so nothing has to be removed on this side.
+ */
+
+const logger = {
+	level: 'silent',
+	child: () => logger,
+	trace: () => undefined,
+	debug: () => undefined,
+	info: () => undefined,
+	warn: () => undefined,
+	error: () => undefined
+} as ILogger
+
+interface DecodedContextInfo {
+	messageAssociation?: {
+		associationType?: number
+		parentMessageKey?: { id?: string; remoteJid?: string; fromMe?: boolean }
+	}
+	deviceListMetadata?: { senderKeyHash?: Uint8Array; senderTimestamp?: number }
+	deviceListMetadataVersion?: number
+	botMetadata?: { personaId?: string }
+	paddingBytes?: Uint8Array
+	messageAddOnExpiryType?: number
+	messageAddOnDurationInSecs?: number
+	messageSecret?: Uint8Array
+	reportingTokenVersion?: number
+}
+
+interface DecodedMessage {
+	conversation?: string
+	albumMessage?: { expectedImageCount?: number; expectedVideoCount?: number }
+	imageMessage?: { url?: string }
+	pinInChatMessage?: { key?: { id?: string } }
+	messageContextInfo?: DecodedContextInfo
+}
+
+const makeCapturingContext = () => {
+	const relayed: Uint8Array[] = []
+	const sent: Uint8Array[] = []
+	const client = {
+		relayMessageBytesWithOptions: async (_jid: string, bytes: Uint8Array, messageId: string) => {
+			relayed.push(bytes)
+			return messageId
+		},
+		sendMessageBytes: async (_jid: string, bytes: Uint8Array) => {
+			sent.push(bytes)
+			return '3EB0AAAAAAAAAAAAAAAA'
+		}
+	} as unknown as WasmWhatsAppClient
+	const ctx = {
+		ev: Object.assign(new EventEmitter(), {
+			createBufferedFunction: <Args extends unknown[], Result>(work: (...args: Args) => Promise<Result>) => work
+		}),
+		logger,
+		fullConfig: { options: {}, emitOwnEvents: false },
+		getUser: () => ({ id: '15550000000@s.whatsapp.net', lid: '100000000000000@lid' }),
+		getMe: () => ({ id: '15550000000@s.whatsapp.net', lid: '100000000000000@lid' }),
+		getClient: async () => client
+	} as unknown as SocketContext
+	return { ctx, relayed, sent }
+}
+
+const groupJid = '120363000000000000@g.us'
+
+const albumParentKey = {
+	remoteJid: groupJid,
+	fromMe: true,
+	id: 'ACCB5994EBDE5FE23D1ECFDC0E0E7131'
+}
+
+const relayDecoded = async (message: WAProto.IMessage): Promise<DecodedMessage> => {
+	const { ctx, relayed } = makeCapturingContext()
+	await makeMessageMethods(ctx).relayMessage(groupJid, message, { messageId: albumParentKey.id })
+	expect(relayed).toHaveLength(1)
+	return decodeProto('Message', relayed[0]!) as DecodedMessage
+}
+
+const albumChild = (): WAProto.IMessage =>
+	({
+		imageMessage: { url: 'https://example.invalid/media', mimetype: 'image/jpeg' },
+		messageContextInfo: {
+			messageAssociation: {
+				associationType: proto.MessageAssociation.AssociationType.MEDIA_ALBUM,
+				parentMessageKey: albumParentKey
+			}
+		}
+	}) as unknown as WAProto.IMessage
+
+const withContextInfo = (messageContextInfo: Record<string, unknown>): WAProto.IMessage =>
+	({ conversation: 'album member', messageContextInfo }) as unknown as WAProto.IMessage
+
+describe('relayMessage: messageContextInfo reaches the bridge', () => {
+	it('keeps the album association that binds an image to its album parent', async () => {
+		const decoded = await relayDecoded(albumChild())
+		const association = decoded.messageContextInfo?.messageAssociation
+		expect(association?.associationType).toBe(proto.MessageAssociation.AssociationType.MEDIA_ALBUM)
+		expect(association?.parentMessageKey?.id).toBe(albumParentKey.id)
+		expect(association?.parentMessageKey?.remoteJid).toBe(groupJid)
+		expect(association?.parentMessageKey?.fromMe).toBe(true)
+	})
+
+	it('keeps deviceListMetadata and its version', async () => {
+		const decoded = await relayDecoded(
+			withContextInfo({
+				deviceListMetadata: { senderKeyHash: new Uint8Array(8).fill(0x0a), senderTimestamp: 1_750_000_000 },
+				deviceListMetadataVersion: 2
+			})
+		)
+		expect(decoded.messageContextInfo?.deviceListMetadata?.senderTimestamp).toBe(1_750_000_000)
+		expect([...(decoded.messageContextInfo?.deviceListMetadata?.senderKeyHash ?? [])]).toEqual([
+			...new Uint8Array(8).fill(0x0a)
+		])
+		expect(decoded.messageContextInfo?.deviceListMetadataVersion).toBe(2)
+	})
+
+	it('keeps botMetadata', async () => {
+		const decoded = await relayDecoded(withContextInfo({ botMetadata: { personaId: 'persona-42' } }))
+		expect(decoded.messageContextInfo?.botMetadata?.personaId).toBe('persona-42')
+	})
+
+	it('keeps paddingBytes', async () => {
+		const decoded = await relayDecoded(withContextInfo({ paddingBytes: new Uint8Array([1, 2, 3, 4]) }))
+		expect([...(decoded.messageContextInfo?.paddingBytes ?? [])]).toEqual([1, 2, 3, 4])
+	})
+
+	it('keeps messageAddOnExpiryType', async () => {
+		const decoded = await relayDecoded(
+			withContextInfo({ messageAddOnExpiryType: proto.MessageContextInfo.MessageAddonExpiryType.STATIC })
+		)
+		expect(decoded.messageContextInfo?.messageAddOnExpiryType).toBe(
+			proto.MessageContextInfo.MessageAddonExpiryType.STATIC
+		)
+	})
+
+	it('keeps messageAddOnDurationInSecs on a relayed pin', async () => {
+		const decoded = await relayDecoded({
+			pinInChatMessage: { key: { id: 'PIN0000000000000000' }, type: proto.PinInChat.Type.PIN_FOR_ALL },
+			messageContextInfo: { messageAddOnDurationInSecs: 604800 }
+		} as unknown as WAProto.IMessage)
+		expect(decoded.messageContextInfo?.messageAddOnDurationInSecs).toBe(604800)
+		expect(decoded.pinInChatMessage?.key?.id).toBe('PIN0000000000000000')
+	})
+
+	// The core reuses a caller-set secret rather than minting a fresh one
+	// (polls need the secret they will later decrypt votes with).
+	it('keeps a caller-set messageSecret', async () => {
+		const secret = new Uint8Array(32).fill(0xab)
+		const decoded = await relayDecoded(withContextInfo({ messageSecret: secret }))
+		expect([...(decoded.messageContextInfo?.messageSecret ?? [])]).toEqual([...secret])
+	})
+
+	it('leaves a message without messageContextInfo alone', async () => {
+		const decoded = await relayDecoded({ conversation: 'no context here' })
+		expect(decoded.conversation).toBe('no context here')
+		expect(decoded.messageContextInfo).toBeFalsy()
+	})
+
+	it('passes an empty messageContextInfo along without inventing fields', async () => {
+		const decoded = await relayDecoded(withContextInfo({}))
+		expect(decoded.conversation).toBe('album member')
+		expect(Object.hasOwn(decoded, 'messageContextInfo')).toBe(true)
+		expect(Object.keys(decoded.messageContextInfo ?? {})).toHaveLength(0)
+	})
+
+	it('passes a context that holds only bridge-owned fields through untouched', async () => {
+		const decoded = await relayDecoded(
+			withContextInfo({ messageSecret: new Uint8Array(32).fill(0x11), reportingTokenVersion: 2 })
+		)
+		expect(decoded.messageContextInfo?.reportingTokenVersion).toBe(2)
+		expect([...(decoded.messageContextInfo?.messageSecret ?? [])]).toEqual([...new Uint8Array(32).fill(0x11)])
+	})
+})
+
+describe('relayMessage: album parent', () => {
+	// The album parent carries its counters as content, not context, so it was
+	// never at risk. Asserted here to keep the two halves of the album apart:
+	// an empty `albumMessage` seen in someone else's quote is not this path.
+	it('relays the album counters as sent', async () => {
+		const decoded = await relayDecoded({
+			albumMessage: { expectedImageCount: 5, expectedVideoCount: 0 }
+		} as unknown as WAProto.IMessage)
+		expect(decoded.albumMessage?.expectedImageCount).toBe(5)
+	})
+})
+
+describe('sendMessage: messageContextInfo reaches the bridge', () => {
+	it('keeps the pin duration generated for a pin', async () => {
+		const { ctx, sent } = makeCapturingContext()
+		await makeMessageMethods(ctx).sendMessage(groupJid, {
+			pin: { remoteJid: groupJid, fromMe: false, id: 'AABBCCDD11223344' },
+			type: proto.PinInChat.Type.PIN_FOR_ALL,
+			time: 604800
+		})
+		expect(sent).toHaveLength(1)
+		const decoded = decodeProto('Message', sent[0]!) as DecodedMessage
+		expect(decoded.messageContextInfo?.messageAddOnDurationInSecs).toBe(604800)
+		expect(decoded.pinInChatMessage?.key?.id).toBe('AABBCCDD11223344')
+	})
+})

--- a/src/__tests__/relay-message-context-info.test.ts
+++ b/src/__tests__/relay-message-context-info.test.ts
@@ -12,9 +12,10 @@ import { expect } from './expect.ts'
  * `messageContextInfo` is where a caller puts everything the protocol keeps
  * beside the content: the album association that binds each image to its album
  * parent, device list metadata, bot metadata, padding, add-on expiry, and the
- * poll secret. The send path must hand all of it to the bridge, which owns
- * `messageSecret` / `reportingTokenVersion` and merges its own values over
- * whatever arrives, so nothing has to be removed on this side.
+ * poll secret. These tests pin the JS side of that: what the send path hands
+ * to the bridge client must be what the caller built. The core decides on its
+ * own `messageSecret` / `reportingTokenVersion` from there, which is why
+ * nothing has to be removed here.
  */
 
 const logger = {
@@ -105,7 +106,7 @@ const albumChild = (): WAProto.IMessage =>
 const withContextInfo = (messageContextInfo: Record<string, unknown>): WAProto.IMessage =>
 	({ conversation: 'album member', messageContextInfo }) as unknown as WAProto.IMessage
 
-describe('relayMessage: messageContextInfo reaches the bridge', () => {
+describe('relayMessage: messageContextInfo in the bytes handed to the bridge', () => {
 	it('keeps the album association that binds an image to its album parent', async () => {
 		const decoded = await relayDecoded(albumChild())
 		const association = decoded.messageContextInfo?.messageAssociation
@@ -157,8 +158,8 @@ describe('relayMessage: messageContextInfo reaches the bridge', () => {
 		expect(decoded.pinInChatMessage?.key?.id).toBe('PIN0000000000000000')
 	})
 
-	// The core reuses a caller-set secret rather than minting a fresh one
-	// (polls need the secret they will later decrypt votes with).
+	// The core reuses a caller-set secret rather than minting a fresh one, so
+	// deleting it here would cost a raw poll the secret it decrypts votes with.
 	it('keeps a caller-set messageSecret', async () => {
 		const secret = new Uint8Array(32).fill(0xab)
 		const decoded = await relayDecoded(withContextInfo({ messageSecret: secret }))
@@ -199,7 +200,7 @@ describe('relayMessage: album parent', () => {
 	})
 })
 
-describe('sendMessage: messageContextInfo reaches the bridge', () => {
+describe('sendMessage: messageContextInfo in the bytes handed to the bridge', () => {
 	it('keeps the pin duration generated for a pin', async () => {
 		const { ctx, sent } = makeCapturingContext()
 		await makeMessageMethods(ctx).sendMessage(groupJid, {


### PR DESCRIPTION
## Summary

`relayMessage` and `sendMessage` deleted the whole `messageContextInfo` from the message before encoding it for the bridge. For an album built from raw protos, the link between each image and its album parent lives in `messageContextInfo.messageAssociation.parentMessageKey`, so that link never reached the wire. The images were sent as loose media, the album parent stayed without members, and the consumer saw "the album does not work".

Everything else a caller can legitimately put in that field went the same way: `deviceListMetadata`, `botMetadata`, `paddingBytes`, `messageAddOnExpiryType`, `messageSecret`, `reportingTokenVersion`, and (outside `pinInChatMessage`) `messageAddOnDurationInSecs`.

Both send paths were affected. The reported bot uses `relayMessage`; `sendMessage` had the same delete.

## Reproduction

`src/__tests__/relay-message-context-info.test.ts` lands in its own commit (`ee9ac97`), before any production change. It drives the real `relayMessage` with a capturing bridge client and decodes the bytes the bridge received. On that commit, 8 of its 12 assertions fail:

```
    not ok 1 - keeps the album association that binds an image to its album parent
    not ok 2 - keeps deviceListMetadata and its version
    not ok 3 - keeps botMetadata
    not ok 4 - keeps paddingBytes
    not ok 5 - keeps messageAddOnExpiryType
    ok 6 - keeps messageAddOnDurationInSecs on a relayed pin
    not ok 7 - keeps a caller-set messageSecret
    ok 8 - leaves a message without messageContextInfo alone
    not ok 9 - passes an empty messageContextInfo along without inventing fields
    not ok 10 - passes a context that holds only bridge-owned fields through untouched
    ok 1 - relays the album counters as sent
    ok 1 - keeps the pin duration generated for a pin
# tests 12
# pass 4
# fail 8
```

The spine assertion fails like this:

```
not ok 1 - keeps the album association that binds an image to its album parent
  error: |-
    Expected values to be strictly equal:

    undefined !== 1

  code: 'ERR_ASSERTION'
  expected: 1
  operator: 'strictEqual'
```

`undefined` is the whole `messageContextInfo`, gone before the encoder ran.

Two of the four that pass on the red commit are deliberate: the relayed pin passes because of the exception carved out in #4, and the album parent's counters pass because they ride on the content rather than on the context. Keeping both in the red commit is what separates the two halves of the album problem.

## Root cause

`stripContextInfoForBridge` in `src/Socket/messages.ts` ran `delete msg.messageContextInfo` and restored exactly one value, `messageAddOnDurationInSecs`, and only for `pinInChatMessage`.

The motive was legitimate: the bridge fills its own `messageSecret` and `reportingTokenVersion`, and a stale value from the caller would be wrong. Deleting the container did solve that, and destroyed everything else the caller had put there. Upstream keeps the field (`Socket/messages-send.js` hoists `message.messageContextInfo` onto the device-sent wrapper and never removes it from the message).

The pin exception (`daae4a6`, #4) was the first production report of this defect, fixed for one field. `messageAssociation` was the second. Each new protocol field in `MessageContextInfo` was one report away from being the third.

## Design

Chosen option: delete nothing. `stripContextInfoForBridge` is removed along with both call sites.

That rests on a fact checked in the core the pinned bridge (0.7.0) builds on, not deduced:

- `wacore/src/reporting_token.rs::prepare_message_with_context` takes the caller's `MessageContextInfo` (`.take().unwrap_or_default()`) and sets only `message_secret` and `reporting_token_version` on it. Everything else is preserved.
- The live send path does the same without the clone: `wacore/src/send/dm.rs` and `send/group.rs` splice a second `MessageContextInfo` carrying those two fields onto the encoded plaintext, and the wire decoder merges the two occurrences with later-set fields winning. When the message already carries an mci, the DM path folds the reporting context into it with `message_context_info_merge`.
- The same paths deliberately reuse a caller-set secret: `let existing_secret = extract_message_secret(message)`, "Reuse the message's own secret when the caller set one (e.g. polls), instead of minting a fresh one that would overwrite it".

So the two bridge-owned fields are settled by the core whatever arrives, which makes deleting them unnecessary, and deleting `messageSecret` specifically is harmful: it defeats the poll secret reuse the core implements on purpose. That rules out the "delete selectively" option. "Keep deleting and restore case by case" is what already failed once, in #4.

No bridge change is needed, so nothing is left dependent on another repository.

One cost worth naming: when a message carries a top-level `messageContextInfo`, the core takes its mci-hoist path, which re-encodes the message instead of sharing one encode between the reporting token and the plaintext. That likely motivated the delete. It applies only to messages that actually carry the field, and a re-encode is a cheaper price than corrupting the caller's data.

## Hypothesis B

The empty `albumMessage: {}` in the quoted `contextInfo` is **not** a baileyrs bug, and the reporter deserves to know that part was never broken.

- `contextInfo.quotedMessage` is built by the client that quotes, and arrives already encoded. baileyrs only decodes it. There is no code on the receive path that rewrites a quoted message.
- The codec is faithful in both directions: a nested `quotedMessage` round-trips its fields through the bridge codec (`quoted-media-enum-regression.test.ts`), and an `albumMessage` carrying `expectedImageCount: 5` relays with the counter intact (`relayMessage: album parent` in the new test file). If the counters had been on the wire, they would have shown up.
- The comparison that motivated the report ("the Rust client shows the same thing") is not independent evidence: baileyrs decodes through whatsapp-rust, so both readings come from one implementation. The comparison that carries weight is against upstream protobufjs, which is what the new auditor now runs on every field.

Whether the quote is empty because the album ended up with no members (a consequence of the bug fixed here) or because WhatsApp always quotes an album as a bare type marker cannot be settled from this side of the wire. Either way there is nothing to fix in the quote path, and the album association is the real defect.

## Also at risk

Everything in `MessageContextInfo` shared the fate of `messageAssociation` on any non-pin message. Each of these now has a test that decodes the bytes handed to the bridge:

| field | status |
| --- | --- |
| `messageAssociation` | preserved, the reported bug |
| `deviceListMetadata` + `deviceListMetadataVersion` | preserved |
| `botMetadata` | preserved |
| `paddingBytes` | preserved |
| `messageAddOnExpiryType` | preserved |
| `messageAddOnDurationInSecs` | preserved for any content type, not just pins |
| `messageSecret` | preserved, and the core reuses it instead of minting a new one |
| `reportingTokenVersion` | preserved, and the core sets its own when it generates a token |

Edge cases covered too: no `messageContextInfo` at all (nothing is invented), an empty one (passes through empty), and one holding only the two bridge-owned fields.

Passing a caller-set `deviceListMetadata` through is upstream behaviour as well; the core computes what it needs for its own fan-out and does not read that field back from the caller.

## Compatibility tooling

The compatibility auditor scored this send path at 100% while it was dropping 45 bytes, because it compares declaration shapes: `relayMessage(jid, message, options)` has the same signature in both libraries whatever it does to the bytes. Nothing in the repository measured behaviour on the way out.

This PR adds that missing dimension, in `scripts/compatibility/wire-fidelity-core.ts` plus a CLI (`npm run compat:audit:wire`):

- A schema sweep: one case per field of `Message` and of `MessageContextInfo`, built from the upstream-derived compact schema, so fields added later are covered without editing the sweep.
- A seeded fuzz on top: random field combinations, because a send path can preserve every field alone and still lose one when a neighbour is present. The seed is printed with the report so a failing case is reproducible.
- Each case goes through the real `relayMessage` with a capturing bridge client. What the bridge received is compared against a plain encode of the same input, then re-read with upstream protobufjs.

Strict mode fails on a dropped field, an altered value, or a send path that throws: an exception produces no auditable bytes at all, which is a harder failure than a drop and must not read as a skip.

Tests in `scripts/compatibility/__tests__/wire-fidelity.test.ts` assert the sweep exercises every `MessageContextInfo` field, that the current send path drops nothing, and, as a check on the tool itself, that a sender which deletes `messageContextInfo` is reported with every one of those paths dropped and that a sender which throws fails the audit. Without those the auditor could pass by finding nothing anywhere.

First run found one cross-implementation gap, reported separately from send-path findings so the two do not get confused: `pollResultSnapshotMessageV3` is field 115 in the bridge proto (and in whatsapp-rust `waproto/src/whatsapp.proto`) and field 114 in baileys 7.0.0-rc13. Both codecs read their own bytes; neither reads the other's. Not touched here, and pinned in the test so a second divergence fails the build.

Current output:

```
send-path wire fidelity
cases: 311
preserved: 1970  dropped: 0  altered: 0  divergent: 2  errored: 0  skipped: 0
- [divergent] Message.pollResultSnapshotMessageV3 :: pollResultSnapshotMessageV3 (upstream protobufjs reads this field at another number)
- [divergent] fuzz#74 :: pollResultSnapshotMessageV3 (upstream protobufjs reads this field at another number)
fuzz seed: 20260808
```

## Contract changes in existing tests

Three test files changed because the helper they exercised no longer exists, not for convenience:

- `content-type-resolution.test.ts`: the `stripContextInfoForBridge` block tested the helper's content-type parameter. Removed with the helper.
- `pin-message.test.ts`: the two tests that pinned the strip mechanics ("strips messageContextInfo entirely", "keeps ONLY messageAddOnDurationInSecs") described behaviour that is now gone. The duration tests stay, and the send-path guarantee they cared about is now asserted end to end in the new file for both `relayMessage` and `sendMessage`.
- `quoted-media-enum-regression.test.ts`: called the helper to mimic the send path before encoding. The line is gone; the assertion is unchanged.

`scripts/compatibility/tsconfig.json` now includes `src/Types/globals.d.ts`, which the library's fetch options depend on and the auditor needs now that it imports from `src`.

## Validation

```
npm run format      clean
npm run lint        clean (tsc + oxlint)
npm run format:check  clean
npm test            681 tests, 681 pass
npm run compat:audit  97.15% (21717/22354), unchanged
npm run compat:audit:wire  311 cases, 0 dropped, 0 altered, 0 errored
npx tsc -p scripts/compatibility/tsconfig.json  clean
```

`test:e2e` was not run locally: it needs a mock server that is not available here. CI ran it and it passed.

Regression proof, done by reverting the central change and re-running: with `delete message.messageContextInfo` restored in both paths, 10 of the new tests fail, including the two that pass on the red commit (`keeps messageAddOnDurationInSecs on a relayed pin` and `keeps the pin duration generated for a pin`), which is what shows the general case now covers the pin exception it replaces. The two that pass in both states are there on purpose and say so: the absent-context edge case, and the album parent counters that separate this bug from the quoted-album question.