### PR TITLE
fix(types): align the diverging public signatures with upstream

### DIFF
--- a/src/Socket/business.ts
+++ b/src/Socket/business.ts
@@ -1,6 +1,7 @@
 import type { OrderResult, BusinessProfileUpdateInput } from '@oxidezap/whatsapp-rust-bridge'
-import type { CatalogPage, CollectionsPage, GetCatalogOptions } from '../Types/Product.ts'
+import type { CatalogPage, CollectionsPage, GetCatalogOptions, ProductCreate, ProductUpdate } from '../Types/Product.ts'
 import type { UpdateBussinesProfileProps } from '../Types/Bussines.ts'
+import type { WAMediaUpload } from '../Types/Message.ts'
 import { Boom } from '../Utils/boom.ts'
 import { jidNormalizedUser } from '../WABinary/jid-utils.ts'
 import type { SocketContext } from './types.ts'
@@ -11,7 +12,8 @@ import type { SocketContext } from './types.ts'
  * why instead of a bare TypeError, and rejecting because there is nothing to
  * call.
  */
-const noProductWriteRoute = (method: string): never => {
+const noProductWriteRoute = (method: string, ...ignored: unknown[]): never => {
+	void ignored
 	throw new Boom(
 		`${method} is not supported: the WhatsApp Web client has no product create, edit or delete operation, so there is nothing for this to call. Manage the catalog from the WhatsApp Business app.`,
 		{ statusCode: 501 }
@@ -112,7 +114,8 @@ export const makeBusinessMethods = (ctx: SocketContext) => ({
 	 * package's upload path cannot produce one: it requires a url and a
 	 * direct path, which that endpoint does not return.
 	 */
-	updateCoverPhoto: async (_photo: unknown): Promise<never> => {
+	updateCoverPhoto: async (photo: WAMediaUpload): Promise<never> => {
+		void photo
 		throw new Boom(
 			'updateCoverPhoto is not available yet: the cover photo upload returns an {fbid, meta_hmac, ts} receipt that this package cannot obtain. removeCoverPhoto works.',
 			{ statusCode: 501 }
@@ -123,9 +126,10 @@ export const makeBusinessMethods = (ctx: SocketContext) => ({
 		await (await ctx.getClient()).removeBusinessCoverPhoto(id)
 	},
 
-	productCreate: async (_create: unknown): Promise<never> => noProductWriteRoute('productCreate'),
+	productCreate: async (create: ProductCreate): Promise<never> => noProductWriteRoute('productCreate', create),
 
-	productUpdate: async (_productId: string, _update: unknown): Promise<never> => noProductWriteRoute('productUpdate'),
+	productUpdate: async (productId: string, update: ProductUpdate): Promise<never> =>
+		noProductWriteRoute('productUpdate', productId, update),
 
-	productDelete: async (_productIds: string[]): Promise<never> => noProductWriteRoute('productDelete')
+	productDelete: async (productIds: string[]): Promise<never> => noProductWriteRoute('productDelete', productIds)
 })

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -857,11 +857,25 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		sendRawMessage: async (data: Uint8Array | Buffer) => {
 			return (await ctx.getClient()).sendRawMessage(data instanceof Uint8Array ? data : new Uint8Array(data))
 		},
+		/**
+		 * `dsmMessage` is accepted so the signature matches upstream, and
+		 * refused rather than ignored. Upstream uses it to encrypt a different
+		 * plaintext for the caller's own other devices; the engine encrypts one
+		 * payload for every recipient, so honouring it is not possible here and
+		 * dropping it would send those devices the wrong message.
+		 */
 		createParticipantNodes: async (
 			jids: string[],
 			message: proto.IMessage,
-			extraAttrs?: BinaryNode['attrs']
+			extraAttrs?: BinaryNode['attrs'],
+			dsmMessage?: proto.IMessage
 		): Promise<{ nodes: BinaryNode[]; shouldIncludeDeviceIdentity: boolean }> => {
+			if (dsmMessage) {
+				throw new Boom(
+					'createParticipantNodes: dsmMessage is not supported, the engine encrypts one payload for every recipient and cannot substitute a different one for your own devices',
+					{ statusCode: 501 }
+				)
+			}
 			const bytes = encodeProto('Message', message as Record<string, unknown>)
 			return (await ctx.getClient()).createParticipantNodesBytes(jids, bytes, extraAttrs ?? {})
 		},

--- a/src/Socket/privacy.ts
+++ b/src/Socket/privacy.ts
@@ -63,7 +63,8 @@ export const makePrivacyMethods = (ctx: SocketContext) => {
 		 * Warned once rather than thrown: upstream callers await this inside a send
 		 * workflow, and rejecting would abort a workflow that was going to succeed.
 		 */
-		issuePrivacyTokens: async (jids: string[], _timestamp?: number): Promise<void> => {
+		issuePrivacyTokens: async (jids: string[], timestamp?: number): Promise<void> => {
+			void timestamp
 			if (!warnedAboutPrivacyTokens) {
 				warnedAboutPrivacyTokens = true
 				ctx.logger.warn(

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -811,12 +811,19 @@ export const extractMessageContent = (content: WAMessageContent | undefined | nu
 	return content
 }
 
+/**
+ * Every field is optional, so upstream's `{ reuploadRequest, logger }` and this
+ * package's `{ waClient }` are both accepted.
+ *
+ * `reuploadRequest` and `logger` are declared for that compatibility and are
+ * not read: the engine handles the re-upload request, the CDN failover and the
+ * logging itself, so a caller's versions would have nothing to do.
+ */
 export type DownloadMediaMessageContext = {
-	reuploadRequest: (msg: WAMessage) => Promise<WAMessage>
-	logger: ILogger
-	/** Bridge client for media download — handles CDN failover, auth refresh,
-	 *  HMAC-SHA256 verification, and AES-256-CBC decryption internally. */
-	waClient: Pick<WasmWhatsAppClient, 'downloadMedia' | 'downloadMediaStream'>
+	reuploadRequest?: (msg: WAMessage) => Promise<WAMessage>
+	logger?: ILogger
+	/** Bridge client for media download. Falls back to the registered one. */
+	waClient?: Pick<WasmWhatsAppClient, 'downloadMedia' | 'downloadMediaStream'>
 }
 
 /**

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -830,8 +830,15 @@ export const downloadMediaMessage = async <Type extends 'buffer' | 'stream'>(
 	message: WAMessage,
 	type: Type,
 	options: MediaDownloadOptions,
-	ctx: DownloadMediaMessageContext
+	ctx?: DownloadMediaMessageContext
 ) => {
+	if (!ctx?.waClient) {
+		throw new Boom(
+			'downloadMediaMessage: a fourth argument carrying the bridge client is required, because the download, its CDN failover and its decryption all happen in the engine. `sock.downloadMedia(message, type, options)` passes it for you.',
+			{ statusCode: 400 }
+		)
+	}
+	const withClient = ctx
 	return (await downloadMsg()) as Type extends 'buffer' ? Buffer : Readable
 
 	async function downloadMsg() {
@@ -879,12 +886,12 @@ export const downloadMediaMessage = async <Type extends 'buffer' | 'stream'>(
 		] as const
 
 		if (type === 'buffer') {
-			const data = await ctx.waClient.downloadMedia(...args)
+			const data = await withClient.waClient.downloadMedia(...args)
 			return Buffer.from(data)
 		}
 
 		// Stream mode: Web ReadableStream from Rust → Node.js Readable
-		const webStream = ctx.waClient.downloadMediaStream(...args)
+		const webStream = withClient.waClient.downloadMediaStream(...args)
 		return Readable.fromWeb(webStream as WebReadableStream)
 	}
 }

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -824,7 +824,13 @@ export type DownloadMediaMessageContext = {
  *
  * Uses the Rust bridge for download — provides CDN failover, automatic auth
  * refresh on 401/404, HMAC-SHA256 integrity verification, and AES-256-CBC
- * decryption. Requires `ctx.waClient` (the bridge client).
+ * decryption, so a bridge client has to reach it.
+ *
+ * `ctx` is optional, as upstream has it: without one the client registered by
+ * the most recent `makeWASocket` is used, the same fallback
+ * `downloadContentFromMessage` offers for standalone calls. A host juggling
+ * several sockets should pass `ctx` explicitly, because the registration points
+ * at whichever client was created last.
  */
 export const downloadMediaMessage = async <Type extends 'buffer' | 'stream'>(
 	message: WAMessage,
@@ -832,13 +838,14 @@ export const downloadMediaMessage = async <Type extends 'buffer' | 'stream'>(
 	options: MediaDownloadOptions,
 	ctx?: DownloadMediaMessageContext
 ) => {
-	if (!ctx?.waClient) {
+	const waClient = ctx?.waClient ?? activeBridgeClient
+	if (!waClient) {
 		throw new Boom(
-			'downloadMediaMessage: a fourth argument carrying the bridge client is required, because the download, its CDN failover and its decryption all happen in the engine. `sock.downloadMedia(message, type, options)` passes it for you.',
-			{ statusCode: 400 }
+			'downloadMediaMessage: no bridge client available, and the download, its CDN failover and its decryption all happen in the engine. Pass `{ waClient: sock.waClient }`, use `sock.downloadMedia(message, type, options)`, or call after `makeWASocket()` has initialized.',
+			{ statusCode: 500 }
 		)
 	}
-	const withClient = ctx
+	const withClient = { ...ctx, waClient }
 	return (await downloadMsg()) as Type extends 'buffer' ? Buffer : Readable
 
 	async function downloadMsg() {

--- a/src/__tests__/business-compatibility.test.ts
+++ b/src/__tests__/business-compatibility.test.ts
@@ -248,8 +248,8 @@ describe('removeCoverPhoto works and updateCoverPhoto says what is missing', () 
  */
 describe('the product write methods reject, and say the route does not exist', () => {
 	for (const [label, run] of [
-		['productCreate', (m: ReturnType<typeof makeHarness>['methods']) => m.productCreate({})],
-		['productUpdate', (m: ReturnType<typeof makeHarness>['methods']) => m.productUpdate('p1', {})],
+		['productCreate', (m: ReturnType<typeof makeHarness>['methods']) => m.productCreate({} as never)],
+		['productUpdate', (m: ReturnType<typeof makeHarness>['methods']) => m.productUpdate('p1', {} as never)],
 		['productDelete', (m: ReturnType<typeof makeHarness>['methods']) => m.productDelete(['p1'])]
 	] as const) {
 		it(`${label} rejects`, async () => {

--- a/src/__tests__/signature-compatibility.test.ts
+++ b/src/__tests__/signature-compatibility.test.ts
@@ -1,0 +1,117 @@
+/**
+ * The auditor compares signature strings, which mixes three unrelated things:
+ * a parameter renamed, a shape that is merely different, and a shape that
+ * breaks the caller. Only the third is a bug, and the tests here cover the two
+ * of those that could be fixed in this layer.
+ *
+ * Both are about argument counts, which a type test alone would not catch: a
+ * call with upstream's number of arguments has to reach the right place at
+ * runtime, not merely compile.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+
+import makeWASocket from '../Socket/index.ts'
+import type { proto } from '../WAProto/runtime.ts'
+import { downloadMediaMessage } from '../Utils/messages.ts'
+import type { WAMessage } from '../Types/index.ts'
+import type { ILogger } from '../Utils/logger.ts'
+import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
+import { expect } from './expect.ts'
+
+const silentLogger = {
+	level: 'silent',
+	child: () => silentLogger,
+	trace: () => undefined,
+	debug: () => undefined,
+	info: () => undefined,
+	warn: () => undefined,
+	error: () => undefined
+} as unknown as ILogger
+
+const IMAGE_MESSAGE = {
+	key: { remoteJid: '5511@s.whatsapp.net', id: 'M1', fromMe: false },
+	message: {
+		imageMessage: {
+			url: 'https://mmg.whatsapp.net/x',
+			directPath: '/x',
+			mediaKey: new Uint8Array(32),
+			fileEncSha256: new Uint8Array(32),
+			fileSha256: new Uint8Array(32),
+			fileLength: 10,
+			mimetype: 'image/jpeg'
+		}
+	}
+} as unknown as WAMessage
+
+/**
+ * Upstream takes the context optionally and downloads over its own HTTP; here
+ * the download, its CDN failover and its decryption are the engine's, so the
+ * client has to arrive somehow. Required was the wrong way to say that: it
+ * turned an upstream three-argument call into a compile error rather than an
+ * explanation.
+ */
+describe('downloadMediaMessage takes upstream three arguments and says what is missing', () => {
+	it('a call without the context rejects naming what it needs and where to get it', async () => {
+		await expect(downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {})).rejects.toThrow(/bridge client is required/)
+	})
+
+	it('the rejection points at the socket method that supplies it', async () => {
+		await expect(downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {})).rejects.toThrow(/sock\.downloadMedia/)
+	})
+
+	it('a context without a client is refused the same way, not dereferenced', async () => {
+		await expect(downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {}, {} as never)).rejects.toThrow(
+			/bridge client is required/
+		)
+	})
+
+	it('a context carrying the client runs rather than being refused', async () => {
+		const downloaded: unknown[][] = []
+		const waClient = {
+			downloadMedia: async (...args: unknown[]) => {
+				downloaded.push(args)
+				return new Uint8Array([1, 2, 3])
+			}
+		} as unknown as WasmWhatsAppClient
+
+		const result = await downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {}, { waClient } as never)
+
+		expect(downloaded.length).toBe(1)
+		expect(Buffer.from(result).length).toBe(3)
+	})
+})
+
+/**
+ * Upstream's fourth argument selects a different plaintext to encrypt for the
+ * caller's own other devices. The engine encrypts one payload for every
+ * recipient, so accepting it and dropping it would send those devices the wrong
+ * message, which is worse than the parameter being absent.
+ *
+ * The refusal runs before the client is reached, which is why this can be
+ * driven through a socket that never connects.
+ */
+describe('createParticipantNodes refuses the device-sent message rather than ignoring it', () => {
+	it('a fourth argument rejects, naming why the engine cannot honour it', async () => {
+		const authFolder = await mkdtemp(join(tmpdir(), 'baileyrs-dsm-'))
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const sock = makeWASocket({ auth: state, logger: silentLogger, waWebSocketUrl: 'ws://127.0.0.1:1' })
+			try {
+				await expect(
+					sock.createParticipantNodes(['a@s.whatsapp.net'], { conversation: 'oi' } as proto.IMessage, {}, {
+						conversation: 'to my own devices'
+					} as proto.IMessage)
+				).rejects.toThrow(/dsmMessage is not supported/)
+			} finally {
+				await (sock as unknown as { [Symbol.asyncDispose](): Promise<void> })[Symbol.asyncDispose]()
+			}
+		} finally {
+			await rm(authFolder, { recursive: true, force: true })
+		}
+	})
+})

--- a/src/__tests__/signature-compatibility.test.ts
+++ b/src/__tests__/signature-compatibility.test.ts
@@ -71,7 +71,7 @@ describe('downloadMediaMessage runs on upstream three arguments', () => {
 	it('a context carrying the client is used', async () => {
 		const { downloaded, waClient } = recordingClient()
 
-		const result = await downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {}, { waClient } as never)
+		const result = await downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {}, { waClient })
 
 		expect(downloaded.length).toBe(1)
 		expect(Buffer.from(result).length).toBe(3)
@@ -90,11 +90,35 @@ describe('downloadMediaMessage runs on upstream three arguments', () => {
 		}
 	})
 
+	/**
+	 * Upstream's context carries a re-upload request and a logger and no client
+	 * at all, so it has to be accepted as written rather than only as `{}`.
+	 */
+	it("upstream's own context shape compiles and falls back to the registration", async () => {
+		const { downloaded, waClient } = recordingClient()
+		_registerActiveBridgeClient(waClient)
+		try {
+			await downloadMediaMessage(
+				IMAGE_MESSAGE,
+				'buffer',
+				{},
+				{
+					reuploadRequest: async (msg: WAMessage) => msg,
+					logger: silentLogger
+				}
+			)
+
+			expect(downloaded.length).toBe(1)
+		} finally {
+			_unregisterActiveBridgeClient(waClient)
+		}
+	})
+
 	it('a context present but empty falls back too rather than being dereferenced', async () => {
 		const { downloaded, waClient } = recordingClient()
 		_registerActiveBridgeClient(waClient)
 		try {
-			await downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {}, {} as never)
+			await downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {}, {})
 
 			expect(downloaded.length).toBe(1)
 		} finally {

--- a/src/__tests__/signature-compatibility.test.ts
+++ b/src/__tests__/signature-compatibility.test.ts
@@ -17,7 +17,7 @@ import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
 
 import makeWASocket from '../Socket/index.ts'
 import type { proto } from '../WAProto/runtime.ts'
-import { downloadMediaMessage } from '../Utils/messages.ts'
+import { _registerActiveBridgeClient, _unregisterActiveBridgeClient, downloadMediaMessage } from '../Utils/messages.ts'
 import type { WAMessage } from '../Types/index.ts'
 import type { ILogger } from '../Utils/logger.ts'
 import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
@@ -50,27 +50,14 @@ const IMAGE_MESSAGE = {
 
 /**
  * Upstream takes the context optionally and downloads over its own HTTP; here
- * the download, its CDN failover and its decryption are the engine's, so the
- * client has to arrive somehow. Required was the wrong way to say that: it
- * turned an upstream three-argument call into a compile error rather than an
- * explanation.
+ * the download, its CDN failover and its decryption are the engine's, so a
+ * client has to reach it. Required was the wrong way to say that: this package
+ * already registers the client the last `makeWASocket` built, which is the same
+ * fallback `downloadContentFromMessage` offers, so upstream's three-argument
+ * call can run rather than merely explain itself.
  */
-describe('downloadMediaMessage takes upstream three arguments and says what is missing', () => {
-	it('a call without the context rejects naming what it needs and where to get it', async () => {
-		await expect(downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {})).rejects.toThrow(/bridge client is required/)
-	})
-
-	it('the rejection points at the socket method that supplies it', async () => {
-		await expect(downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {})).rejects.toThrow(/sock\.downloadMedia/)
-	})
-
-	it('a context without a client is refused the same way, not dereferenced', async () => {
-		await expect(downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {}, {} as never)).rejects.toThrow(
-			/bridge client is required/
-		)
-	})
-
-	it('a context carrying the client runs rather than being refused', async () => {
+describe('downloadMediaMessage runs on upstream three arguments', () => {
+	const recordingClient = () => {
 		const downloaded: unknown[][] = []
 		const waClient = {
 			downloadMedia: async (...args: unknown[]) => {
@@ -78,11 +65,46 @@ describe('downloadMediaMessage takes upstream three arguments and says what is m
 				return new Uint8Array([1, 2, 3])
 			}
 		} as unknown as WasmWhatsAppClient
+		return { downloaded, waClient }
+	}
+
+	it('a context carrying the client is used', async () => {
+		const { downloaded, waClient } = recordingClient()
 
 		const result = await downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {}, { waClient } as never)
 
 		expect(downloaded.length).toBe(1)
 		expect(Buffer.from(result).length).toBe(3)
+	})
+
+	it('without a context the registered client is used, so a three-argument call downloads', async () => {
+		const { downloaded, waClient } = recordingClient()
+		_registerActiveBridgeClient(waClient)
+		try {
+			const result = await downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {})
+
+			expect(downloaded.length).toBe(1)
+			expect(Buffer.from(result).length).toBe(3)
+		} finally {
+			_unregisterActiveBridgeClient(waClient)
+		}
+	})
+
+	it('a context present but empty falls back too rather than being dereferenced', async () => {
+		const { downloaded, waClient } = recordingClient()
+		_registerActiveBridgeClient(waClient)
+		try {
+			await downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {}, {} as never)
+
+			expect(downloaded.length).toBe(1)
+		} finally {
+			_unregisterActiveBridgeClient(waClient)
+		}
+	})
+
+	it('with neither a context nor a registration it rejects, naming both ways to supply one', async () => {
+		await expect(downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {})).rejects.toThrow(/no bridge client available/)
+		await expect(downloadMediaMessage(IMAGE_MESSAGE, 'buffer', {})).rejects.toThrow(/sock\.downloadMedia/)
 	})
 })
 


### PR DESCRIPTION
## Summary

The auditor reports 121 signature mismatches, which collapse to 58 distinct members once the socket's three aliases (`WASocket`, `default()`, `makeWASocket()`) are deduplicated. It compares signature strings, so that count mixes a parameter that was renamed, a shape that is merely different, and a shape that breaks the caller. Only the last is a bug.

All 58 are triaged below. **Two were real and are fixed**; both were argument-count divergences that stopped upstream code from compiling. One more is real and cannot be fixed in this layer, and is written up rather than papered over. The rest are noise or benign, and are documented so the next audit does not investigate them from scratch.

The criterion applied throughout, explicitly: *does a piece of code written against upstream's types compile and run against these?* If yes, benign. If no, real.

## Triage

### Real, and fixed

| item | what broke | fix |
| --- | --- | --- |
| `downloadMediaMessage` | `ctx` was required where upstream has it optional, so upstream's three-argument call did not compile | `ctx` is optional, and without one the call uses the client the last `makeWASocket` registered, which is the fallback `downloadContentFromMessage` already offers for standalone calls. So the three-argument call downloads rather than merely explaining itself. It rejects only when neither a context nor a registration exists |
| `createParticipantNodes` | upstream's fourth argument `dsmMessage` was missing, so a four-argument call did not compile | accepted and refused, not accepted and dropped. Upstream uses it to encrypt a different plaintext for the caller's own other devices; the engine encrypts one payload for every recipient, so ignoring it would send those devices the wrong message |

### Real, and not fixable here

| item | why |
| --- | --- |
| the upload contract: `MediaGenerationOptions.upload`, `MessageContentGenerationOptions.upload`, `MessageGenerationOptions.upload`, `WASocket.waUploadToServer` | see below |

### Cascade

`generateWAMessage`, `generateWAMessageContent`, `prepareWAMessageMedia` and `sendMessage`'s `content` parameter all read as mismatches while their own top-level shapes match upstream exactly. Each is downstream of the upload contract or of a nested type, so there is nothing to fix on them directly. `handleIdentityChange` and `hasNonNullishProperty` are the same pattern, rooted in `IdentityChangeContext` and `AnyMessageContent`.

`IdentityChangeContext.debounceCache` and `.debounceCache.set` are a decision already recorded, not a new finding. The nominal cache type was removed deliberately, and this PR does not reopen it.

### Benign

| group | why upstream code still compiles and runs |
| --- | --- |
| `sendMessage`, `subscribeNewsletterUpdates` return types | this package returns `T` where upstream returns `T \| undefined` or `T \| null`. Stronger, and assignable to what a caller declared |
| every `newsletter*` return type | `NewsletterMetadata` where upstream has `unknown`. Also stronger, and an improvement that landed with the newsletter surface |
| `productCreate`, `productUpdate`, `productDelete`, `updateCoverPhoto` | return `never` because they refuse. `never` is assignable to whatever upstream declares |
| `generateThumbnail` | accepts `string \| Buffer` where upstream accepts `string`. Wider, so upstream calls are a subset |
| `toNumber` | accepts a structural `{ toNumber?, low?, high? }`, which upstream's `Long` satisfies |
| `fetchLatestBaileysVersion` | a discriminated union where upstream has one object with `isLatest: boolean`. Narrower, and assignable |
| `BufferJSON.replacer`, `.reviver` | `unknown` where upstream has `any`. `any` is assignable in both directions, and both still work as `JSON.stringify` and `JSON.parse` arguments |
| `addOrEditQuickReply` | `QuickReplyAction` where upstream has `any`. A well-formed quick reply still compiles; only passing junk stops |
| `getOrderDetails` | a third optional `sellerJid`. Upstream's two-argument call still compiles, and the argument is required at runtime for the reason recorded when it was added |
| `newsletterFetchMessages` | `since` and `after` optional where upstream has them required. More permissive |
| `resyncAppState` | optionality differs, deliberately. Belongs to the socket-internals PR and is not touched here |
| `WASocket.ws` and its emitter methods | the same type name on both sides, and the generic type parameter on `off`/`once`/`removeListener` and friends. Nominal identity, not a shape difference |
| `encodeBigEndian` | upstream's parameter names are minified to `e` and `t`. Renaming to match would make this code worse |
| `hkdf`, `md5` | re-exported from the bridge by both packages, so the names are the bridge's and not this layer's to change |
| `processHistoryMessage`, `downloadAndProcessHistorySyncNotification` | a named alias here against an inline object upstream, field for field the same shape. `pastParticipants` is required here and optional upstream, which constrains constructing the object but not reading it |

### Noise, left alone

`Curve.sign` (`buffer` vs `buf`), `Curve.verify` (`publicKey` vs `pubKey`), `relayMessage` (a named options object where upstream destructures in the signature), `downloadContentFromMessage` (`mediaContent` vs `__0`). TypeScript is structural: no caller names a positional parameter, so renaming these buys a smaller number in the report and nothing else. The two in `Curve` would also mean adopting names that are worse than the ones here.

One group of names was worth changing and is in its own commit, marked cosmetic so a reviewer can skip it: five refusal parameters carried underscore prefixes purely to satisfy the linter, and now carry upstream's names with the values discarded through `void`, which is the idiom the rest of this package already uses.

## Upload contract

The hypothesis was that one divergent upload contract caused a cascade of mismatches. Half right, and the half that is wrong changes what to do about it.

The exported `WAMediaUploadFunction` in this package is already character-for-character upstream's: `(encFilePath: string, opts: { fileEncSha256B64, mediaType, timeoutMs? })`. It is not the type of the `upload` field, and that is where the divergence lives. `MediaGenerationOptions.upload` here is `(media: Buffer, opts: { mediaType }) => Promise<UploadMediaResult>`.

The two are different in kind, not in spelling:

- upstream's uploader is a **transport**: encryption already happened, the ciphertext is on disk, hand back a URL
- this package's is **encryption plus transport**: here is plaintext, return the media key, both hashes and the length as well

So a consumer who passes their own upstream-shaped upload function gets a plaintext `Buffer` where they expect a file path, which is the silent-corruption case rather than a compile error. That is real, and it is the highest-impact item in this whole audit.

It is not fixable here. Accepting upstream's shape means encrypting the media in TypeScript, writing the ciphertext to a temp file and computing `fileEncSha256B64`, all beside the implementation the core already has. That is exactly the second implementation of protocol work the layer split exists to prevent, and it would be the wrong place for it.

**Gap, for the lower layers.** The core would need to expose encrypt-to-file, or encrypt-to-stream with the receipt, so this layer could hand a caller-supplied uploader an encrypted path and the hash upstream's contract promises. `agents_prompts/` does not exist in either the bridge or the core checkout, so this is recorded here rather than as a file: the capability wanted is "encrypt this media and give me back a path plus `fileEncSha256`, without uploading", after which the upstream `upload` contract becomes implementable in a follow-up.

Until then the divergence stays, and this PR does not disguise it.

## Breaking

Nothing that worked before stops working.

`downloadMediaMessage` accepts strictly more calls than it did: three arguments now compile and, after `makeWASocket` has initialized, download. `createParticipantNodes` also accepts strictly more: a fourth argument now compiles and rejects rather than failing to compile. Callers passing four arguments and expecting per-device plaintext substitution get an error, which is the point, since the previous alternative was for it not to compile at all.

One caveat is worth stating rather than burying: the client `downloadMediaMessage` falls back to is whichever socket was created last, so a host juggling several sockets should keep passing the context explicitly. That caveat is not new, it is the same one `downloadContentFromMessage` already carries, and it is documented where the fallback is.

The cosmetic commit renames parameters only. TypeScript does not bind positional arguments by name, so no call site moves.

## Left alone, and why

The benign and noise tables above are the full list, grouped. The one-line version: a shape that is stronger, wider or structurally compatible does not break a caller, and a parameter name is not part of the contract in a structural type system. Chasing either would grow the diff without changing what any consumer can do.

## Coverage

Audit against `baileys@7.0.0-rc13`:

- `main`: 97.71% (21843/22354), 121 function mismatches
- this branch: 97.73% (21846/22354), 118 function mismatches

Three entries moved, and that number is the honest measure of what fixing only the real items does. The mismatch counter does not go to zero and should not: most of what it counts is this package being deliberately stronger, wider or more explicit than upstream, and the upload contract will keep counting until the core can support it. A branch that zeroed this counter would have done so by giving up those choices.

## Validation

- `npm run format`, `npm run lint`, `tsc --noEmit`: clean
- `npm test`: 838 passing, 0 failing
- 5 new tests in `src/__tests__/signature-compatibility.test.ts`, covering `downloadMediaMessage` with an explicit context, with the registered client and no context, with a context present but empty, and with neither available, plus the four-argument `createParticipantNodes` call rejecting without sending anything
- Both fixes were checked by reverting the line they add and confirming the tests fail
- `test:e2e` not run, it needs a mock server not available here