### PR TITLE
fix(legacy-store): accept status/broadcast sender-key addresses

### DIFF
--- a/src/Compatibility/__tests__/legacy-store-sender-key-routing.test.ts
+++ b/src/Compatibility/__tests__/legacy-store-sender-key-routing.test.ts
@@ -1,12 +1,9 @@
 /**
- * Sender-key addresses are not exclusive to groups.
- *
- * Status updates and broadcast lists fan out through the same sender-key
- * mechanism as groups, so `status@broadcast:<address>` reaches the legacy-store
- * translator just like `<group>@g.us:<address>` does. Anchoring the chat part on
- * `@g.us:` made every status address throw `invalid native sender-key address`,
- * and since the throw surfaces inside a storage operation it aborts whatever
- * triggered it — a `sendMessage` to an unrelated group, for example.
+ * A sender key is `<chatJid>:<signalAddress>`, and the chat is not always a
+ * group: status updates and broadcast lists fan out through the very same
+ * mechanism, so `status@broadcast:<address>` reaches this translator too.
+ * The throw lands inside a storage operation, so it aborts whatever triggered
+ * it — a welcome message to an unrelated group, for example.
  */
 
 import { describe, it } from 'node:test'
@@ -14,27 +11,62 @@ import { NativeStore } from '../legacy-store/constants.ts'
 import { legacyKey, nativeKey } from '../legacy-store/routing.ts'
 import { expect } from '../../__tests__/expect.ts'
 
-const GROUP_NATIVE = '120363000000000001@g.us:5511900000001@c.us.0'
-const GROUP_LEGACY = '120363000000000001@g.us::5511900000001::0'
+const GROUP = '120363000000000001@g.us'
 
-const STATUS_NATIVE = 'status@broadcast:5511900000001:76@c.us.0'
-const STATUS_LEGACY = 'status@broadcast::5511900000001::76'
+/** `[label, native, legacy]` for every chat kind that owns a sender key. */
+const ADDRESSES = [
+	['group, PN sender', `${GROUP}:5511900000001@c.us.0`, `${GROUP}::5511900000001::0`],
+	['group, LID sender', `${GROUP}:5511900000001@lid.0`, `${GROUP}::5511900000001_1::0`],
+	['group, JID device', `${GROUP}:5511900000001:5@c.us.0`, `${GROUP}::5511900000001::5`],
+	['status', 'status@broadcast:5511900000001:76@c.us.0', 'status@broadcast::5511900000001::76'],
+	['broadcast list', '558694979017@broadcast:5511900000001@c.us.0', '558694979017@broadcast::5511900000001::0'],
+	['status, hosted sender', 'status@broadcast:5511900000001:9@hosted.0', 'status@broadcast::5511900000001_128::9']
+] as const
+
+/** Shapes no translator can make sense of, paired so both directions face the
+ *  same defect: `[label, native, legacy]`. */
+const MALFORMED = [
+	['no chat part', '5511900000001@c.us.0', '5511900000001.0'],
+	['chat without a domain', 'nochat:5511900000001@c.us.0', 'nochat::5511900000001::0'],
+	['chat without a user', '@g.us:5511900000001@c.us.0', '@g.us::5511900000001::0'],
+	['non-numeric sender', `${GROUP}:notanumber@c.us.0`, `${GROUP}::notanumber::0`],
+	['sender without a domain', `${GROUP}:5511900000001.0`, `${GROUP}::5511900000001::`]
+] as const
 
 describe('legacy-store sender-key routing', () => {
-	it('translates group addresses', () => {
-		expect(legacyKey(NativeStore.SENDER_KEY, GROUP_NATIVE)).toBe(GROUP_LEGACY)
+	it('translates every chat kind that owns a sender key', () => {
+		for (const [label, native, legacy] of ADDRESSES) {
+			expect(`${label}: ${legacyKey(NativeStore.SENDER_KEY, native)}`).toBe(`${label}: ${legacy}`)
+		}
 	})
 
-	it('translates status addresses instead of throwing', () => {
-		expect(legacyKey(NativeStore.SENDER_KEY, STATUS_NATIVE)).toBe(STATUS_LEGACY)
+	it('round-trips every chat kind back to the native key', () => {
+		for (const [label, native, legacy] of ADDRESSES) {
+			expect(`${label}: ${nativeKey(NativeStore.SENDER_KEY, legacy)}`).toBe(`${label}: ${native}`)
+			expect(`${label}: ${nativeKey(NativeStore.SENDER_KEY, legacyKey(NativeStore.SENDER_KEY, native))}`).toBe(
+				`${label}: ${native}`
+			)
+		}
 	})
 
-	it('round-trips both chat kinds', () => {
-		expect(nativeKey(NativeStore.SENDER_KEY, GROUP_LEGACY)).toBe(GROUP_NATIVE)
-		expect(nativeKey(NativeStore.SENDER_KEY, STATUS_LEGACY)).toBe(STATUS_NATIVE)
+	it('translates chat domains it has no knowledge of', () => {
+		// The chat namespace belongs to the core. A translator that only knows
+		// today's chat domains turns tomorrow's into a storage failure.
+		const native = '120363000000000001@futurechat:5511900000001@c.us.0'
+		const legacy = '120363000000000001@futurechat::5511900000001::0'
+		expect(legacyKey(NativeStore.SENDER_KEY, native)).toBe(legacy)
+		expect(nativeKey(NativeStore.SENDER_KEY, legacy)).toBe(native)
 	})
 
-	it('still rejects an address with no chat terminator', () => {
+	it('rejects malformed addresses in both directions', () => {
+		for (const [label, native, legacy] of MALFORMED) {
+			expect(() => `${label}: ${legacyKey(NativeStore.SENDER_KEY, native)}`).toThrow(TypeError)
+			expect(() => `${label}: ${nativeKey(NativeStore.SENDER_KEY, legacy)}`).toThrow(TypeError)
+		}
+	})
+
+	it('names the sender-key address when the chat part is missing', () => {
 		expect(() => legacyKey(NativeStore.SENDER_KEY, '5511900000001@c.us.0')).toThrow(/invalid native sender-key address/)
+		expect(() => nativeKey(NativeStore.SENDER_KEY, '5511900000001.0')).toThrow(/invalid legacy sender-key address/)
 	})
 })

--- a/src/Compatibility/__tests__/legacy-store-sender-key-routing.test.ts
+++ b/src/Compatibility/__tests__/legacy-store-sender-key-routing.test.ts
@@ -33,6 +33,18 @@ const MALFORMED = [
 	['sender without a domain', `${GROUP}:5511900000001.0`, `${GROUP}::5511900000001::`]
 ] as const
 
+/** No JID carries whitespace or a control character. Validating the chat only
+ *  by "not a separator" would let one through and make it a storage key, where
+ *  it is invisible in a log and unmatchable by a later lookup. */
+const NOT_A_JID = [
+	['space', '120363000000000001 @g.us'],
+	['inner space', '120363 000000001@g.us'],
+	['tab', `120363${String.fromCharCode(9)}000000001@g.us`],
+	['newline', `120363${String.fromCharCode(10)}000000001@g.us`],
+	['carriage return', `120363000000000001@g${String.fromCharCode(13)}.us`],
+	['null', `120363${String.fromCharCode(0)}000000001@g.us`]
+] as const
+
 describe('legacy-store sender-key routing', () => {
 	it('translates every chat kind that owns a sender key', () => {
 		for (const [label, native, legacy] of ADDRESSES) {
@@ -62,6 +74,13 @@ describe('legacy-store sender-key routing', () => {
 		for (const [label, native, legacy] of MALFORMED) {
 			expect(() => `${label}: ${legacyKey(NativeStore.SENDER_KEY, native)}`).toThrow(TypeError)
 			expect(() => `${label}: ${nativeKey(NativeStore.SENDER_KEY, legacy)}`).toThrow(TypeError)
+		}
+	})
+
+	it('rejects a chat that is not a JID, in both directions', () => {
+		for (const [label, chat] of NOT_A_JID) {
+			expect(() => `${label}: ${legacyKey(NativeStore.SENDER_KEY, `${chat}:5511900000001@c.us.0`)}`).toThrow(TypeError)
+			expect(() => `${label}: ${nativeKey(NativeStore.SENDER_KEY, `${chat}::5511900000001::0`)}`).toThrow(TypeError)
 		}
 	})
 

--- a/src/Compatibility/__tests__/legacy-store-sender-key-routing.test.ts
+++ b/src/Compatibility/__tests__/legacy-store-sender-key-routing.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Sender-key addresses are not exclusive to groups.
+ *
+ * Status updates and broadcast lists fan out through the same sender-key
+ * mechanism as groups, so `status@broadcast:<address>` reaches the legacy-store
+ * translator just like `<group>@g.us:<address>` does. Anchoring the chat part on
+ * `@g.us:` made every status address throw `invalid native sender-key address`,
+ * and since the throw surfaces inside a storage operation it aborts whatever
+ * triggered it — a `sendMessage` to an unrelated group, for example.
+ */
+
+import { describe, it } from 'node:test'
+import { NativeStore } from '../legacy-store/constants.ts'
+import { legacyKey, nativeKey } from '../legacy-store/routing.ts'
+import { expect } from '../../__tests__/expect.ts'
+
+const GROUP_NATIVE = '120363000000000001@g.us:5511900000001@c.us.0'
+const GROUP_LEGACY = '120363000000000001@g.us::5511900000001::0'
+
+const STATUS_NATIVE = 'status@broadcast:5511900000001:76@c.us.0'
+const STATUS_LEGACY = 'status@broadcast::5511900000001::76'
+
+describe('legacy-store sender-key routing', () => {
+	it('translates group addresses', () => {
+		expect(legacyKey(NativeStore.SENDER_KEY, GROUP_NATIVE)).toBe(GROUP_LEGACY)
+	})
+
+	it('translates status addresses instead of throwing', () => {
+		expect(legacyKey(NativeStore.SENDER_KEY, STATUS_NATIVE)).toBe(STATUS_LEGACY)
+	})
+
+	it('round-trips both chat kinds', () => {
+		expect(nativeKey(NativeStore.SENDER_KEY, GROUP_LEGACY)).toBe(GROUP_NATIVE)
+		expect(nativeKey(NativeStore.SENDER_KEY, STATUS_LEGACY)).toBe(STATUS_NATIVE)
+	})
+
+	it('still rejects an address with no chat terminator', () => {
+		expect(() => legacyKey(NativeStore.SENDER_KEY, '5511900000001@c.us.0')).toThrow(/invalid native sender-key address/)
+	})
+})

--- a/src/Compatibility/legacy-store/constants.ts
+++ b/src/Compatibility/legacy-store/constants.ts
@@ -86,8 +86,16 @@ export const SignalDomain = Object.freeze({
 	GROUP: 'g.us',
 	LID: 'lid',
 	HOSTED: 'hosted',
-	HOSTED_LID: 'hosted.lid'
+	HOSTED_LID: 'hosted.lid',
+	BROADCAST: 'broadcast'
 } as const)
+
+/**
+ * Chats that own sender keys. Group messaging is the common case, but status
+ * (`status@broadcast`) and broadcast lists are fanned out with the same
+ * sender-key mechanism, so their addresses reach the store too.
+ */
+export const SenderKeyDomains = Object.freeze([SignalDomain.GROUP, SignalDomain.BROADCAST] as const)
 
 export const SignalAddressSyntax = Object.freeze({
 	DOMAIN: '@',

--- a/src/Compatibility/legacy-store/constants.ts
+++ b/src/Compatibility/legacy-store/constants.ts
@@ -86,16 +86,8 @@ export const SignalDomain = Object.freeze({
 	GROUP: 'g.us',
 	LID: 'lid',
 	HOSTED: 'hosted',
-	HOSTED_LID: 'hosted.lid',
-	BROADCAST: 'broadcast'
+	HOSTED_LID: 'hosted.lid'
 } as const)
-
-/**
- * Chats that own sender keys. Group messaging is the common case, but status
- * (`status@broadcast`) and broadcast lists are fanned out with the same
- * sender-key mechanism, so their addresses reach the store too.
- */
-export const SenderKeyDomains = Object.freeze([SignalDomain.GROUP, SignalDomain.BROADCAST] as const)
 
 export const SignalAddressSyntax = Object.freeze({
 	DOMAIN: '@',

--- a/src/Compatibility/legacy-store/routing.ts
+++ b/src/Compatibility/legacy-store/routing.ts
@@ -78,8 +78,10 @@ function legacySignalAddress(address: string): string {
 
 /** A sender key is `<chatJid>:<signalAddress>`, and the chat is a group, status
  *  or a broadcast list. Which chats fan out through sender keys is the core's
- *  namespace, so the boundary validates the JID shape, not the domain. */
-const CHAT_JID = /^[^:@]+@[^:@]+$/
+ *  namespace, so the boundary validates the JID shape, not the domain. No JID
+ *  carries whitespace or a control character, and letting one through would
+ *  mint a storage key that no later lookup can match. */
+const CHAT_JID = /^[^\s:@\p{Cc}]+@[^\s:@\p{Cc}]+$/u
 
 function legacySenderKey(key: string): string {
 	const chatDomain = key.indexOf(SignalAddressSyntax.DOMAIN)

--- a/src/Compatibility/legacy-store/routing.ts
+++ b/src/Compatibility/legacy-store/routing.ts
@@ -5,6 +5,7 @@ import {
 	LidMapping,
 	NativeStore,
 	RouteKind,
+	SenderKeyDomains,
 	SignalAddressSyntax,
 	SignalDomain,
 	SignalDomainType,
@@ -77,16 +78,27 @@ function legacySignalAddress(address: string): string {
 }
 
 function legacySenderKey(key: string): string {
-	const groupTerminator = `${SignalAddressSyntax.DOMAIN}${SignalDomain.GROUP}${SignalAddressSyntax.JID_DEVICE}`
-	const groupEnd = key.indexOf(groupTerminator)
-	if (groupEnd < 0) throw new TypeError(`invalid native sender-key address: ${key}`)
-	const addressStart = groupEnd + groupTerminator.length
-	const group = key.slice(0, addressStart - SignalAddressSyntax.JID_DEVICE.length)
-	const address = legacySignalAddress(key.slice(addressStart))
-	const deviceSeparator = address.lastIndexOf(SignalAddressSyntax.SIGNAL_DEVICE)
-	return [group, address.slice(0, deviceSeparator), address.slice(deviceSeparator + 1)].join(
-		SignalAddressSyntax.SENDER_KEY_PART
-	)
+	// A sender key is `<chatJid>:<signalAddress>`, and the chat is not always a
+	// group: status updates and broadcast lists fan out through the very same
+	// mechanism, so `status@broadcast:<address>` is a legitimate address that
+	// reaches this translator. Anchoring only on `@g.us:` made every one of them
+	// throw, and because the throw happens inside a storage operation it takes
+	// down whatever triggered it — a `sendMessage` to an unrelated group, for
+	// instance.
+	for (const domain of SenderKeyDomains) {
+		const terminator = `${SignalAddressSyntax.DOMAIN}${domain}${SignalAddressSyntax.JID_DEVICE}`
+		const chatEnd = key.indexOf(terminator)
+		if (chatEnd < 0) continue
+		const addressStart = chatEnd + terminator.length
+		const chat = key.slice(0, addressStart - SignalAddressSyntax.JID_DEVICE.length)
+		const address = legacySignalAddress(key.slice(addressStart))
+		const deviceSeparator = address.lastIndexOf(SignalAddressSyntax.SIGNAL_DEVICE)
+		return [chat, address.slice(0, deviceSeparator), address.slice(deviceSeparator + 1)].join(
+			SignalAddressSyntax.SENDER_KEY_PART
+		)
+	}
+
+	throw new TypeError(`invalid native sender-key address: ${key}`)
 }
 
 const passthroughKey = (_store: ProjectedStoreName, key: string): string => key

--- a/src/Compatibility/legacy-store/routing.ts
+++ b/src/Compatibility/legacy-store/routing.ts
@@ -5,7 +5,6 @@ import {
 	LidMapping,
 	NativeStore,
 	RouteKind,
-	SenderKeyDomains,
 	SignalAddressSyntax,
 	SignalDomain,
 	SignalDomainType,
@@ -77,28 +76,21 @@ function legacySignalAddress(address: string): string {
 	return `${user}${SignalAddressSyntax.SIGNAL_DEVICE}${parsed.device}`
 }
 
-function legacySenderKey(key: string): string {
-	// A sender key is `<chatJid>:<signalAddress>`, and the chat is not always a
-	// group: status updates and broadcast lists fan out through the very same
-	// mechanism, so `status@broadcast:<address>` is a legitimate address that
-	// reaches this translator. Anchoring only on `@g.us:` made every one of them
-	// throw, and because the throw happens inside a storage operation it takes
-	// down whatever triggered it — a `sendMessage` to an unrelated group, for
-	// instance.
-	for (const domain of SenderKeyDomains) {
-		const terminator = `${SignalAddressSyntax.DOMAIN}${domain}${SignalAddressSyntax.JID_DEVICE}`
-		const chatEnd = key.indexOf(terminator)
-		if (chatEnd < 0) continue
-		const addressStart = chatEnd + terminator.length
-		const chat = key.slice(0, addressStart - SignalAddressSyntax.JID_DEVICE.length)
-		const address = legacySignalAddress(key.slice(addressStart))
-		const deviceSeparator = address.lastIndexOf(SignalAddressSyntax.SIGNAL_DEVICE)
-		return [chat, address.slice(0, deviceSeparator), address.slice(deviceSeparator + 1)].join(
-			SignalAddressSyntax.SENDER_KEY_PART
-		)
-	}
+/** A sender key is `<chatJid>:<signalAddress>`, and the chat is a group, status
+ *  or a broadcast list. Which chats fan out through sender keys is the core's
+ *  namespace, so the boundary validates the JID shape, not the domain. */
+const CHAT_JID = /^[^:@]+@[^:@]+$/
 
-	throw new TypeError(`invalid native sender-key address: ${key}`)
+function legacySenderKey(key: string): string {
+	const chatDomain = key.indexOf(SignalAddressSyntax.DOMAIN)
+	const chatEnd = chatDomain < 0 ? -1 : key.indexOf(SignalAddressSyntax.JID_DEVICE, chatDomain)
+	const chat = chatEnd < 0 ? '' : key.slice(0, chatEnd)
+	if (!CHAT_JID.test(chat)) throw new TypeError(`invalid native sender-key address: ${key}`)
+	const address = legacySignalAddress(key.slice(chatEnd + SignalAddressSyntax.JID_DEVICE.length))
+	const deviceSeparator = address.lastIndexOf(SignalAddressSyntax.SIGNAL_DEVICE)
+	return [chat, address.slice(0, deviceSeparator), address.slice(deviceSeparator + 1)].join(
+		SignalAddressSyntax.SENDER_KEY_PART
+	)
 }
 
 const passthroughKey = (_store: ProjectedStoreName, key: string): string => key
@@ -158,7 +150,7 @@ function nativeSignalAddress(address: string): string {
 
 function nativeSenderKey(key: string): string {
 	const parts = key.split(SignalAddressSyntax.SENDER_KEY_PART)
-	if (parts.length !== 3 || !parts[0] || !parts[1] || !parts[2]) {
+	if (parts.length !== 3 || !CHAT_JID.test(parts[0]!) || !parts[1] || !parts[2]) {
 		throw new TypeError(`invalid legacy sender-key address: ${key}`)
 	}
 	return `${parts[0]}${SignalAddressSyntax.JID_DEVICE}${nativeSignalAddress(`${parts[1]}.${parts[2]}`)}`

--- a/src/Utils/__tests__/_legacy-store-fixtures.ts
+++ b/src/Utils/__tests__/_legacy-store-fixtures.ts
@@ -73,6 +73,11 @@ export const UPSTREAM_SK_KEY_LID = `${SAMPLE_GROUP}::100000037037034_1::0`
 export const BRIDGE_SK_KEY_PN_DEV = `${SAMPLE_GROUP}:559980000003:5@s.whatsapp.net.0`
 export const UPSTREAM_SK_KEY_PN_DEV = `${SAMPLE_GROUP}::559980000003::5`
 
+// Status is fanned out with sender keys exactly like a group chat is.
+export const SAMPLE_STATUS = 'status@broadcast'
+export const BRIDGE_SK_KEY_STATUS = `${SAMPLE_STATUS}:559980000003:76@c.us.0`
+export const UPSTREAM_SK_KEY_STATUS = `${SAMPLE_STATUS}::559980000003::76`
+
 // Session keys (pairwise, no group prefix).
 export const BRIDGE_SESSION_KEY_LID = '100000037037034@lid.0'
 export const UPSTREAM_SESSION_KEY_LID = '100000037037034_1.0'

--- a/src/Utils/__tests__/wrap-legacy-store-sender-key.test.ts
+++ b/src/Utils/__tests__/wrap-legacy-store-sender-key.test.ts
@@ -17,8 +17,10 @@ import { wrapLegacyStore } from '../wrap-legacy-store.ts'
 import {
 	BRIDGE_SK_KEY_LID,
 	BRIDGE_SK_KEY_PN_DEV,
+	BRIDGE_SK_KEY_STATUS,
 	UPSTREAM_SK_KEY_LID,
 	UPSTREAM_SK_KEY_PN_DEV,
+	UPSTREAM_SK_KEY_STATUS,
 	buildBridgeSenderKeyBytes,
 	fill,
 	makeWrapped
@@ -37,6 +39,12 @@ describe('wrap-legacy-store: sender_key key-name translation', () => {
 		const { wrapped, keys } = await makeWrapped()
 		await wrapped.set('sender_key', BRIDGE_SK_KEY_PN_DEV, buildBridgeSenderKeyBytes())
 		expect(keys.raw['sender-key']?.[UPSTREAM_SK_KEY_PN_DEV]).toBeDefined()
+	})
+
+	test('status chat translates like a group chat', async () => {
+		const { wrapped, keys } = await makeWrapped()
+		await wrapped.set('sender_key', BRIDGE_SK_KEY_STATUS, buildBridgeSenderKeyBytes())
+		expect(keys.raw['sender-key']?.[UPSTREAM_SK_KEY_STATUS]).toBeDefined()
 	})
 
 	test('bridge GET reads back from the upstream-formatted key', async () => {
@@ -64,6 +72,34 @@ describe('wrap-legacy-store: sender_key key-name translation', () => {
 
 		const out = await wrapped.get('sender_key', BRIDGE_SK_KEY_LID)
 		expect(out).not.toBe(null)
+	})
+})
+
+describe('wrap-legacy-store: sender_key batch deletion', () => {
+	test('a group + status batch deletes both instead of failing as a whole', async () => {
+		const { wrapped, keys } = await makeWrapped()
+		await wrapped.setMany!('sender_key', [
+			[BRIDGE_SK_KEY_LID, buildBridgeSenderKeyBytes()],
+			[BRIDGE_SK_KEY_STATUS, buildBridgeSenderKeyBytes()]
+		])
+
+		await wrapped.deleteMany!('sender_key', [BRIDGE_SK_KEY_LID, BRIDGE_SK_KEY_STATUS])
+
+		expect(keys.raw['sender-key']?.[UPSTREAM_SK_KEY_LID]).toBeUndefined()
+		expect(keys.raw['sender-key']?.[UPSTREAM_SK_KEY_STATUS]).toBeUndefined()
+	})
+
+	// All-or-nothing is deliberate: an untranslatable key is a defect, and a
+	// partial delete would strip the native mirror while the legacy projection
+	// survives.
+	test('a genuinely malformed key still rejects the whole batch', async () => {
+		const { wrapped, keys } = await makeWrapped()
+		await wrapped.set('sender_key', BRIDGE_SK_KEY_LID, buildBridgeSenderKeyBytes())
+
+		await expect(wrapped.deleteMany!('sender_key', [BRIDGE_SK_KEY_LID, 'not-a-sender-key'])).rejects.toThrow(
+			/invalid native sender-key/
+		)
+		expect(keys.raw['sender-key']?.[UPSTREAM_SK_KEY_LID]).toBeDefined()
 	})
 })
 


### PR DESCRIPTION
## Problem

Sender keys are not exclusive to groups. Status updates and broadcast lists fan
out through the same sender-key mechanism, so `status@broadcast:<address>`
reaches the legacy-store translator alongside `<group>@g.us:<address>`.

`legacySenderKey` anchors the chat part on `@g.us:`:

```ts
const groupTerminator = `${SignalAddressSyntax.DOMAIN}${SignalDomain.GROUP}${SignalAddressSyntax.JID_DEVICE}` // "@g.us:"
const groupEnd = key.indexOf(groupTerminator)
if (groupEnd < 0) throw new TypeError(`invalid native sender-key address: ${key}`)
```

so every status address throws. Reproduction against `0.1.1`:

```js
import { legacyKey } from '@oxidezap/baileyrs/lib/Compatibility/legacy-store/routing.js'

legacyKey('sender_key', '120363000000000001@g.us:5511900000001@c.us.0') // ok
legacyKey('sender_key', 'status@broadcast:5511900000001:76@c.us.0')     // TypeError
```

Because the throw happens inside a storage operation, it aborts whatever
triggered it. In production this surfaced as `sendMessage` failing for an
**unrelated group** — the offending key has nothing to do with the chat being
written to:

```
Error [WhatsAppError]: storage operation failed: JS delete: invalid native
sender-key address: status@broadcast:5586XXXXXXXXX:76@c.us.0
  kind: 'storage',
  operation: 'JS delete: invalid native sender-key address: status@broadcast:5586XXXXXXXXX:76@c.us.0'
```

It reproduces on any bot that receives status updates while using an
upstream-style `auth: { creds, keys }` store (the `wrapLegacyStore` path).

## Fix

Parse the chat part by **shape** instead of by domain: the chat is everything
before the first `:` that follows the `@`, validated as a JID. Which chats fan
out through sender keys is the core's namespace, so this boundary validates the
form and stays out of that decision. Groups, `status@broadcast`, broadcast
lists and any chat kind the core adds later all translate without a new entry
here.

The same rule now applies in **both** directions. `nativeSenderKey` used to
accept any `<chat>::<user>::<device>` and hand back an address that
`legacySenderKey` would then reject:

```js
nativeKey('sender_key', 'nochat::5511900000001::0')      // ok -> nochat:5511900000001@c.us.0
legacyKey('sender_key', 'nochat:5511900000001@c.us.0')   // TypeError
```

That asymmetry was the evidence the original behaviour was a defect rather than
a policy, so closing it is part of the fix.

The shape check excludes whitespace and control characters, not just the
separators. No JID carries them, and one that slips through becomes a storage
key that is invisible in a log and unmatchable by a later lookup.

`constants.ts` is unchanged: `SignalDomain` is the vocabulary of Signal
*address* domains, and `broadcast` is a chat domain, so it does not belong
there.

## Tests

`src/Compatibility/__tests__/legacy-store-sender-key-routing.test.ts` covers
group, status and broadcast addresses, an unknown chat domain, chats carrying
whitespace or a control character, the round-trip in both directions, and keeps
the rejection for malformed addresses.

Batch behaviour is deliberately unchanged: a genuinely malformed key still
fails the whole `deleteMany`, so a bad key surfaces instead of being skipped in
silence.

- `node --test` — 909 passing
- `tsc --noEmit` — clean
- `oxfmt --check src` / `oxlint` — clean

Each fix commit is paired with the test that pins it, and reverting the fix
alone makes that test fail — so the tests are tied to the behaviour rather than
to the implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept sender-key addresses from status, broadcast lists, and any chat JID in the legacy-store translator to stop storage errors during status reception. This prevents unrelated `sendMessage` calls from failing.

- **Bug Fixes**
  - Parse chat by JID shape (not domain) so groups, `status@broadcast`, broadcast lists, and future chat kinds translate.
  - Make `legacyKey` and `nativeKey` symmetric; enforce a valid chat JID (reject whitespace/control chars); reject malformed addresses in both directions; add tests for unknown domains and round-trips.
  - Fix batch deletes: mixed group/status `deleteMany` succeeds; malformed keys still fail the batch.

<sup>Written for commit c9b9587d5de6fab31c73b0cc00923452f1bf58ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sender-key routing for status updates and broadcast lists.
  * Added validation for supported chat address formats.
  * Ensured sender-key conversions reject malformed addresses with clear errors.
  * Improved batch deletion so valid keys are removed safely while malformed entries are rejected without partial deletion.

* **Tests**
  * Added coverage for group, status, broadcast, hosted, unknown, and malformed chat addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
