### PR TITLE
fix(socket): reject an invalid enum argument before it reaches the bridge

### DIFF
--- a/src/Bridge/__tests__/dts-drift.test.ts
+++ b/src/Bridge/__tests__/dts-drift.test.ts
@@ -11,33 +11,10 @@
  */
 
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { describe, it } from 'node:test'
 import { KNOWN_BRIDGE_EVENT_TYPES } from '../adapt.ts'
+import { loadBridgeDts } from '../../__tests__/bridge-dts.ts'
 import { expect } from '../../__tests__/expect.ts'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-
-/** Resolve `whatsapp_rust_bridge.d.ts` from the installed package. */
-function loadBridgeDts(): string {
-	const candidates = [
-		path.resolve(__dirname, '../../../node_modules/@oxidezap/whatsapp-rust-bridge/dist/whatsapp_rust_bridge.d.ts'),
-		// Pre-0.6.0-alpha.39 packages shipped the declarations under pkg/.
-		path.resolve(__dirname, '../../../node_modules/@oxidezap/whatsapp-rust-bridge/pkg/whatsapp_rust_bridge.d.ts'),
-		// Sibling checkout, for local development against an unpublished bridge.
-		path.resolve(__dirname, '../../../../whatsapp-rust-bridge/pkg/whatsapp_rust_bridge.d.ts')
-	]
-	for (const candidate of candidates) {
-		try {
-			return readFileSync(candidate, 'utf8')
-		} catch {
-			/* try next */
-		}
-	}
-	throw new Error(`Could not find whatsapp_rust_bridge.d.ts. Tried:\n  ${candidates.join('\n  ')}`)
-}
 
 /**
  * Extract every discriminator string from the `WhatsAppEvent` union. The

--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -131,6 +131,9 @@ export type MediaType = keyof typeof MEDIA_HKDF_KEY_MAPPING
 
 export const MEDIA_KEYS = Object.keys(MEDIA_PATH_MAP) as MediaType[]
 
+/** The type's own members, for checking one that arrives untyped. */
+export const MEDIA_TYPES = Object.keys(MEDIA_HKDF_KEY_MAPPING) as MediaType[]
+
 /** 120s timeout for history sync stall detection, matching upstream Baileys. */
 export const HISTORY_SYNC_PAUSED_TIMEOUT_MS = 120_000
 

--- a/src/Defaults/index.ts
+++ b/src/Defaults/index.ts
@@ -131,8 +131,12 @@ export type MediaType = keyof typeof MEDIA_HKDF_KEY_MAPPING
 
 export const MEDIA_KEYS = Object.keys(MEDIA_PATH_MAP) as MediaType[]
 
-/** The type's own members, for checking one that arrives untyped. */
-export const MEDIA_TYPES = Object.keys(MEDIA_HKDF_KEY_MAPPING) as MediaType[]
+/**
+ * The type's own members, for checking one that arrives untyped. Readonly
+ * because it is public and the upload guard reads it: editing it would change
+ * what every caller is allowed to send.
+ */
+export const MEDIA_TYPES: readonly MediaType[] = Object.keys(MEDIA_HKDF_KEY_MAPPING) as MediaType[]
 
 /** 120s timeout for history sync stall detection, matching upstream Baileys. */
 export const HISTORY_SYNC_PAUSED_TIMEOUT_MS = 120_000

--- a/src/Socket/blocking.ts
+++ b/src/Socket/blocking.ts
@@ -1,8 +1,14 @@
 import { bridgeBlocklistToBaileys } from '../Compatibility/socket-results.ts'
+import { assertArgumentDomain } from '../Utils/argument-domain.ts'
 import type { SocketContext } from './types.ts'
 
+export const BLOCK_ACTIONS = ['block', 'unblock'] as const
+
+export type BlockAction = (typeof BLOCK_ACTIONS)[number]
+
 export const makeBlockingMethods = (ctx: SocketContext) => ({
-	updateBlockStatus: async (jid: string, action: 'block' | 'unblock') => {
+	updateBlockStatus: async (jid: string, action: BlockAction) => {
+		assertArgumentDomain('updateBlockStatus', 'action', action, BLOCK_ACTIONS)
 		await (await ctx.getClient()).updateBlockStatus(jid, action)
 	},
 

--- a/src/Socket/communities.ts
+++ b/src/Socket/communities.ts
@@ -2,7 +2,17 @@ import { bridgeGroupMetadataToBaileys } from '../Compatibility/group-metadata.ts
 import { bridgeParticipantChangesToBaileys } from '../Compatibility/socket-results.ts'
 import { PARTICIPANT_ACTIONS, type GroupMetadata, type ParticipantAction } from '../Types/index.ts'
 import { assertArgumentDomain } from '../Utils/argument-domain.ts'
-import { makeGroupMethods } from './groups.ts'
+import {
+	GROUP_REQUEST_ACTIONS,
+	GROUP_SETTINGS,
+	JOIN_APPROVAL_MODES,
+	makeGroupMethods,
+	MEMBER_ADD_MODES,
+	type GroupRequestAction,
+	type GroupSetting,
+	type JoinApprovalMode,
+	type MemberAddMode
+} from './groups.ts'
 import type { SocketContext } from './types.ts'
 
 type LinkedGroup = {
@@ -79,7 +89,16 @@ export const makeCommunityMethods = (ctx: SocketContext, groups = makeGroupMetho
 		},
 
 		communityRequestParticipantsList: groups.groupRequestParticipantsList,
-		communityRequestParticipantsUpdate: groups.groupRequestParticipantsUpdate,
+
+		/**
+		 * The four below are the group operation, and they check the argument
+		 * themselves rather than delegating straight to it: a refusal has to name
+		 * the method the consumer called, not the one it happens to reuse.
+		 */
+		communityRequestParticipantsUpdate: async (jid: string, participants: string[], action: GroupRequestAction) => {
+			assertArgumentDomain('communityRequestParticipantsUpdate', 'action', action, GROUP_REQUEST_ACTIONS)
+			return groups.groupRequestParticipantsUpdate(jid, participants, action)
+		},
 
 		communityParticipantsUpdate: async (jid: string, participants: string[], action: ParticipantAction) => {
 			assertArgumentDomain('communityParticipantsUpdate', 'action', action, PARTICIPANT_ACTIONS)
@@ -98,9 +117,18 @@ export const makeCommunityMethods = (ctx: SocketContext, groups = makeGroupMetho
 		communityAcceptInviteV4: groups.groupAcceptInviteV4,
 		communityGetInviteInfo: groups.groupGetInviteInfo,
 		communityToggleEphemeral: groups.groupToggleEphemeral,
-		communitySettingUpdate: groups.groupSettingUpdate,
-		communityMemberAddMode: groups.groupMemberAddMode,
-		communityJoinApprovalMode: groups.groupJoinApprovalMode,
+		communitySettingUpdate: async (jid: string, setting: GroupSetting): Promise<void> => {
+			assertArgumentDomain('communitySettingUpdate', 'setting', setting, GROUP_SETTINGS)
+			return groups.groupSettingUpdate(jid, setting)
+		},
+		communityMemberAddMode: async (jid: string, mode: MemberAddMode): Promise<void> => {
+			assertArgumentDomain('communityMemberAddMode', 'mode', mode, MEMBER_ADD_MODES)
+			return groups.groupMemberAddMode(jid, mode)
+		},
+		communityJoinApprovalMode: async (jid: string, mode: JoinApprovalMode): Promise<void> => {
+			assertArgumentDomain('communityJoinApprovalMode', 'mode', mode, JOIN_APPROVAL_MODES)
+			return groups.groupJoinApprovalMode(jid, mode)
+		},
 		communityFetchAllParticipating
 	}
 }

--- a/src/Socket/communities.ts
+++ b/src/Socket/communities.ts
@@ -1,6 +1,7 @@
 import { bridgeGroupMetadataToBaileys } from '../Compatibility/group-metadata.ts'
 import { bridgeParticipantChangesToBaileys } from '../Compatibility/socket-results.ts'
-import type { GroupMetadata, ParticipantAction } from '../Types/index.ts'
+import { PARTICIPANT_ACTIONS, type GroupMetadata, type ParticipantAction } from '../Types/index.ts'
+import { assertArgumentDomain } from '../Utils/argument-domain.ts'
 import { makeGroupMethods } from './groups.ts'
 import type { SocketContext } from './types.ts'
 
@@ -81,6 +82,7 @@ export const makeCommunityMethods = (ctx: SocketContext, groups = makeGroupMetho
 		communityRequestParticipantsUpdate: groups.groupRequestParticipantsUpdate,
 
 		communityParticipantsUpdate: async (jid: string, participants: string[], action: ParticipantAction) => {
+			assertArgumentDomain('communityParticipantsUpdate', 'action', action, PARTICIPANT_ACTIONS)
 			return bridgeParticipantChangesToBaileys(
 				await (await ctx.getClient()).communityParticipantsUpdate(jid, participants, action)
 			)

--- a/src/Socket/communities.ts
+++ b/src/Socket/communities.ts
@@ -91,9 +91,8 @@ export const makeCommunityMethods = (ctx: SocketContext, groups = makeGroupMetho
 		communityRequestParticipantsList: groups.groupRequestParticipantsList,
 
 		/**
-		 * The four below are the group operation, and they check the argument
-		 * themselves rather than delegating straight to it: a refusal has to name
-		 * the method the consumer called, not the one it happens to reuse.
+		 * The community methods that are the group operation check under their own
+		 * name before delegating: a refusal has to name the method that was called.
 		 */
 		communityRequestParticipantsUpdate: async (jid: string, participants: string[], action: GroupRequestAction) => {
 			assertArgumentDomain('communityRequestParticipantsUpdate', 'action', action, GROUP_REQUEST_ACTIONS)

--- a/src/Socket/contacts.ts
+++ b/src/Socket/contacts.ts
@@ -1,4 +1,9 @@
+import { assertArgumentDomain } from '../Utils/argument-domain.ts'
 import type { SocketContext } from './types.ts'
+
+export const PROFILE_PICTURE_TYPES = ['preview', 'image'] as const
+
+export type ProfilePictureType = (typeof PROFILE_PICTURE_TYPES)[number]
 
 export type OnWhatsAppResult = {
 	exists: boolean
@@ -26,7 +31,8 @@ export const makeContactMethods = (ctx: SocketContext) => ({
 		})
 	},
 
-	profilePictureUrl: async (jid: string, type: 'preview' | 'image' = 'preview', timeoutMs?: number) => {
+	profilePictureUrl: async (jid: string, type: ProfilePictureType = 'preview', timeoutMs?: number) => {
+		assertArgumentDomain('profilePictureUrl', 'type', type, PROFILE_PICTURE_TYPES)
 		const result = await (await ctx.getClient()).profilePictureUrl(jid, type, timeoutMs)
 		return result?.url
 	},

--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -52,7 +52,8 @@ export const makeGroupMethods = (ctx: SocketContext) => {
 	}
 
 	const groupSettingUpdate = async (jid: string, setting: GroupSetting): Promise<void> => {
-		const mapped = GROUP_SETTING_ALIASES[assertArgumentDomain('groupSettingUpdate', 'setting', setting, GROUP_SETTINGS)]
+		const checked = assertArgumentDomain('groupSettingUpdate', 'setting', setting, GROUP_SETTINGS)
+		const mapped = GROUP_SETTING_ALIASES[checked]
 		await (await ctx.getClient()).groupSettingUpdate(jid, mapped.setting, mapped.value)
 	}
 

--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -5,20 +5,42 @@ import {
 	bridgeParticipantChangesToBaileys
 } from '../Compatibility/socket-results.ts'
 import { emitMessageUpsert } from '../Compatibility/message-upsert.ts'
-import { WAMessageStubType, type GroupMetadata, type ParticipantAction, type WAMessageKey } from '../Types/index.ts'
+import {
+	PARTICIPANT_ACTIONS,
+	WAMessageStubType,
+	type GroupMetadata,
+	type ParticipantAction,
+	type WAMessageKey
+} from '../Types/index.ts'
+import { assertArgumentDomain } from '../Utils/argument-domain.ts'
 import { generateMessageIDV2, unixTimestampSeconds } from '../Utils/generics.ts'
 import { proto } from '../WAProto/runtime.ts'
 import { bridgeGroupMetadataToBaileys } from '../Compatibility/group-metadata.ts'
 import type { SocketContext } from './types.ts'
 
-type GroupSetting = 'announcement' | 'not_announcement' | 'locked' | 'unlocked'
-
-const GROUP_SETTING_ALIASES: Record<GroupSetting, { setting: 'locked' | 'announce'; value: boolean }> = {
+const GROUP_SETTING_ALIASES = {
 	announcement: { setting: 'announce', value: true },
 	not_announcement: { setting: 'announce', value: false },
 	locked: { setting: 'locked', value: true },
 	unlocked: { setting: 'locked', value: false }
-}
+} as const satisfies Record<string, { setting: 'locked' | 'announce'; value: boolean }>
+
+/** The table is the definition: both the type and the accepted set come off it. */
+export type GroupSetting = keyof typeof GROUP_SETTING_ALIASES
+
+const GROUP_SETTINGS = Object.keys(GROUP_SETTING_ALIASES) as GroupSetting[]
+
+export const GROUP_REQUEST_ACTIONS = ['approve', 'reject'] as const
+
+export type GroupRequestAction = (typeof GROUP_REQUEST_ACTIONS)[number]
+
+export const MEMBER_ADD_MODES = ['admin_add', 'all_member_add'] as const
+
+export type MemberAddMode = (typeof MEMBER_ADD_MODES)[number]
+
+export const JOIN_APPROVAL_MODES = ['on', 'off'] as const
+
+export type JoinApprovalMode = (typeof JOIN_APPROVAL_MODES)[number]
 
 const inviteExpirationNumber = (value: number | { toNumber(): number } | null | undefined): number =>
 	typeof value === 'number' ? value : (value?.toNumber() ?? 0)
@@ -30,7 +52,7 @@ export const makeGroupMethods = (ctx: SocketContext) => {
 	}
 
 	const groupSettingUpdate = async (jid: string, setting: GroupSetting): Promise<void> => {
-		const mapped = GROUP_SETTING_ALIASES[setting]
+		const mapped = GROUP_SETTING_ALIASES[assertArgumentDomain('groupSettingUpdate', 'setting', setting, GROUP_SETTINGS)]
 		await (await ctx.getClient()).groupSettingUpdate(jid, mapped.setting, mapped.value)
 	}
 
@@ -109,13 +131,15 @@ export const makeGroupMethods = (ctx: SocketContext) => {
 			return bridgeMembershipRequestsToBaileys(await (await ctx.getClient()).groupRequestParticipantsList(jid))
 		},
 
-		groupRequestParticipantsUpdate: async (jid: string, participants: string[], action: 'approve' | 'reject') => {
+		groupRequestParticipantsUpdate: async (jid: string, participants: string[], action: GroupRequestAction) => {
+			assertArgumentDomain('groupRequestParticipantsUpdate', 'action', action, GROUP_REQUEST_ACTIONS)
 			return bridgeMembershipRequestUpdatesToBaileys(
 				await (await ctx.getClient()).groupRequestParticipantsUpdate(jid, participants, action)
 			)
 		},
 
 		groupParticipantsUpdate: async (jid: string, participants: string[], action: ParticipantAction) => {
+			assertArgumentDomain('groupParticipantsUpdate', 'action', action, PARTICIPANT_ACTIONS)
 			return bridgeParticipantChangesToBaileys(
 				await (await ctx.getClient()).groupParticipantsUpdate(jid, participants, action)
 			)
@@ -153,11 +177,15 @@ export const makeGroupMethods = (ctx: SocketContext) => {
 
 		groupSettingUpdate,
 
-		groupMemberAddMode: async (jid: string, mode: 'admin_add' | 'all_member_add'): Promise<void> => {
+		groupMemberAddMode: async (jid: string, mode: MemberAddMode): Promise<void> => {
+			assertArgumentDomain('groupMemberAddMode', 'mode', mode, MEMBER_ADD_MODES)
 			await (await ctx.getClient()).groupMemberAddMode(jid, mode)
 		},
 
-		groupJoinApprovalMode: async (jid: string, mode: 'on' | 'off'): Promise<void> => {
+		groupJoinApprovalMode: async (jid: string, mode: JoinApprovalMode): Promise<void> => {
+			// Anything but 'on' used to mean off, so a typo turned approvals off
+			// and reported success.
+			assertArgumentDomain('groupJoinApprovalMode', 'mode', mode, JOIN_APPROVAL_MODES)
 			await (await ctx.getClient()).groupSettingUpdate(jid, 'membership_approval', mode === 'on')
 		},
 

--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -28,7 +28,7 @@ const GROUP_SETTING_ALIASES = {
 /** The table is the definition: both the type and the accepted set come off it. */
 export type GroupSetting = keyof typeof GROUP_SETTING_ALIASES
 
-export const GROUP_SETTINGS = Object.keys(GROUP_SETTING_ALIASES) as GroupSetting[]
+export const GROUP_SETTINGS: readonly GroupSetting[] = Object.keys(GROUP_SETTING_ALIASES) as GroupSetting[]
 
 export const GROUP_REQUEST_ACTIONS = ['approve', 'reject'] as const
 

--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -28,7 +28,7 @@ const GROUP_SETTING_ALIASES = {
 /** The table is the definition: both the type and the accepted set come off it. */
 export type GroupSetting = keyof typeof GROUP_SETTING_ALIASES
 
-const GROUP_SETTINGS = Object.keys(GROUP_SETTING_ALIASES) as GroupSetting[]
+export const GROUP_SETTINGS = Object.keys(GROUP_SETTING_ALIASES) as GroupSetting[]
 
 export const GROUP_REQUEST_ACTIONS = ['approve', 'reject'] as const
 

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -37,7 +37,13 @@ import { DisconnectReason, WA_PRESENCES } from '../Types/index.ts'
 import { assertArgumentDomain } from '../Utils/argument-domain.ts'
 import { Boom } from '../Utils/boom.ts'
 import { makeEventBuffer } from '../Utils/event-buffer.ts'
-import { _registerActiveBridgeClient, _unregisterActiveBridgeClient, downloadMediaMessage } from '../Utils/messages.ts'
+import {
+	_registerActiveBridgeClient,
+	_unregisterActiveBridgeClient,
+	downloadMediaMessage,
+	MEDIA_DOWNLOAD_TYPES,
+	type MediaDownloadType
+} from '../Utils/messages.ts'
 import { makeNativeCryptoProvider } from '../Utils/native-crypto-provider.ts'
 import type { MediaDownloadOptions } from '../Utils/messages-media.ts'
 import { wrapLegacyStore } from '../Utils/wrap-legacy-store.ts'
@@ -983,11 +989,15 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		...makeNewsletterMethods(ctx),
 		...makeBusinessMethods(ctx),
 		...makeServerQueryMethods(ctx),
-		downloadMedia: async <T extends 'buffer' | 'stream'>(
+		downloadMedia: async <T extends MediaDownloadType>(
 			message: WAMessage,
 			type: T,
 			options: MediaDownloadOptions = {}
 		) => {
+			// Checked here as well as in the helper: the client is awaited while
+			// the context below is built, and a check past that await reports a
+			// stack without the caller in it.
+			assertArgumentDomain('downloadMedia', 'type', type, MEDIA_DOWNLOAD_TYPES)
 			return downloadMediaMessage(message, type, options, {
 				logger,
 				reuploadRequest: (m: WAMessage) => sock.updateMediaMessage(m),

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -18,7 +18,7 @@ import { makeStanzaResponseMethods } from '../Compatibility/stanza-responses.ts'
 import { makeParticipatingRefreshHandler } from '../Compatibility/participating-refresh.ts'
 import { makeTaggedMessageWaiter } from '../Compatibility/tagged-message-waiter.ts'
 import { isRawNodeForwardingEnabled, WebSocketClient } from '../Compatibility/websocket-client.ts'
-import { DEFAULT_CONNECTION_CONFIG, type MediaType } from '../Defaults/index.ts'
+import { DEFAULT_CONNECTION_CONFIG, MEDIA_TYPES, type MediaType } from '../Defaults/index.ts'
 import type {
 	BinaryNode,
 	AuthenticationCreds,
@@ -29,10 +29,12 @@ import type {
 	UserFacingSocketConfig,
 	WABusinessProfile,
 	WAMessage,
-	WAMessageKey
+	WAMessageKey,
+	WAPresence
 } from '../Types/index.ts'
 import type Long from 'long'
-import { DisconnectReason } from '../Types/index.ts'
+import { DisconnectReason, WA_PRESENCES } from '../Types/index.ts'
+import { assertArgumentDomain } from '../Utils/argument-domain.ts'
 import { Boom } from '../Utils/boom.ts'
 import { makeEventBuffer } from '../Utils/event-buffer.ts'
 import { _registerActiveBridgeClient, _unregisterActiveBridgeClient, downloadMediaMessage } from '../Utils/messages.ts'
@@ -898,10 +900,10 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		 * caller hears about the protocol mistake instead of the bridge silently
 		 * sending nothing.
 		 */
-		sendPresenceUpdate: async (
-			type: 'available' | 'unavailable' | 'composing' | 'recording' | 'paused',
-			toJid?: string
-		) => {
+		sendPresenceUpdate: async (type: WAPresence, toJid?: string) => {
+			// Ahead of the client: an off-union value used to fall through to the
+			// chat-state branch and be reported as a missing jid.
+			assertArgumentDomain('sendPresenceUpdate', 'type', type, WA_PRESENCES)
 			const c = await ctx.getClient()
 			if (type === 'available' || type === 'unavailable') {
 				return c.sendPresence(type)
@@ -920,6 +922,9 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		 * keep working. Delegates to the bridge's encrypt + CDN-failover upload.
 		 */
 		waUploadToServer: async (data: Uint8Array | Buffer, opts: { mediaType: MediaType }): Promise<UploadMediaResult> => {
+			// The upstream set, which is wider than what the bridge uploads:
+			// `toBridgeMediaType` below still refuses the ones it cannot map.
+			assertArgumentDomain('waUploadToServer', 'mediaType', opts?.mediaType, MEDIA_TYPES)
 			const bytes = data instanceof Uint8Array && !Buffer.isBuffer(data) ? data : new Uint8Array(data)
 			return (await ctx.getClient()).uploadMedia(bytes, toBridgeMediaType(opts.mediaType))
 		},

--- a/src/Socket/messages.ts
+++ b/src/Socket/messages.ts
@@ -11,7 +11,8 @@ import type {
 	WAMessageContent,
 	WAMessageKey
 } from '../Types/index.ts'
-import { WAProto } from '../Types/index.ts'
+import { MESSAGE_RECEIPT_TYPES, WAProto } from '../Types/index.ts'
+import { assertArgumentDomain } from '../Utils/argument-domain.ts'
 import { Boom } from '../Utils/boom.ts'
 import { generateWAMessage, getContentType, normalizeMessageContent } from '../Utils/messages.ts'
 import { jidNormalizedUser } from '../WABinary/index.ts'
@@ -227,6 +228,9 @@ export const makeMessageMethods = (ctx: SocketContext) => ({
 	 * Not supported: 'hist_sync', 'peer_msg' (logged as warning)
 	 */
 	sendReceipt: async (jid: string, participant: string | undefined, messageIds: string[], type: MessageReceiptType) => {
+		// Ahead of the empty-list exit: the types this method handles elsewhere
+		// resolve without sending anything, so a typo looked like a no-op.
+		assertArgumentDomain('sendReceipt', 'type', type, MESSAGE_RECEIPT_TYPES)
 		if (!messageIds.length) return
 
 		if (type === 'read' || type === 'read-self') {
@@ -261,6 +265,7 @@ export const makeMessageMethods = (ctx: SocketContext) => ({
 	 * Send receipts for multiple message keys, grouped by JID and participant.
 	 */
 	sendReceipts: async (keys: WAMessageKey[], type: MessageReceiptType) => {
+		assertArgumentDomain('sendReceipts', 'type', type, MESSAGE_RECEIPT_TYPES)
 		const client = await ctx.getClient()
 		const receiptKeys = receiptMessageKeys(keys)
 

--- a/src/Socket/newsletter.ts
+++ b/src/Socket/newsletter.ts
@@ -3,9 +3,14 @@ import { bridgeNewsletterMetadataToBaileys } from '../Compatibility/newsletter-r
 import type { NewsletterMetadataResult } from '@oxidezap/whatsapp-rust-bridge'
 import type { NewsletterMetadata, NewsletterUpdate } from '../Types/Newsletter.ts'
 import type { WAMediaUpload } from '../Types/index.ts'
+import { assertArgumentDomain } from '../Utils/argument-domain.ts'
 import { Boom } from '../Utils/boom.ts'
 import { generateProfilePicture } from '../Utils/messages-media.ts'
 import type { SocketContext } from './types.ts'
+
+export const NEWSLETTER_KEY_TYPES = ['invite', 'jid'] as const
+
+export type NewsletterKeyType = (typeof NEWSLETTER_KEY_TYPES)[number]
 
 export const makeNewsletterMethods = (ctx: SocketContext) => ({
 	newsletterCreate: async (name: string, description?: string): Promise<NewsletterMetadata> => {
@@ -17,10 +22,8 @@ export const makeNewsletterMethods = (ctx: SocketContext) => ({
 	 * rather than one that inspects the key. Resolves to null when the
 	 * newsletter does not exist, matching upstream.
 	 */
-	newsletterMetadata: async (type: 'invite' | 'jid', key: string): Promise<NewsletterMetadata | null> => {
-		if (type !== 'invite' && type !== 'jid') {
-			throw new Boom(`newsletterMetadata: unknown key type '${type}'`, { statusCode: 400 })
-		}
+	newsletterMetadata: async (type: NewsletterKeyType, key: string): Promise<NewsletterMetadata | null> => {
+		assertArgumentDomain('newsletterMetadata', 'type', type, NEWSLETTER_KEY_TYPES)
 		const client = await ctx.getClient()
 		const result =
 			type === 'invite' ? await client.newsletterMetadataByInvite(key) : await client.newsletterMetadata(key)

--- a/src/Socket/presence.ts
+++ b/src/Socket/presence.ts
@@ -1,7 +1,10 @@
+import { WA_CHAT_STATES, WA_PRESENCE_STATUSES, type WAChatState, type WAPresenceStatus } from '../Types/index.ts'
+import { assertArgumentDomain } from '../Utils/argument-domain.ts'
 import type { SocketContext } from './types.ts'
 
 export const makePresenceMethods = (ctx: SocketContext) => ({
-	sendPresence: async (status: 'available' | 'unavailable') => {
+	sendPresence: async (status: WAPresenceStatus) => {
+		assertArgumentDomain('sendPresence', 'status', status, WA_PRESENCE_STATUSES)
 		await (await ctx.getClient()).sendPresence(status)
 	},
 
@@ -9,7 +12,8 @@ export const makePresenceMethods = (ctx: SocketContext) => ({
 		await (await ctx.getClient()).presenceSubscribe(toJid)
 	},
 
-	sendChatState: async (jid: string, state: 'composing' | 'recording' | 'paused') => {
+	sendChatState: async (jid: string, state: WAChatState) => {
+		assertArgumentDomain('sendChatState', 'state', state, WA_CHAT_STATES)
 		await (await ctx.getClient()).sendChatState(jid, state)
 	}
 })

--- a/src/Socket/privacy.ts
+++ b/src/Socket/privacy.ts
@@ -1,11 +1,18 @@
-import type {
-	WAPrivacyCallValue,
-	WAPrivacyGroupAddValue,
-	WAPrivacyMessagesValue,
-	WAPrivacyOnlineValue,
-	WAPrivacyValue,
-	WAReadReceiptsValue
+import {
+	WA_PRIVACY_CALL_VALUES,
+	WA_PRIVACY_GROUP_ADD_VALUES,
+	WA_PRIVACY_MESSAGES_VALUES,
+	WA_PRIVACY_ONLINE_VALUES,
+	WA_PRIVACY_VALUES,
+	WA_READ_RECEIPTS_VALUES,
+	type WAPrivacyCallValue,
+	type WAPrivacyGroupAddValue,
+	type WAPrivacyMessagesValue,
+	type WAPrivacyOnlineValue,
+	type WAPrivacyValue,
+	type WAReadReceiptsValue
 } from '../Types/index.ts'
+import { assertArgumentDomain } from '../Utils/argument-domain.ts'
 import type { SocketContext } from './types.ts'
 
 export const makePrivacyMethods = (ctx: SocketContext) => {
@@ -18,39 +25,53 @@ export const makePrivacyMethods = (ctx: SocketContext) => {
 			return (await ctx.getClient()).fetchPrivacySettings()
 		},
 
+		/**
+		 * The untyped escape hatch, left open on purpose: the bridge takes both
+		 * halves as plain strings and the core's wire enums carry a fallback, so
+		 * this is the way to reach a category or value the wrappers below do not
+		 * name yet. The wrappers are the checked path.
+		 */
 		updatePrivacySetting: async (category: string, value: string) => {
 			await (await ctx.getClient()).updatePrivacySetting(category, value)
 		},
 
 		updateLastSeenPrivacy: async (value: WAPrivacyValue) => {
+			assertArgumentDomain('updateLastSeenPrivacy', 'value', value, WA_PRIVACY_VALUES)
 			await (await ctx.getClient()).updatePrivacySetting('last', value)
 		},
 
 		updateOnlinePrivacy: async (value: WAPrivacyOnlineValue) => {
+			assertArgumentDomain('updateOnlinePrivacy', 'value', value, WA_PRIVACY_ONLINE_VALUES)
 			await (await ctx.getClient()).updatePrivacySetting('online', value)
 		},
 
 		updateProfilePicturePrivacy: async (value: WAPrivacyValue) => {
+			assertArgumentDomain('updateProfilePicturePrivacy', 'value', value, WA_PRIVACY_VALUES)
 			await (await ctx.getClient()).updatePrivacySetting('profile', value)
 		},
 
 		updateStatusPrivacy: async (value: WAPrivacyValue) => {
+			assertArgumentDomain('updateStatusPrivacy', 'value', value, WA_PRIVACY_VALUES)
 			await (await ctx.getClient()).updatePrivacySetting('status', value)
 		},
 
 		updateReadReceiptsPrivacy: async (value: WAReadReceiptsValue) => {
+			assertArgumentDomain('updateReadReceiptsPrivacy', 'value', value, WA_READ_RECEIPTS_VALUES)
 			await (await ctx.getClient()).updatePrivacySetting('readreceipts', value)
 		},
 
 		updateGroupsAddPrivacy: async (value: WAPrivacyGroupAddValue) => {
+			assertArgumentDomain('updateGroupsAddPrivacy', 'value', value, WA_PRIVACY_GROUP_ADD_VALUES)
 			await (await ctx.getClient()).updatePrivacySetting('groupadd', value)
 		},
 
 		updateCallPrivacy: async (value: WAPrivacyCallValue) => {
+			assertArgumentDomain('updateCallPrivacy', 'value', value, WA_PRIVACY_CALL_VALUES)
 			await (await ctx.getClient()).updatePrivacySetting('calladd', value)
 		},
 
 		updateMessagesPrivacy: async (value: WAPrivacyMessagesValue) => {
+			assertArgumentDomain('updateMessagesPrivacy', 'value', value, WA_PRIVACY_MESSAGES_VALUES)
 			await (await ctx.getClient()).updatePrivacySetting('messages', value)
 		},
 

--- a/src/Socket/server-queries.ts
+++ b/src/Socket/server-queries.ts
@@ -2,8 +2,13 @@ import type { BotListResult, NewChatMessageCappingResult } from '@oxidezap/whats
 import type { BotListInfo } from '../Types/Chat.ts'
 import type { NewChatMessageCapInfo } from '../Types/State.ts'
 import type { MediaConnInfo } from '../Types/Message.ts'
+import { assertArgumentDomain } from '../Utils/argument-domain.ts'
 import { Boom } from '../Utils/boom.ts'
 import type { SocketContext } from './types.ts'
+
+export const DIRTY_BIT_TYPES = ['account_sync', 'groups'] as const
+
+export type DirtyBitType = (typeof DIRTY_BIT_TYPES)[number]
 
 /**
  * Every section, flattened and deduplicated, rather than only the section the
@@ -98,7 +103,8 @@ export const makeServerQueryMethods = (ctx: SocketContext) => {
 			return toCapInfo(await (await ctx.getClient()).fetchNewChatMessageCappingInfo())
 		},
 
-		cleanDirtyBits: async (type: 'account_sync' | 'groups', fromTimestamp?: number | string): Promise<void> => {
+		cleanDirtyBits: async (type: DirtyBitType, fromTimestamp?: number | string): Promise<void> => {
+			assertArgumentDomain('cleanDirtyBits', 'type', type, DIRTY_BIT_TYPES)
 			let timestamp: number | null = null
 			if (fromTimestamp !== undefined) {
 				// A blank string is not a timestamp, and `Number('')` is the epoch,

--- a/src/Types/Chat.ts
+++ b/src/Types/Chat.ts
@@ -7,21 +7,50 @@ import type { ChatLabelAssociationActionBody } from './LabelAssociation.ts'
 import type { MessageLabelAssociationActionBody } from './LabelAssociation.ts'
 import type { MinimalMessage, WAMessageKey } from './Message.ts'
 
-/** privacy settings in WhatsApp Web */
-export type WAPrivacyValue = 'all' | 'contacts' | 'contact_blacklist' | 'none'
+/**
+ * privacy settings in WhatsApp Web
+ *
+ * Each of these is a set first and a type second: the wrappers that take one
+ * check the value against the same array the type is derived from, so a value
+ * cannot be accepted by the compiler and refused at runtime, or the reverse.
+ */
+export const WA_PRIVACY_VALUES = ['all', 'contacts', 'contact_blacklist', 'none'] as const
 
-export type WAPrivacyOnlineValue = 'all' | 'match_last_seen'
+export type WAPrivacyValue = (typeof WA_PRIVACY_VALUES)[number]
 
-export type WAPrivacyGroupAddValue = 'all' | 'contacts' | 'contact_blacklist'
+export const WA_PRIVACY_ONLINE_VALUES = ['all', 'match_last_seen'] as const
 
-export type WAReadReceiptsValue = 'all' | 'none'
+export type WAPrivacyOnlineValue = (typeof WA_PRIVACY_ONLINE_VALUES)[number]
 
-export type WAPrivacyCallValue = 'all' | 'known'
+export const WA_PRIVACY_GROUP_ADD_VALUES = ['all', 'contacts', 'contact_blacklist'] as const
 
-export type WAPrivacyMessagesValue = 'all' | 'contacts'
+export type WAPrivacyGroupAddValue = (typeof WA_PRIVACY_GROUP_ADD_VALUES)[number]
+
+export const WA_READ_RECEIPTS_VALUES = ['all', 'none'] as const
+
+export type WAReadReceiptsValue = (typeof WA_READ_RECEIPTS_VALUES)[number]
+
+export const WA_PRIVACY_CALL_VALUES = ['all', 'known'] as const
+
+export type WAPrivacyCallValue = (typeof WA_PRIVACY_CALL_VALUES)[number]
+
+export const WA_PRIVACY_MESSAGES_VALUES = ['all', 'contacts'] as const
+
+export type WAPrivacyMessagesValue = (typeof WA_PRIVACY_MESSAGES_VALUES)[number]
+
+/** the two the account itself broadcasts, as opposed to the per-chat states */
+export const WA_PRESENCE_STATUSES = ['unavailable', 'available'] as const
+
+export type WAPresenceStatus = (typeof WA_PRESENCE_STATUSES)[number]
+
+export const WA_CHAT_STATES = ['composing', 'recording', 'paused'] as const
+
+export type WAChatState = (typeof WA_CHAT_STATES)[number]
 
 /** set of statuses visible to other people; see updatePresence() in WhatsAppWeb.Send */
-export type WAPresence = 'unavailable' | 'available' | 'composing' | 'recording' | 'paused'
+export const WA_PRESENCES = [...WA_PRESENCE_STATUSES, ...WA_CHAT_STATES] as const
+
+export type WAPresence = (typeof WA_PRESENCES)[number]
 
 export const ALL_WA_PATCH_NAMES = [
 	'critical_block',

--- a/src/Types/GroupMetadata.ts
+++ b/src/Types/GroupMetadata.ts
@@ -7,7 +7,10 @@ export type GroupParticipant = Contact & {
 	admin?: 'admin' | 'superadmin' | null
 }
 
-export type ParticipantAction = 'add' | 'remove' | 'promote' | 'demote' | 'modify'
+export const PARTICIPANT_ACTIONS = ['add', 'remove', 'promote', 'demote', 'modify'] as const
+
+/** Derived from the values, so the runtime check and the type cannot drift. */
+export type ParticipantAction = (typeof PARTICIPANT_ACTIONS)[number]
 
 export type RequestJoinAction = 'created' | 'revoked' | 'rejected'
 

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -93,15 +93,19 @@ export type MessageWithContextInfo =
 	| 'pollResultSnapshotMessage'
 	| 'messageHistoryNotice'
 
-export type MessageReceiptType =
-	| 'read'
-	| 'read-self'
-	| 'hist_sync'
-	| 'peer_msg'
-	| 'sender'
-	| 'inactive'
-	| 'played'
-	| undefined
+/** `undefined` is a member: it is how upstream spells a delivery receipt. */
+export const MESSAGE_RECEIPT_TYPES = [
+	'read',
+	'read-self',
+	'hist_sync',
+	'peer_msg',
+	'sender',
+	'inactive',
+	'played',
+	undefined
+] as const
+
+export type MessageReceiptType = (typeof MESSAGE_RECEIPT_TYPES)[number]
 
 export type MediaConnInfo = {
 	auth: string

--- a/src/Utils/argument-domain.ts
+++ b/src/Utils/argument-domain.ts
@@ -6,9 +6,9 @@ const shown = (value: unknown): string => {
 	try {
 		return String(value)
 	} catch {
-		// A null-prototype object, or one whose conversion throws. Reporting the
-		// bad argument must not fail on the argument.
-		return Object.prototype.toString.call(value)
+		// A null-prototype object, a revoked proxy, a trap that throws. `typeof`
+		// reads nothing off the value, so reporting it cannot fail on it.
+		return `[${typeof value}]`
 	}
 }
 

--- a/src/Utils/argument-domain.ts
+++ b/src/Utils/argument-domain.ts
@@ -1,7 +1,16 @@
 import { Boom } from './boom.ts'
 
 /** Quoted when it is a string, bare otherwise, so `""` and `undefined` read apart. */
-const shown = (value: unknown): string => (typeof value === 'string' ? JSON.stringify(value) : String(value))
+const shown = (value: unknown): string => {
+	if (typeof value === 'string') return JSON.stringify(value)
+	try {
+		return String(value)
+	} catch {
+		// A null-prototype object, or one whose conversion throws. Reporting the
+		// bad argument must not fail on the argument.
+		return Object.prototype.toString.call(value)
+	}
+}
 
 /**
  * Refuse a value outside a closed set, naming the method, the parameter, what

--- a/src/Utils/argument-domain.ts
+++ b/src/Utils/argument-domain.ts
@@ -1,0 +1,34 @@
+import { Boom } from './boom.ts'
+
+/** Quoted when it is a string, bare otherwise, so `""` and `undefined` read apart. */
+const shown = (value: unknown): string => (typeof value === 'string' ? JSON.stringify(value) : String(value))
+
+/**
+ * Refuse a value outside a closed set, naming the method, the parameter, what
+ * arrived and everything that is accepted.
+ *
+ * Call it in the synchronous prefix of the public method, ahead of the first
+ * `await`. That is what puts the caller's own frame in the stack: a
+ * fire-and-forget call leaves no awaiting frame for V8 to stitch an async
+ * stack onto, and past the bridge boundary the rejection is built inside wasm
+ * and carries nothing but wasm frames.
+ *
+ * The domain is always the values that define the parameter's type, never a
+ * second list written beside it.
+ */
+export const assertArgumentDomain = <Value extends string | undefined>(
+	method: string,
+	parameter: string,
+	value: unknown,
+	domain: readonly Value[]
+): Value => {
+	if ((domain as readonly unknown[]).includes(value)) return value as Value
+
+	const error = new Boom(
+		`${method}: ${JSON.stringify(parameter)} must be one of ${domain.map(shown).join(', ')}, received ${shown(value)}`,
+		{ statusCode: 400, data: { parameter, value, accepted: [...domain] } }
+	)
+	// Drop this frame: the method the consumer called is the useful top.
+	Error.captureStackTrace(error, assertArgumentDomain)
+	throw error
+}

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -29,6 +29,7 @@ import type {
 import { WAMessageStatus, WAProto } from '../Types/index.ts'
 import { proto } from '../WAProto/runtime.ts'
 import { isJidGroup, isJidNewsletter, isJidStatusBroadcast, jidNormalizedUser } from '../WABinary/index.ts'
+import { assertArgumentDomain } from './argument-domain.ts'
 import { Boom } from './boom.ts'
 import { sha256 } from './crypto.ts'
 import { getKeyAuthor, toNumber, unixTimestampSeconds } from './generics.ts'
@@ -826,6 +827,10 @@ export type DownloadMediaMessageContext = {
 	waClient?: Pick<WasmWhatsAppClient, 'downloadMedia' | 'downloadMediaStream'>
 }
 
+export const MEDIA_DOWNLOAD_TYPES = ['buffer', 'stream'] as const
+
+export type MediaDownloadType = (typeof MEDIA_DOWNLOAD_TYPES)[number]
+
 /**
  * Downloads the given message. Throws an error if it's not a media message.
  *
@@ -839,12 +844,15 @@ export type DownloadMediaMessageContext = {
  * several sockets should pass `ctx` explicitly, because the registration points
  * at whichever client was created last.
  */
-export const downloadMediaMessage = async <Type extends 'buffer' | 'stream'>(
+export const downloadMediaMessage = async <Type extends MediaDownloadType>(
 	message: WAMessage,
 	type: Type,
 	options: MediaDownloadOptions,
 	ctx?: DownloadMediaMessageContext
 ) => {
+	// Anything but 'buffer' used to take the stream branch, so a typo returned
+	// a Readable to a caller holding it as a Buffer.
+	assertArgumentDomain('downloadMediaMessage', 'type', type, MEDIA_DOWNLOAD_TYPES)
 	const waClient = ctx?.waClient ?? activeBridgeClient
 	if (!waClient) {
 		throw new Boom(

--- a/src/__tests__/argument-domains.types.ts
+++ b/src/__tests__/argument-domains.types.ts
@@ -1,0 +1,15 @@
+/**
+ * The domains the socket checks against are public, and the checks read them
+ * live. A consumer able to edit one could make a valid call start failing, or
+ * an invalid one start passing, everywhere at once. They are readonly to say
+ * so, and these assertions fail the build if that stops being true.
+ */
+
+import { MEDIA_TYPES, type MediaType } from '../Defaults/index.ts'
+import { PARTICIPANT_ACTIONS } from '../Types/index.ts'
+
+// @ts-expect-error the exported media domain is readonly
+export const mutableMediaTypes: MediaType[] = MEDIA_TYPES
+
+// @ts-expect-error the domains declared `as const` are readonly already
+export const mutableParticipantActions: string[] = PARTICIPANT_ACTIONS

--- a/src/__tests__/argument-domains.types.ts
+++ b/src/__tests__/argument-domains.types.ts
@@ -6,10 +6,14 @@
  */
 
 import { MEDIA_TYPES, type MediaType } from '../Defaults/index.ts'
+import { GROUP_SETTINGS, type GroupSetting } from '../Socket/groups.ts'
 import { PARTICIPANT_ACTIONS } from '../Types/index.ts'
 
 // @ts-expect-error the exported media domain is readonly
 export const mutableMediaTypes: MediaType[] = MEDIA_TYPES
+
+// @ts-expect-error the group-setting domain is readonly, and two methods read it
+export const mutableGroupSettings: GroupSetting[] = GROUP_SETTINGS
 
 // @ts-expect-error the domains declared `as const` are readonly already
 export const mutableParticipantActions: string[] = PARTICIPANT_ACTIONS

--- a/src/__tests__/bridge-dts.ts
+++ b/src/__tests__/bridge-dts.ts
@@ -28,7 +28,9 @@ export const loadBridgeDts = (): string => {
 
 /** The members of an `export type X = "a" | "b"`, in declaration order. */
 export const bridgeStringUnion = (dts: string, name: string): string[] => {
-	const declaration = new RegExp(`^export type ${name} = (.+);$`, 'mu').exec(dts)
+	// `[^;]+` rather than `.+`: the generator wraps long unions across lines, as
+	// it already does for WhatsAppEvent, and a body-shaped match survives that.
+	const declaration = new RegExp(`^export type ${name} = ([^;]+);$`, 'mu').exec(dts)
 	if (!declaration) throw new Error(`the bridge no longer declares ${name}`)
 	return [...declaration[1]!.matchAll(/"([^"]*)"/gu)].map(match => match[1]!)
 }

--- a/src/__tests__/bridge-dts.ts
+++ b/src/__tests__/bridge-dts.ts
@@ -1,0 +1,34 @@
+/**
+ * The bridge's own declarations, which several tests read as the contract the
+ * core actually deserializes. Not a `.test.ts`, so the runner leaves it alone.
+ */
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const CANDIDATES = [
+	'../../node_modules/@oxidezap/whatsapp-rust-bridge/dist/whatsapp_rust_bridge.d.ts',
+	// Pre-0.6.0-alpha.39 packages shipped the declarations under pkg/.
+	'../../node_modules/@oxidezap/whatsapp-rust-bridge/pkg/whatsapp_rust_bridge.d.ts',
+	// Sibling checkout, for local development against an unpublished bridge.
+	'../../../whatsapp-rust-bridge/pkg/whatsapp_rust_bridge.d.ts'
+].map(candidate => path.resolve(import.meta.dirname, candidate))
+
+/** Resolve `whatsapp_rust_bridge.d.ts` from the installed package. */
+export const loadBridgeDts = (): string => {
+	for (const candidate of CANDIDATES) {
+		try {
+			return readFileSync(candidate, 'utf8')
+		} catch {
+			/* try the next one */
+		}
+	}
+	throw new Error(`Could not find whatsapp_rust_bridge.d.ts. Tried:\n  ${CANDIDATES.join('\n  ')}`)
+}
+
+/** The members of an `export type X = "a" | "b"`, in declaration order. */
+export const bridgeStringUnion = (dts: string, name: string): string[] => {
+	const declaration = new RegExp(`^export type ${name} = (.+);$`, 'mu').exec(dts)
+	if (!declaration) throw new Error(`the bridge no longer declares ${name}`)
+	return [...declaration[1]!.matchAll(/"([^"]*)"/gu)].map(match => match[1]!)
+}

--- a/src/__tests__/closed-domain-arguments.test.ts
+++ b/src/__tests__/closed-domain-arguments.test.ts
@@ -23,7 +23,6 @@
  */
 
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
 import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -32,6 +31,7 @@ import P from 'pino'
 
 import makeWASocket from '../Socket/index.ts'
 import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
+import { bridgeStringUnion, loadBridgeDts } from './bridge-dts.ts'
 import { expect } from './expect.ts'
 
 type Socket = ReturnType<typeof makeWASocket>
@@ -320,32 +320,10 @@ const enclosingName = (text: string, index: number): string => {
 	return name
 }
 
-/** Read the union members of an `export type X = "a" | "b"` in the bridge .d.ts. */
-const bridgeUnion = (() => {
-	const candidates = [
-		path.resolve(
-			import.meta.dirname,
-			'../../node_modules/@oxidezap/whatsapp-rust-bridge/dist/whatsapp_rust_bridge.d.ts'
-		),
-		path.resolve(import.meta.dirname, '../../../whatsapp-rust-bridge/pkg/whatsapp_rust_bridge.d.ts')
-	]
-	let dts = ''
-	for (const candidate of candidates) {
-		try {
-			dts = readFileSync(candidate, 'utf8')
-			break
-		} catch {
-			/* try the next one */
-		}
-	}
-	if (!dts) throw new Error(`could not find whatsapp_rust_bridge.d.ts, tried:\n  ${candidates.join('\n  ')}`)
+/** The bridge's own union for a name, as the core deserializes it. */
+const bridgeDts = loadBridgeDts()
 
-	return (name: string): string[] => {
-		const declaration = new RegExp(`^export type ${name} = (.+);$`, 'mu').exec(dts)
-		if (!declaration) throw new Error(`the bridge no longer declares ${name}`)
-		return [...declaration[1]!.matchAll(/"([^"]*)"/gu)].map(match => match[1]!)
-	}
-})()
+const bridgeUnion = (name: string): string[] => bridgeStringUnion(bridgeDts, name)
 
 const isDomainRejection = (error: unknown): boolean => error instanceof Error && / must be one of /u.test(error.message)
 

--- a/src/__tests__/closed-domain-arguments.test.ts
+++ b/src/__tests__/closed-domain-arguments.test.ts
@@ -476,6 +476,17 @@ describe('a closed-domain argument is rejected before it reaches the bridge', { 
 		expect(isDomainRejection(error)).toBe(false)
 	})
 
+	it('a value that cannot be turned into a string is still reported as a bad argument', async () => {
+		// Rendering the value is part of the message, so a value that throws on
+		// conversion could replace the 400 with a TypeError from our own report.
+		for (const hostile of [Object.create(null) as unknown, { toString: () => JSON.parse('nope') }]) {
+			const error = await settle(() => sock.groupParticipantsUpdate(GROUP, [USER], arg(hostile)))
+			expect(statusCodeOf(error)).toBe(400)
+			expect(isDomainRejection(error)).toBe(true)
+			expect((error as Error).message).toContain('[object')
+		}
+	})
+
 	it('every closed-domain parameter on the socket is covered or exempt', async () => {
 		const directory = path.resolve(import.meta.dirname, '../Socket')
 		const covered = new Set(CASES.flatMap(entry => (entry.source ? [entry.source] : [])))

--- a/src/__tests__/closed-domain-arguments.test.ts
+++ b/src/__tests__/closed-domain-arguments.test.ts
@@ -479,7 +479,18 @@ describe('a closed-domain argument is rejected before it reaches the bridge', { 
 	it('a value that cannot be turned into a string is still reported as a bad argument', async () => {
 		// Rendering the value is part of the message, so a value that throws on
 		// conversion could replace the 400 with a TypeError from our own report.
-		for (const hostile of [Object.create(null) as unknown, { toString: () => JSON.parse('nope') }]) {
+		// A revoked proxy throws on any read at all, `Object.prototype.toString`
+		// included, so the fallback cannot read the value either.
+		const revocable = Proxy.revocable({}, {})
+		revocable.revoke()
+		const hostileValues: unknown[] = [
+			Object.create(null),
+			{ toString: () => JSON.parse('nope') },
+			revocable.proxy,
+			new Proxy({}, { get: () => JSON.parse('nope') })
+		]
+
+		for (const hostile of hostileValues) {
 			const error = await settle(() => sock.groupParticipantsUpdate(GROUP, [USER], arg(hostile)))
 			expect(statusCodeOf(error)).toBe(400)
 			expect(isDomainRejection(error)).toBe(true)

--- a/src/__tests__/closed-domain-arguments.test.ts
+++ b/src/__tests__/closed-domain-arguments.test.ts
@@ -30,6 +30,7 @@ import { after, before, describe, it } from 'node:test'
 import P from 'pino'
 
 import makeWASocket from '../Socket/index.ts'
+import { downloadMediaMessage } from '../Utils/messages.ts'
 import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
 import { bridgeStringUnion, loadBridgeDts } from './bridge-dts.ts'
 import { expect } from './expect.ts'
@@ -254,14 +255,48 @@ const CASES: DomainCase[] = [
 		source: 'messages.ts:sendReceipts:type'
 	},
 	{
-		// The socket method is a delegate, and `downloadMediaMessage` is also
-		// exported on its own, so the check belongs there and the message says
-		// that name.
-		label: 'downloadMediaMessage',
+		label: 'downloadMedia',
 		parameter: 'type',
 		values: ['buffer', 'stream'],
 		call: (sock, value) =>
 			sock.downloadMedia({ key: { remoteJid: USER, id: '3EB0' }, message: {} }, arg<'buffer'>(value), {})
+	},
+	{
+		// The socket method delegates to this one, which is also exported on its
+		// own, so both entry points check and each reports its own name.
+		label: 'downloadMediaMessage',
+		parameter: 'type',
+		values: ['buffer', 'stream'],
+		call: (_sock, value) =>
+			downloadMediaMessage({ key: { remoteJid: USER, id: '3EB0' }, message: {} }, arg<'buffer'>(value), {})
+	},
+	{
+		label: 'communityRequestParticipantsUpdate',
+		parameter: 'action',
+		values: ['approve', 'reject'],
+		call: (sock, value) => sock.communityRequestParticipantsUpdate(GROUP, [USER], arg(value)),
+		source: 'communities.ts:communityRequestParticipantsUpdate:action'
+	},
+	{
+		label: 'communitySettingUpdate',
+		parameter: 'setting',
+		values: ['announcement', 'not_announcement', 'locked', 'unlocked'],
+		call: (sock, value) => sock.communitySettingUpdate(GROUP, arg(value)),
+		source: 'communities.ts:communitySettingUpdate:setting'
+	},
+	{
+		label: 'communityMemberAddMode',
+		parameter: 'mode',
+		values: ['admin_add', 'all_member_add'],
+		call: (sock, value) => sock.communityMemberAddMode(GROUP, arg(value)),
+		source: 'communities.ts:communityMemberAddMode:mode'
+	},
+	{
+		label: 'communityJoinApprovalMode',
+		parameter: 'mode',
+		values: ['on', 'off'],
+		call: (sock, value) => sock.communityJoinApprovalMode(GROUP, arg(value)),
+		source: 'communities.ts:communityJoinApprovalMode:mode'
 	}
 ]
 

--- a/src/__tests__/closed-domain-arguments.test.ts
+++ b/src/__tests__/closed-domain-arguments.test.ts
@@ -1,0 +1,492 @@
+/**
+ * An argument outside a closed set is the caller's mistake, and the report of
+ * it has to reach the caller.
+ *
+ * Reported from production: `groupParticipantsUpdate(from, [id], '☠️')`, called
+ * from a `setTimeout` with neither `await` nor `.catch`. The value crossed into
+ * the bridge untouched and the core's deserializer rejected it, so the consumer
+ * got an `unhandledRejection` whose every frame is `wasm://wasm/<hash>` and
+ * whose text is the Rust variant error. Nothing in it points at the line that
+ * made the call, and that line is a one-word fix once you can find it.
+ *
+ * So the contract pinned here is: the rejection names the parameter, lists the
+ * accepted values, shows what arrived, and carries a stack with the call site
+ * in it. The last one is only possible if the check runs in the synchronous
+ * prefix of the method, before the first `await`: a fire-and-forget call has no
+ * awaiting frame for V8 to stitch an async stack onto, so anything thrown after
+ * the boundary reports frames the consumer never wrote.
+ *
+ * Everything here drives the real public socket, pointed at a port nothing
+ * listens on. A value that passes validation fails downstream as "not
+ * connected" rather than reaching a server, which is the distinction these
+ * tests need: rejected-by-us versus not-rejected-by-us.
+ */
+
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { after, before, describe, it } from 'node:test'
+import P from 'pino'
+
+import makeWASocket from '../Socket/index.ts'
+import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
+import { expect } from './expect.ts'
+
+type Socket = ReturnType<typeof makeWASocket>
+
+/** Pass an off-union value through a typed parameter, the way plain JS does. */
+const arg = <T>(value: unknown): T => value as T
+
+const GROUP = '120363000000000000@g.us'
+const USER = '15550000000@s.whatsapp.net'
+const NEWSLETTER = '120363000000000001@newsletter'
+
+/** Every media type upstream names, which is what `waUploadToServer` takes. */
+const MEDIA_TYPES = [
+	'audio',
+	'document',
+	'gif',
+	'image',
+	'ppic',
+	'product',
+	'ptt',
+	'sticker',
+	'video',
+	'thumbnail-document',
+	'thumbnail-image',
+	'thumbnail-video',
+	'thumbnail-link',
+	'md-msg-hist',
+	'md-app-state',
+	'product-catalog-image',
+	'payment-bg-image',
+	'ptv',
+	'biz-cover-photo'
+]
+
+const RECEIPT_TYPES = ['read', 'read-self', 'hist_sync', 'peer_msg', 'sender', 'inactive', 'played', undefined]
+
+const PRIVACY_VALUES = ['all', 'contacts', 'contact_blacklist', 'none']
+
+interface DomainCase {
+	/** The name the message uses, which is the method a consumer called. */
+	label: string
+	parameter: string
+	/** Every value the method accepts, as the message must list them. */
+	values: ReadonlyArray<string | undefined>
+	call: (sock: Socket, value: unknown) => Promise<unknown>
+	/** `file.ts:method:parameter`, as the source scan below spells it. */
+	source?: string
+}
+
+const CASES: DomainCase[] = [
+	{
+		label: 'groupParticipantsUpdate',
+		parameter: 'action',
+		values: ['add', 'remove', 'promote', 'demote', 'modify'],
+		call: (sock, value) => sock.groupParticipantsUpdate(GROUP, [USER], arg(value)),
+		source: 'groups.ts:groupParticipantsUpdate:action'
+	},
+	{
+		label: 'communityParticipantsUpdate',
+		parameter: 'action',
+		values: ['add', 'remove', 'promote', 'demote', 'modify'],
+		call: (sock, value) => sock.communityParticipantsUpdate(GROUP, [USER], arg(value)),
+		source: 'communities.ts:communityParticipantsUpdate:action'
+	},
+	{
+		label: 'groupRequestParticipantsUpdate',
+		parameter: 'action',
+		values: ['approve', 'reject'],
+		call: (sock, value) => sock.groupRequestParticipantsUpdate(GROUP, [USER], arg(value)),
+		source: 'groups.ts:groupRequestParticipantsUpdate:action'
+	},
+	{
+		label: 'groupSettingUpdate',
+		parameter: 'setting',
+		values: ['announcement', 'not_announcement', 'locked', 'unlocked'],
+		call: (sock, value) => sock.groupSettingUpdate(GROUP, arg(value)),
+		source: 'groups.ts:groupSettingUpdate:setting'
+	},
+	{
+		label: 'groupMemberAddMode',
+		parameter: 'mode',
+		values: ['admin_add', 'all_member_add'],
+		call: (sock, value) => sock.groupMemberAddMode(GROUP, arg(value)),
+		source: 'groups.ts:groupMemberAddMode:mode'
+	},
+	{
+		label: 'groupJoinApprovalMode',
+		parameter: 'mode',
+		values: ['on', 'off'],
+		call: (sock, value) => sock.groupJoinApprovalMode(GROUP, arg(value)),
+		source: 'groups.ts:groupJoinApprovalMode:mode'
+	},
+	{
+		label: 'updateLastSeenPrivacy',
+		parameter: 'value',
+		values: PRIVACY_VALUES,
+		call: (sock, value) => sock.updateLastSeenPrivacy(arg(value)),
+		source: 'privacy.ts:updateLastSeenPrivacy:value'
+	},
+	{
+		label: 'updateProfilePicturePrivacy',
+		parameter: 'value',
+		values: PRIVACY_VALUES,
+		call: (sock, value) => sock.updateProfilePicturePrivacy(arg(value)),
+		source: 'privacy.ts:updateProfilePicturePrivacy:value'
+	},
+	{
+		label: 'updateStatusPrivacy',
+		parameter: 'value',
+		values: PRIVACY_VALUES,
+		call: (sock, value) => sock.updateStatusPrivacy(arg(value)),
+		source: 'privacy.ts:updateStatusPrivacy:value'
+	},
+	{
+		label: 'updateOnlinePrivacy',
+		parameter: 'value',
+		values: ['all', 'match_last_seen'],
+		call: (sock, value) => sock.updateOnlinePrivacy(arg(value)),
+		source: 'privacy.ts:updateOnlinePrivacy:value'
+	},
+	{
+		label: 'updateReadReceiptsPrivacy',
+		parameter: 'value',
+		values: ['all', 'none'],
+		call: (sock, value) => sock.updateReadReceiptsPrivacy(arg(value)),
+		source: 'privacy.ts:updateReadReceiptsPrivacy:value'
+	},
+	{
+		label: 'updateGroupsAddPrivacy',
+		parameter: 'value',
+		values: ['all', 'contacts', 'contact_blacklist'],
+		call: (sock, value) => sock.updateGroupsAddPrivacy(arg(value)),
+		source: 'privacy.ts:updateGroupsAddPrivacy:value'
+	},
+	{
+		label: 'updateCallPrivacy',
+		parameter: 'value',
+		values: ['all', 'known'],
+		call: (sock, value) => sock.updateCallPrivacy(arg(value)),
+		source: 'privacy.ts:updateCallPrivacy:value'
+	},
+	{
+		label: 'updateMessagesPrivacy',
+		parameter: 'value',
+		values: ['all', 'contacts'],
+		call: (sock, value) => sock.updateMessagesPrivacy(arg(value)),
+		source: 'privacy.ts:updateMessagesPrivacy:value'
+	},
+	{
+		label: 'updateBlockStatus',
+		parameter: 'action',
+		values: ['block', 'unblock'],
+		call: (sock, value) => sock.updateBlockStatus(USER, arg(value)),
+		source: 'blocking.ts:updateBlockStatus:action'
+	},
+	{
+		label: 'sendPresence',
+		parameter: 'status',
+		values: ['available', 'unavailable'],
+		call: (sock, value) => sock.sendPresence(arg(value)),
+		source: 'presence.ts:sendPresence:status'
+	},
+	{
+		label: 'sendChatState',
+		parameter: 'state',
+		values: ['composing', 'recording', 'paused'],
+		call: (sock, value) => sock.sendChatState(USER, arg(value)),
+		source: 'presence.ts:sendChatState:state'
+	},
+	{
+		label: 'sendPresenceUpdate',
+		parameter: 'type',
+		values: ['available', 'unavailable', 'composing', 'recording', 'paused'],
+		call: (sock, value) => sock.sendPresenceUpdate(arg(value), USER),
+		source: 'index.ts:sendPresenceUpdate:type'
+	},
+	{
+		label: 'profilePictureUrl',
+		parameter: 'type',
+		values: ['preview', 'image'],
+		call: (sock, value) => sock.profilePictureUrl(USER, arg(value)),
+		source: 'contacts.ts:profilePictureUrl:type'
+	},
+	{
+		label: 'newsletterMetadata',
+		parameter: 'type',
+		values: ['invite', 'jid'],
+		call: (sock, value) => sock.newsletterMetadata(arg(value), NEWSLETTER),
+		source: 'newsletter.ts:newsletterMetadata:type'
+	},
+	{
+		label: 'cleanDirtyBits',
+		parameter: 'type',
+		values: ['account_sync', 'groups'],
+		call: (sock, value) => sock.cleanDirtyBits(arg(value)),
+		source: 'server-queries.ts:cleanDirtyBits:type'
+	},
+	{
+		label: 'waUploadToServer',
+		parameter: 'mediaType',
+		values: MEDIA_TYPES,
+		call: (sock, value) => sock.waUploadToServer(new Uint8Array([1, 2, 3]), { mediaType: arg(value) }),
+		source: 'index.ts:waUploadToServer:mediaType'
+	},
+	{
+		label: 'sendReceipt',
+		parameter: 'type',
+		values: RECEIPT_TYPES,
+		call: (sock, value) => sock.sendReceipt(USER, undefined, ['3EB0'], arg(value)),
+		source: 'messages.ts:sendReceipt:type'
+	},
+	{
+		label: 'sendReceipts',
+		parameter: 'type',
+		values: RECEIPT_TYPES,
+		call: (sock, value) => sock.sendReceipts([{ remoteJid: USER, id: '3EB0' }], arg(value)),
+		source: 'messages.ts:sendReceipts:type'
+	},
+	{
+		// The socket method is a delegate, and `downloadMediaMessage` is also
+		// exported on its own, so the check belongs there and the message says
+		// that name.
+		label: 'downloadMediaMessage',
+		parameter: 'type',
+		values: ['buffer', 'stream'],
+		call: (sock, value) =>
+			sock.downloadMedia({ key: { remoteJid: USER, id: '3EB0' }, message: {} }, arg<'buffer'>(value), {})
+	}
+]
+
+/**
+ * Closed-domain parameters the scan finds that no case covers, each with the
+ * reason it is not validated. An entry here is a decision, not a backlog item.
+ */
+const EXEMPT: Record<string, string> = {
+	'groups.ts:<module>:setting': 'a value in the alias table, not a parameter',
+	'business.ts:minutesPastMidnight:which': 'a module-internal helper, called with a literal at both call sites',
+	'internals.ts:resyncAppState:collections': 'a no-op wrapper: nothing is forwarded to the bridge',
+	'server-queries.ts:createCallLink:_type': 'refused with a 501 whatever the value is'
+}
+
+/** `parameter: 'a' | 'b'`, or a parameter of a type that is one of those. */
+const CLOSED_DOMAIN_PARAMETER =
+	/(?:(?:const|let|var)\s+)?(?<parameter>[A-Za-z_$][\w$]*)\??:\s*(?:readonly )?\(?(?:(?:'[^']*'\s*\|\s*)+'[^']*'|(?:ParticipantAction|MediaType|MessageReceiptType|WAPresence|GroupSetting|WAPrivacyValue|WAPrivacyOnlineValue|WAPrivacyGroupAddValue|WAReadReceiptsValue|WAPrivacyCallValue|WAPrivacyMessagesValue)\b)/gu
+
+/** The method whose parameter list the match sits in. */
+const enclosingName = (text: string, index: number): string => {
+	const opener =
+		/(?:(?<assigned>[A-Za-z_$][\w$]*)\s*=\s*|(?<keyed>[A-Za-z_$][\w$]*)\s*:\s*)(?:async\s*)?(?:<[^<>]*>\s*)?\(/gu
+	let name = '<module>'
+	for (const match of text.slice(0, index).matchAll(opener)) {
+		name = match.groups?.assigned ?? match.groups?.keyed ?? name
+	}
+	return name
+}
+
+/** Read the union members of an `export type X = "a" | "b"` in the bridge .d.ts. */
+const bridgeUnion = (() => {
+	const candidates = [
+		path.resolve(
+			import.meta.dirname,
+			'../../node_modules/@oxidezap/whatsapp-rust-bridge/dist/whatsapp_rust_bridge.d.ts'
+		),
+		path.resolve(import.meta.dirname, '../../../whatsapp-rust-bridge/pkg/whatsapp_rust_bridge.d.ts')
+	]
+	let dts = ''
+	for (const candidate of candidates) {
+		try {
+			dts = readFileSync(candidate, 'utf8')
+			break
+		} catch {
+			/* try the next one */
+		}
+	}
+	if (!dts) throw new Error(`could not find whatsapp_rust_bridge.d.ts, tried:\n  ${candidates.join('\n  ')}`)
+
+	return (name: string): string[] => {
+		const declaration = new RegExp(`^export type ${name} = (.+);$`, 'mu').exec(dts)
+		if (!declaration) throw new Error(`the bridge no longer declares ${name}`)
+		return [...declaration[1]!.matchAll(/"([^"]*)"/gu)].map(match => match[1]!)
+	}
+})()
+
+const isDomainRejection = (error: unknown): boolean => error instanceof Error && / must be one of /u.test(error.message)
+
+const statusCodeOf = (error: unknown): number | undefined =>
+	(error as { output?: { statusCode?: number } })?.output?.statusCode
+
+/** Settle a call, reporting a wait that never ends rather than hanging on it. */
+const settle = async (run: () => Promise<unknown>): Promise<unknown> => {
+	let timer: NodeJS.Timeout | undefined
+	const pending = new Promise(resolve => {
+		timer = setTimeout(() => resolve(new Error('the call never settled')), 10_000)
+	})
+	const outcome = await Promise.race([
+		run().then(
+			() => undefined,
+			(error: unknown) => error
+		),
+		pending
+	])
+	clearTimeout(timer)
+	return outcome
+}
+
+/** How the message renders a value it received, or one it accepts. */
+const shown = (value: unknown): string => (typeof value === 'string' ? JSON.stringify(value) : String(value))
+
+const assertNamesTheMistake = (error: unknown, { label, parameter, values }: DomainCase, received: unknown): void => {
+	// Reported in full: what a consumer gets today is exactly what makes this
+	// fail, so the failure has to show it.
+	const got = error instanceof Error ? `${error.message}\n${error.stack}` : `no rejection, got ${String(error)}`
+	assert.ok(error instanceof Error, `${label}(${shown(received)}) had to reject, ${got}`)
+
+	const message = error.message
+	const missing = [label, JSON.stringify(parameter), shown(received), ...values.map(shown)].filter(
+		text => !message.includes(text)
+	)
+	assert.deepStrictEqual(
+		missing,
+		[],
+		`the rejection has to name the method, the parameter, what arrived and every accepted value, and these are missing.\n${got}`
+	)
+	// A caller error, not a fault of ours: the status the socket already uses
+	// for a malformed argument.
+	assert.strictEqual(statusCodeOf(error), 400, `a caller mistake is a 400.\n${got}`)
+}
+
+describe('a closed-domain argument is rejected before it reaches the bridge', { timeout: 180_000 }, () => {
+	let folder: string
+	let sock: Socket
+
+	before(async () => {
+		folder = await mkdtemp(path.join(tmpdir(), 'baileyrs-domains-'))
+		const { state } = await useMultiFileAuthState(folder)
+		sock = makeWASocket({
+			auth: state,
+			logger: P({ level: 'silent' }),
+			waWebSocketUrl: 'ws://127.0.0.1:1'
+		})
+	})
+
+	after(async () => {
+		await sock.end(undefined)
+		await rm(folder, { recursive: true, force: true })
+	})
+
+	it('the reported call rejects with the call site in the stack', async () => {
+		const reported = CASES[0]!
+		// The reported shape exactly: created inside a timer, never awaited, so
+		// there is no caller frame for V8 to stitch an async stack onto.
+		const error = await new Promise<unknown>(resolve => {
+			setTimeout(() => {
+				const pending = sock.groupParticipantsUpdate(GROUP, [USER], arg('☠️'))
+				pending.then(() => resolve(new Error('expected a rejection')), resolve)
+			}, 0)
+		})
+
+		assertNamesTheMistake(error, reported, '☠️')
+		const stack = (error as Error).stack ?? ''
+		// The whole point: the consumer's own file is in there, and none of the
+		// frames belong to the bridge.
+		expect(stack).toContain('closed-domain-arguments.test.ts')
+		expect(stack.includes('wasm://')).toBe(false)
+	})
+
+	for (const testCase of CASES) {
+		const { label, parameter, values } = testCase
+		const probes: unknown[] = ['☠️', 'bogus', '']
+		const spelled = values.find(value => typeof value === 'string')!
+		if (spelled.toUpperCase() !== spelled) probes.push(spelled.toUpperCase())
+		if (!values.includes(undefined)) probes.push(undefined, null)
+
+		it(`${label} rejects an off-domain ${parameter}`, async () => {
+			for (const probe of probes) {
+				const error = await settle(() => testCase.call(sock, probe))
+				assertNamesTheMistake(error, testCase, probe)
+			}
+		})
+
+		it(`${label} still accepts every value of ${parameter}`, async () => {
+			for (const value of values) {
+				const error = await settle(() => testCase.call(sock, value))
+				// Offline, so most of these fail downstream. What must not
+				// happen is this layer rejecting a value it documents.
+				expect(isDomainRejection(error)).toBe(false)
+			}
+		})
+	}
+
+	it('an omitted optional argument takes its default instead of being rejected', async () => {
+		const error = await settle(() => sock.profilePictureUrl(USER))
+		expect(isDomainRejection(error)).toBe(false)
+	})
+
+	it('every closed-domain parameter on the socket is covered or exempt', async () => {
+		const directory = path.resolve(import.meta.dirname, '../Socket')
+		const covered = new Set(CASES.flatMap(entry => (entry.source ? [entry.source] : [])))
+		const found: string[] = []
+
+		for (const file of (await readdir(directory)).filter(name => name.endsWith('.ts'))) {
+			const text = await readFile(path.join(directory, file), 'utf8')
+			for (const match of text.matchAll(CLOSED_DOMAIN_PARAMETER)) {
+				if (/^(?:const|let|var)\b/u.test(match[0]!)) continue
+				found.push(`${file}:${enclosingName(text, match.index)}:${match.groups!.parameter}`)
+			}
+		}
+
+		// A new method taking one of these lands here: give it a case above, or
+		// an EXEMPT entry saying why the value is safe to pass through.
+		const uncovered = [...new Set(found)].filter(key => !covered.has(key) && !(key in EXEMPT)).toSorted()
+		expect(uncovered).toEqual([])
+
+		const stale = [...covered].filter(key => !found.includes(key)).toSorted()
+		expect(stale).toEqual([])
+	})
+
+	describe('the accepted values match what the core deserializes', () => {
+		const valuesOf = (label: string): string[] =>
+			(CASES.find(entry => entry.label === label)!.values as string[]).toSorted()
+
+		for (const [label, union] of [
+			['groupParticipantsUpdate', 'GroupParticipantAction'],
+			['communityParticipantsUpdate', 'GroupParticipantAction'],
+			['groupRequestParticipantsUpdate', 'GroupRequestAction'],
+			['groupMemberAddMode', 'MemberAddMode'],
+			['updateBlockStatus', 'BlockAction'],
+			['sendPresence', 'PresenceStatus'],
+			['sendChatState', 'ChatState'],
+			['profilePictureUrl', 'PictureType']
+		] as const) {
+			it(`${label} accepts exactly the bridge's ${union}`, () => {
+				expect(valuesOf(label)).toEqual(bridgeUnion(union).toSorted())
+			})
+		}
+
+		it('the privacy wrappers stay inside the values the core knows', () => {
+			const known = new Set(bridgeUnion('PrivacyValue'))
+			const values = CASES.filter(entry => entry.parameter === 'value').flatMap(entry => entry.values as string[])
+			expect([...new Set(values)].filter(value => !known.has(value))).toEqual([])
+		})
+
+		it('the settings the group wrappers map onto are all bridge settings', () => {
+			const known = new Set(bridgeUnion('GroupSetting'))
+			expect(['locked', 'announce', 'membership_approval'].filter(setting => !known.has(setting))).toEqual([])
+		})
+
+		it('cleanDirtyBits stays inside the dirty types the core knows', () => {
+			const known = new Set(bridgeUnion('DirtyType'))
+			expect(valuesOf('cleanDirtyBits').filter(type => !known.has(type))).toEqual([])
+		})
+
+		it('every media type the bridge uploads is one waUploadToServer accepts', () => {
+			const accepted = new Set(valuesOf('waUploadToServer'))
+			expect(bridgeUnion('MediaType').filter(type => !accepted.has(type))).toEqual([])
+		})
+	})
+})

--- a/src/__tests__/closed-domain-arguments.test.ts
+++ b/src/__tests__/closed-domain-arguments.test.ts
@@ -79,6 +79,8 @@ interface DomainCase {
 	call: (sock: Socket, value: unknown) => Promise<unknown>
 	/** `file.ts:method:parameter`, as the source scan below spells it. */
 	source?: string
+	/** The parameter has a default, so omitting it is not passing a value. */
+	defaulted?: boolean
 }
 
 const CASES: DomainCase[] = [
@@ -213,7 +215,8 @@ const CASES: DomainCase[] = [
 		parameter: 'type',
 		values: ['preview', 'image'],
 		call: (sock, value) => sock.profilePictureUrl(USER, arg(value)),
-		source: 'contacts.ts:profilePictureUrl:type'
+		source: 'contacts.ts:profilePictureUrl:type',
+		defaulted: true
 	},
 	{
 		label: 'newsletterMetadata',
@@ -270,17 +273,46 @@ const EXEMPT: Record<string, string> = {
 	'groups.ts:<module>:setting': 'a value in the alias table, not a parameter',
 	'business.ts:minutesPastMidnight:which': 'a module-internal helper, called with a literal at both call sites',
 	'internals.ts:resyncAppState:collections': 'a no-op wrapper: nothing is forwarded to the bridge',
-	'server-queries.ts:createCallLink:_type': 'refused with a 501 whatever the value is'
+	'server-queries.ts:createCallLink:_type': 'refused with a 501 whatever the value is',
+	'internals.ts:upsertMessage:type': 'published on the event bus, so the value comes back to the caller unchanged'
 }
 
-/** `parameter: 'a' | 'b'`, or a parameter of a type that is one of those. */
-const CLOSED_DOMAIN_PARAMETER =
-	/(?:(?:const|let|var)\s+)?(?<parameter>[A-Za-z_$][\w$]*)\??:\s*(?:readonly )?\(?(?:(?:'[^']*'\s*\|\s*)+'[^']*'|(?:ParticipantAction|MediaType|MessageReceiptType|WAPresence|GroupSetting|WAPrivacyValue|WAPrivacyOnlineValue|WAPrivacyGroupAddValue|WAReadReceiptsValue|WAPrivacyCallValue|WAPrivacyMessagesValue)\b)/gu
+/** A type declared as a set of string literals, however it is spelled. */
+const CLOSED_DOMAIN_TYPE =
+	/type (?<name>[A-Za-z_$][\w$]*) =\s*(?:\(typeof [\w$]+\)\[number\]|keyof typeof [\w$]+|\|?\s*'[^']*'(?:\s*\|\s*'[^']*')+)/gu
+
+/** `parameter: 'a' | 'b'`, or a parameter typed by one of the above. */
+const ANNOTATED_PARAMETER =
+	/(?<declarator>(?:const|let|var)\s+)?(?<parameter>[A-Za-z_$][\w$]*)\??:\s*(?:readonly )?\(?(?<type>'[^']*'(?:\s*\|\s*'[^']*')+|[A-Za-z_$][\w$]*)/gu
+
+/**
+ * Every closed-domain type name in the package, so the scan follows a signature
+ * that names its domain instead of spelling it out. Resolved rather than
+ * listed: a list would go stale the first time one of them is renamed, which is
+ * the same failure the scan exists to prevent.
+ */
+const closedDomainTypeNames = async (): Promise<Set<string>> => {
+	const names = new Set<string>()
+	const visit = async (directory: string): Promise<void> => {
+		for (const entry of await readdir(directory, { withFileTypes: true })) {
+			if (entry.name === '__tests__' || entry.name === 'WAProto') continue
+			const full = path.join(directory, entry.name)
+			if (entry.isDirectory()) await visit(full)
+			else if (entry.name.endsWith('.ts')) {
+				for (const match of (await readFile(full, 'utf8')).matchAll(CLOSED_DOMAIN_TYPE)) {
+					names.add(match.groups!.name!)
+				}
+			}
+		}
+	}
+	await visit(path.resolve(import.meta.dirname, '..'))
+	return names
+}
 
 /** The method whose parameter list the match sits in. */
 const enclosingName = (text: string, index: number): string => {
 	const opener =
-		/(?:(?<assigned>[A-Za-z_$][\w$]*)\s*=\s*|(?<keyed>[A-Za-z_$][\w$]*)\s*:\s*)(?:async\s*)?(?:<[^<>]*>\s*)?\(/gu
+		/(?:(?<assigned>[A-Za-z_$][\w$]*)\s*=\s*|(?<keyed>[A-Za-z_$][\w$]*)\s*:\s*)(?:[\w$.]+\s*\(\s*)?(?:async\s*)?(?:<[^<>]*>\s*)?\(/gu
 	let name = '<module>'
 	for (const match of text.slice(0, index).matchAll(opener)) {
 		name = match.groups?.assigned ?? match.groups?.keyed ?? name
@@ -403,7 +435,11 @@ describe('a closed-domain argument is rejected before it reaches the bridge', { 
 		const probes: unknown[] = ['☠️', 'bogus', '']
 		const spelled = values.find(value => typeof value === 'string')!
 		if (spelled.toUpperCase() !== spelled) probes.push(spelled.toUpperCase())
-		if (!values.includes(undefined)) probes.push(undefined, null)
+		// `undefined` is a value only where the domain has it or the parameter
+		// has a default, and there it means "not passed" rather than a mistake.
+		// `null` never does: it is a value the caller chose.
+		if (!values.includes(undefined) && !testCase.defaulted) probes.push(undefined)
+		if (!values.includes(undefined)) probes.push(null)
 
 		it(`${label} rejects an off-domain ${parameter}`, async () => {
 			for (const probe of probes) {
@@ -430,13 +466,16 @@ describe('a closed-domain argument is rejected before it reaches the bridge', { 
 	it('every closed-domain parameter on the socket is covered or exempt', async () => {
 		const directory = path.resolve(import.meta.dirname, '../Socket')
 		const covered = new Set(CASES.flatMap(entry => (entry.source ? [entry.source] : [])))
+		const domainTypes = await closedDomainTypeNames()
 		const found: string[] = []
 
 		for (const file of (await readdir(directory)).filter(name => name.endsWith('.ts'))) {
 			const text = await readFile(path.join(directory, file), 'utf8')
-			for (const match of text.matchAll(CLOSED_DOMAIN_PARAMETER)) {
-				if (/^(?:const|let|var)\b/u.test(match[0]!)) continue
-				found.push(`${file}:${enclosingName(text, match.index)}:${match.groups!.parameter}`)
+			for (const match of text.matchAll(ANNOTATED_PARAMETER)) {
+				const { declarator, parameter, type } = match.groups!
+				if (declarator) continue
+				if (!type!.startsWith("'") && !domainTypes.has(type!)) continue
+				found.push(`${file}:${enclosingName(text, match.index)}:${parameter}`)
 			}
 		}
 

--- a/src/__tests__/newsletter-compatibility.test.ts
+++ b/src/__tests__/newsletter-compatibility.test.ts
@@ -84,8 +84,10 @@ describe('newsletterMetadata takes (type, key) and dispatches on the type', () =
 	it('an unknown key type rejects rather than being treated as a jid', async () => {
 		const { calls, methods } = makeHarness()
 
+		// Same refusal as before, now worded like every other off-domain
+		// argument: the parameter, what arrived, and what is accepted.
 		await expect(methods.newsletterMetadata('nope' as unknown as 'jid', 'whatever')).rejects.toThrow(
-			/unknown key type 'nope'/
+			/newsletterMetadata: "type" must be one of "invite", "jid", received "nope"/
 		)
 		expect(calls).toEqual([])
 	})


### PR DESCRIPTION
## Summary

A closed-domain argument that is outside its set now fails at the method that took it.

Before, `groupParticipantsUpdate(jid, [p], '☠️')` produced this, and nothing else:

```
WhatsAppError: invalid argument action: Error: unknown variant `☠️`,
expected one of `add`, `remove`, `promote`, `demote`, `modify`
    at __wbg_new_… (@oxidezap/whatsapp-rust-bridge/dist/index.js:1:44819)
    at wasm://wasm/014b740e:wasm-function[10421]:0x49a20a
    at wasm://wasm/014b740e:wasm-function[3292]:0x3ee8fa
    …
```

Now:

```
Error: groupParticipantsUpdate: "action" must be one of "add", "remove", "promote", "demote", "modify", received "☠️"
    at Object.groupParticipantsUpdate (src/Socket/groups.ts:142:4)
    at Timeout._onTimeout (bot.js:9:4)
```

It is a `Boom(400)` carrying `data: { parameter, value, accepted }`, so the reason is readable by a
human and branchable by code. Thirty arguments across the socket surface report this way: nine used
to fail inside the bridge with a wasm-only stack, thirteen used to not fail at all, and three failed
with a message about something else.

## Reproduction

`src/__tests__/closed-domain-arguments.test.ts`, committed failing first (91defe4). It drives the
real public socket against a port nothing listens on, so a value that passes validation fails
downstream as "not connected" rather than reaching a server: rejected-by-us and not-rejected-by-us
stay distinguishable. The headline test makes the call the way the report did, inside a `setTimeout`
with no `await` and no `.catch`.

Red, 26 of 65 failing:

```
✖ the reported call rejects with the call site in the stack
  AssertionError: the rejection has to name the method, the parameter, what arrived and
  every accepted value, and these are missing.
  invalid argument action: Error: unknown variant `☠️`, expected one of `add`, `remove`, `promote`, `demote`, `modify`
  WhatsAppError: invalid argument action: Error: unknown variant `☠️`, expected one of `add`, …
      at __wbg_new_b667d279fd5aa943 (node_modules/@oxidezap/whatsapp-rust-bridge/dist/index.js:1:44819)
      at wasm://wasm/014b740e:wasm-function[10421]:0x49a20a
      at wasm://wasm/014b740e:wasm-function[3292]:0x3ee8fa
      at wasm://wasm/014b740e:wasm-function[11674]:0x4b8057
      at $R (node_modules/@oxidezap/whatsapp-rust-bridge/dist/index.js:1:51189)
      at K (node_modules/@oxidezap/whatsapp-rust-bridge/dist/index.js:2:1004)
      at node:internal/process/task_queues:149:7
  + actual - expected
  + [ 'groupParticipantsUpdate', '"action"', '"☠️"', '"add"', '"remove"', '"promote"', '"demote"', '"modify"' ]
  - []

# tests 65
# pass 39
# fail 26
```

Green after 8399e33, with the stack pointing at the timer callback that made the call:

```
Error: groupParticipantsUpdate: "action" must be one of "add", "remove", "promote", "demote", "modify", received "☠️"
    at Object.groupParticipantsUpdate (file:///…/src/Socket/groups.ts:142:4)
    at Timeout._onTimeout (file:///…/probe.ts:9:4)
    at listOnTimeout (node:internal/timers:585:17)
statusCode 400
data {"parameter":"action","value":"☠️","accepted":["add","remove","promote","demote","modify"]}

# tests 75
# pass 75
# fail 0
```

The three failure shapes the red run recorded, which is what these arguments looked like before:

| shape | arguments |
| --- | --- |
| a wasm rejection with no JS frame | `groupParticipantsUpdate`, `communityParticipantsUpdate`, `groupRequestParticipantsUpdate`, `groupMemberAddMode`, `updateBlockStatus`, `sendPresence`, `sendChatState`, `sendPresenceUpdate`, `profilePictureUrl` |
| no failure at all, the value went to the server or nowhere | `groupJoinApprovalMode` (anything but `'on'` meant off), the eight privacy wrappers (the typo went on the wire), `cleanDirtyBits` (same), `sendReceipt` / `sendReceipts` (debug line, then resolve), `downloadMediaMessage` (a stream where a buffer was asked for) |
| a message about something else | `groupSettingUpdate` ("Cannot read properties of undefined"), `waUploadToServer` (named no parameter), `newsletterMetadata` (listed no accepted values) |

## Root cause

The value crossed the bridge boundary unchecked. The core rejects it correctly, and the bridge turns
that into a proper rejection naming the field, but the `Error` is constructed inside wasm: the frames
it captures are the wasm ones plus the shim, and none of them belong to the caller.

V8 does stitch async frames onto an awaiting caller, so a consumer doing `await sock.…()` would at
least see its own function. The reported call was made from a `setTimeout` with no `await` and no
`.catch`, which is the common shape for fire-and-forget bot commands. There is no awaiting frame, so
the rejection carries nothing but wasm addresses.

That is why the check has to run in the **synchronous prefix** of the public method, ahead of the
first `await`: the `Error` is then constructed on the caller's own stack. A check placed after
`await ctx.getClient()` would produce a better message and the same useless stack.

## Not a regression

This case never worked. Upstream Baileys uses `action` as the **tag name** of the node it sends:

```js
const result = await groupQuery(jid, 'set', [{ tag: action, attrs: {}, content: … }])
const node = getBinaryNodeChild(result, action)
const participantsAffected = getBinaryNodeChildren(node, 'participant')
return participantsAffected.map(…)
```

With `'☠️'` that builds `<☠️>` on the wire, the server answers with no node of that name,
`getBinaryNodeChild` returns `undefined`, `getBinaryNodeChildren(undefined, 'participant')` returns
`[]`, and the call **resolves with an empty array**. The participant was never removed and nothing
said so. baileyrs did not introduce the defect; it made a latent one visible, badly.

Worth noting for anyone auditing their own bot: `'modify'` is a real value here. The core takes
`add | remove | promote | demote | modify`, one more than the classic upstream `ParticipantAction`,
and the tests below pin our set to the bridge's.

## Scope

Every closed-domain argument on the socket surface, from a source scan rather than a search by name.

| file | method | parameter | domain | covered |
| --- | --- | --- | --- | --- |
| `Socket/groups.ts` | `groupParticipantsUpdate` | `action` | `ParticipantAction` | yes |
| `Socket/groups.ts` | `groupRequestParticipantsUpdate` | `action` | `GroupRequestAction` | yes |
| `Socket/groups.ts` | `groupSettingUpdate` | `setting` | keys of the alias table | yes |
| `Socket/groups.ts` | `groupMemberAddMode` | `mode` | `MemberAddMode` | yes |
| `Socket/groups.ts` | `groupJoinApprovalMode` | `mode` | `JoinApprovalMode` | yes |
| `Socket/communities.ts` | `communityParticipantsUpdate` | `action` | `ParticipantAction` | yes |
| `Socket/communities.ts` | `communityRequestParticipantsUpdate` | `action` | `GroupRequestAction` | yes |
| `Socket/communities.ts` | `communitySettingUpdate` | `setting` | keys of the alias table | yes |
| `Socket/communities.ts` | `communityMemberAddMode` | `mode` | `MemberAddMode` | yes |
| `Socket/communities.ts` | `communityJoinApprovalMode` | `mode` | `JoinApprovalMode` | yes |
| `Socket/privacy.ts` | `updateLastSeenPrivacy` | `value` | `WAPrivacyValue` | yes |
| `Socket/privacy.ts` | `updateProfilePicturePrivacy` | `value` | `WAPrivacyValue` | yes |
| `Socket/privacy.ts` | `updateStatusPrivacy` | `value` | `WAPrivacyValue` | yes |
| `Socket/privacy.ts` | `updateOnlinePrivacy` | `value` | `WAPrivacyOnlineValue` | yes |
| `Socket/privacy.ts` | `updateReadReceiptsPrivacy` | `value` | `WAReadReceiptsValue` | yes |
| `Socket/privacy.ts` | `updateGroupsAddPrivacy` | `value` | `WAPrivacyGroupAddValue` | yes |
| `Socket/privacy.ts` | `updateCallPrivacy` | `value` | `WAPrivacyCallValue` | yes |
| `Socket/privacy.ts` | `updateMessagesPrivacy` | `value` | `WAPrivacyMessagesValue` | yes |
| `Socket/blocking.ts` | `updateBlockStatus` | `action` | `BlockAction` | yes |
| `Socket/presence.ts` | `sendPresence` | `status` | `WAPresenceStatus` | yes |
| `Socket/presence.ts` | `sendChatState` | `state` | `WAChatState` | yes |
| `Socket/contacts.ts` | `profilePictureUrl` | `type` | `ProfilePictureType` | yes |
| `Socket/newsletter.ts` | `newsletterMetadata` | `type` | `NewsletterKeyType` | yes (message unified) |
| `Socket/server-queries.ts` | `cleanDirtyBits` | `type` | `DirtyBitType` | yes |
| `Socket/index.ts` | `sendPresenceUpdate` | `type` | `WAPresence` | yes |
| `Socket/index.ts` | `waUploadToServer` | `opts.mediaType` | `MediaType` | yes |
| `Socket/index.ts` | `downloadMedia` | `type` | `MediaDownloadType` | yes |
| `Socket/messages.ts` | `sendReceipt` | `type` | `MessageReceiptType` | yes |
| `Socket/messages.ts` | `sendReceipts` | `type` | `MessageReceiptType` | yes |
| `Utils/messages.ts` | `downloadMediaMessage` | `type` | `MediaDownloadType` | yes |

The community methods that are the group operation check under their own names before delegating, so
a refusal never points at a method the consumer did not call; same for `downloadMedia`, which checks
before awaiting the client and then delegates to `downloadMediaMessage`, itself an exported entry
point with its own check.

The scan also found four that are deliberately not validated, each recorded with its reason in the
test's `EXEMPT` table:

| where | why not |
| --- | --- |
| `internals.ts:resyncAppState:collections` | a no-op wrapper, nothing is forwarded |
| `server-queries.ts:createCallLink:_type` | refused with a 501 whatever the value is |
| `internals.ts:upsertMessage:type` | published on the event bus, the value comes back to the caller unchanged |
| `business.ts:minutesPastMidnight:which` | module-internal helper, called with a literal at both call sites |

`updatePrivacySetting(category, value)` stays open on purpose and is documented as such: both halves
are `string` at the bridge and the core's wire enums carry a fallback, so it is the escape hatch for
a category the eight wrappers do not name yet.

## Design

**One check, called at each boundary.** `assertArgumentDomain(method, parameter, value, domain)` in
`src/Utils/argument-domain.ts` is the only place that builds this error. It is called from the
synchronous prefix of each method rather than from a wrapper around the socket, because that is the
only position that captures the caller's frame, and because a `Proxy` over the socket would sit on
the hot path of every property read for the sake of thirty arguments.

**The values are the definition, not a copy of it.** Each domain is the array its type is derived
from:

```ts
export const PARTICIPANT_ACTIONS = ['add', 'remove', 'promote', 'demote', 'modify'] as const
export type ParticipantAction = (typeof PARTICIPANT_ACTIONS)[number]
```

Same for the privacy values, presence, chat states and receipt types. `MediaType` already derived
from `MEDIA_HKDF_KEY_MAPPING`, so its domain is `Object.keys` of that map; `GroupSetting` now derives
from the alias table the method dispatches through, so the accepted set and the mapping cannot
disagree. No domain is written down twice.

**When the core changes.** The risk of a check here is refusing a value the core has started
accepting, which would be worse than the bug. Three things guard it:

- the tests compare each domain against the bridge's own `.d.ts` unions, exactly, for
  `GroupParticipantAction`, `GroupRequestAction`, `MemberAddMode`, `BlockAction`, `PresenceStatus`,
  `ChatState` and `PictureType`; a bridge bump that adds a variant fails CI here first
- where our set is deliberately narrower (the per-category privacy values and the dirty-bit types,
  whose bridge types carry a `| string` fallback), the tests assert ours is a subset of what the core
  knows, so the narrowing stays intentional
- for media, every type the bridge uploads must be one `waUploadToServer` accepts

**Not forgetting the next one.** A source scan resolves every closed-domain type in the package
(literal unions, `(typeof X)[number]`, `keyof typeof X`) and then requires every socket parameter
typed by one of them to be either in the test table or in `EXEMPT` with a reason. A method added
later with an off-domain argument fails that test rather than shipping unchecked.

Nothing coerces or falls back. `'REMOVE'` is refused rather than lowercased, `null` and `''` are
refused, and an omitted optional argument still takes its default (`profilePictureUrl(jid)` is
`'preview'`); `undefined` is accepted only where the domain contains it, which is how upstream spells
a delivery receipt in `MessageReceiptType`.

## Validation

```
npm run format      # clean
npm run lint        # tsc + oxlint, clean
npm test            # 984 tests, 984 pass, 0 fail
npm run compat:audit
```

`compat:audit` reports **97.92% (21896/22361)**, identical to the score on the unmodified tree: the
public signatures did not change, only what they refuse.

Every guard site was reverted one at a time, with the suite re-run after each: all of them fail a
test when removed, none is dead code. Reverting the single line in `groupParticipantsUpdate` fails
`the reported call rejects with the call site in the stack` and `groupParticipantsUpdate rejects an
off-domain action`; reverting the whole change is the red commit above, at 26 failures.

`npm run test:e2e` was not run locally (it needs the mock server); CI runs it and it is green.

One existing test changed. `newsletter-compatibility` asserted the wording of the bespoke check
`newsletterMetadata` already had (`unknown key type 'nope'`), which is now the shared message; the
assertion still pins that the call is refused rather than treated as a jid, and now also that the
accepted values are listed.