### PR TITLE
fix(deps): bump @oxidezap/whatsapp-rust-bridge to 0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.7.0",
+        "@oxidezap/whatsapp-rust-bridge": "0.7.1",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.7.0.tgz",
-      "integrity": "sha512-RD8Ueg+xf2MAIUoYz+rlkHvWyOOEqvafEH6nh7xARq6JvGOcWBYy9xxDwRy03HWP9lVeIYUPeY5lqRYaTH9W6g==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.7.1.tgz",
+      "integrity": "sha512-FYcwASL56G7vadQ6QXD5kBr7pdjE7aN1gOATHtKgeUIscWcCQ76SN+F3A3UNSrm7lHON3FyQOBPgwNBqFPZYFg==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@oxidezap/whatsapp-rust-bridge": "0.7.0",
+    "@oxidezap/whatsapp-rust-bridge": "0.7.1",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"


### PR DESCRIPTION
## Summary

Bumps the bridge from 0.7.0 to [0.7.1](https://github.com/oxidezap/whatsapp-rust-bridge/releases/tag/v0.7.1), which carries a single fix: [whatsapp-rust-bridge#34](https://github.com/oxidezap/whatsapp-rust-bridge/pull/34), `fix(errors): report a dropped connection as not-connected, not internal`.

## What changes for a consumer

A send that landed in a disconnect window came back as `kind: 'internal'`. The two kinds say opposite things to a host: `internal` means the bridge broke and there is nothing to be done, `not-connected` means reconnect and try again. So a transient drop, the most ordinary failure a long-running bot has, read as fatal, and hosts that branch on the kind gave up on a send that only needed a retry.

The sweep behind the fix moves 39 of the 48 source-less core error variants off the `internal` fallback onto the kind that actually describes them, `InternalChannelClosed` included: a closed channel is a mechanism, reconnecting is the remedy, and the kind names the remedy.

`not-connected` keeps the meaning it already had. Only which errors reach it changed, so a host already handling that kind needs no changes.

## Why nothing on this side needed adapting

- No baileyrs code branches on a bridge error kind. `grep` over `src` for `not-connected` and `'internal'` outside tests returns nothing, and the `.kind` reads that do exist belong to the message-relay plan and the legacy-store route catalog, neither of which is a bridge error.
- The declarations are byte identical between the two versions apart from six generated `__wasm_bindgen_func_elem_*` function-table indices. No signature, union, interface or type changed:

```
$ diff 0.7.0/whatsapp_rust_bridge.d.ts 0.7.1/whatsapp_rust_bridge.d.ts
4583,4588c4583,4588
<     readonly __wasm_bindgen_func_elem_4243: (a: number, b: number, c: number) => void;
...
>     readonly __wasm_bindgen_func_elem_4245: (a: number, b: number, c: number) => void;
```

## Validation

```
npm run lint          # tsc + oxlint, clean
npm run format:check  # clean
npm test              # 985 tests, 985 pass, 0 fail
npm run compat:audit  # 97.92% (21896/22361), unchanged
```

The suite is not blind to the bump. `bridge-argument-rejection` drives a real 0.7.1 client in a child process and still gets `invalid-argument` naming each parameter; the `.d.ts` drift tests compare `KNOWN_BRIDGE_EVENT_TYPES` and every closed-domain set against the new declarations, so a changed event variant or enum member would have failed here.

`npm run test:e2e` was not run locally, since it needs the mock server; CI runs it.

---
_Generated by [Claude Code](https://claude.ai/code/session_013RoCgwYZfbgmzFBYy68rHm)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `@oxidezap/whatsapp-rust-bridge` to 0.7.1 to fix disconnect error classification. Sends during a transient drop now return 'not-connected' (retry) instead of 'internal' (fatal), so retries happen correctly without app changes.

<sup>Written for commit bcbaee9f91b0eae60cff9f5efc0e8a4f57ce0f78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WhatsApp integration dependency to version 0.7.1 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->