### PR TITLE
docs(readme): say that connecting can last minutes under engine backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,19 +246,19 @@ Here is what that costs on a rate-limited account. Four consecutive
 | `429` #3 | 813.9s | 968.5s |
 | `429` #4 | 903.5s | 1872.0s |
 
-About 16 minutes offline by the third failure, and about 31 by the fourth. For
-all of it the consumer sees exactly **one** `connection: 'connecting'`: no
-`lastDisconnect`, no status code, no repeat. `isConnected` and `isLoggedIn` are
-both `false` throughout, exactly as they are during a first connection, so
-neither tells you a retry is scheduled.
+About 16 minutes offline once the third retry delay has run, and about 31 once
+the fourth has. For all of it the consumer sees exactly **one**
+`connection: 'connecting'`: no `lastDisconnect`, no status code, no repeat.
+`isConnected` and `isLoggedIn` are both `false` throughout, exactly as they are
+during a first connection, so neither tells you a retry is scheduled.
 
 **Do not arm a readiness timeout on `connecting`, and above all do not restart
 the process when one expires.** The backoff counter lives in the Rust client
-that your socket owns, so it dies with the process. The next boot connects
-immediately, replays the whole startup burst against a server that just asked
-for less traffic, and earns the next `429` sooner. Restarting is the single
-worst answer to a rate limit, and an upstream-shaped readiness timeout leads
-straight to it.
+that your socket owns, so it dies with the process. The next boot starts a new
+attempt immediately, replays the whole startup burst against a server that just
+asked for less traffic, and earns the next `429` sooner. Restarting is the
+single worst answer to a rate limit, and an upstream-shaped readiness timeout
+leads straight to it.
 
 What to do instead:
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ A few behaviors that differ from upstream — almost always to your advantage:
   | anything else | reconnect, after a short delay |
 
   `Example/example.ts` implements exactly this.
+- **`connecting` is not a short state here.** The engine's backoff grows with
+  each consecutive failure, so a single `connecting` can stand for minutes of
+  downtime with nothing else emitted in between. See
+  [When `connecting` lasts minutes](#when-connecting-lasts-minutes): a
+  readiness timeout written for upstream's `connecting` misreads this one.
 - **No `getMessage` / `cachedGroupMetadata` polyfill required.** The Rust
   side caches group metadata and message keys natively. You can still pass
   them — they're respected as overrides — but they're optional.
@@ -223,6 +228,53 @@ A few behaviors that differ from upstream — almost always to your advantage:
 - **Your key store also holds bridge state, so "empty" is not "unpaired".**
   See [Bridge state in your key store](#bridge-state-in-your-key-store) — this
   one can break a boot path, so it has its own section.
+
+### When `connecting` lasts minutes
+
+Upstream Baileys emits `connecting` once per socket, and it resolves to `open`
+or `close` within seconds, because upstream never retries on its own. On
+baileyrs the same value also covers every drop the engine is retrying, and the
+backoff between those retries climbs with each consecutive failure.
+
+Here is what that costs on a rate-limited account. Three `429 rate-overlimit`
+in a row, measured against the production reconnect path:
+
+| failure | next attempt in | offline so far |
+| --- | --- | --- |
+| `429` #1 | 8.4s | 8.4s |
+| `429` #2 | 146.2s | 154.6s |
+| `429` #3 | 813.9s | 968.5s |
+| `429` #4 | 903.5s | 1872.0s |
+
+About 16 minutes offline after the third one. For all 16 of those minutes the
+consumer sees exactly **one** `connection: 'connecting'`: no `lastDisconnect`,
+no status code, no repeat. `isConnected` and `isLoggedIn` are both `false`
+throughout, exactly as they are during a first connection, so neither tells you
+a retry is scheduled.
+
+**Do not arm a readiness timeout on `connecting`, and above all do not restart
+the process when one expires.** The backoff counter lives in the Rust client
+that your socket owns, so it dies with the process. The next boot connects
+immediately, replays the whole startup burst against a server that just asked
+for less traffic, and earns the next `429` sooner. Restarting is the single
+worst answer to a rate limit, and an upstream-shaped readiness timeout leads
+straight to it.
+
+What to do instead:
+
+- Treat `open` and `close` as the only decision points. `connecting` carries no
+  failure to react to, and it is never a reason to build a second socket. Only
+  `close` is.
+- Read `connecting` in context: after an `open` it means the engine is retrying
+  a drop it owns and will keep retrying; with no `open` before it, it is a first
+  connection still being established. Neither one is stuck.
+- If you need a liveness watchdog anyway, budget it well past the ladder above,
+  tens of minutes rather than seconds, and have it alert a human instead of
+  killing the process. A shorter one fires on a backoff that was about to
+  succeed.
+- Fix the cause on your side: send less. The engine restores the connection,
+  but it does not pace your traffic, and the traffic is what earned the `429`.
+  Queueing, throttling and deferral are yours to decide, the same as upstream.
 
 ### Bridge state in your key store
 

--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ or `close` within seconds, because upstream never retries on its own. On
 baileyrs the same value also covers every drop the engine is retrying, and the
 backoff between those retries climbs with each consecutive failure.
 
-Here is what that costs on a rate-limited account. Three `429 rate-overlimit`
-in a row, measured against the production reconnect path:
+Here is what that costs on a rate-limited account. Four consecutive
+`429 rate-overlimit`, measured against the production reconnect path:
 
 | failure | next attempt in | offline so far |
 | --- | --- | --- |
@@ -246,11 +246,11 @@ in a row, measured against the production reconnect path:
 | `429` #3 | 813.9s | 968.5s |
 | `429` #4 | 903.5s | 1872.0s |
 
-About 16 minutes offline after the third one. For all 16 of those minutes the
-consumer sees exactly **one** `connection: 'connecting'`: no `lastDisconnect`,
-no status code, no repeat. `isConnected` and `isLoggedIn` are both `false`
-throughout, exactly as they are during a first connection, so neither tells you
-a retry is scheduled.
+About 16 minutes offline by the third failure, and about 31 by the fourth. For
+all of it the consumer sees exactly **one** `connection: 'connecting'`: no
+`lastDisconnect`, no status code, no repeat. `isConnected` and `isLoggedIn` are
+both `false` throughout, exactly as they are during a first connection, so
+neither tells you a retry is scheduled.
 
 **Do not arm a readiness timeout on `connecting`, and above all do not restart
 the process when one expires.** The backoff counter lives in the Rust client


### PR DESCRIPTION
## Summary

The gotchas table already promised the shape of the contract: `close` means the socket is finished, transient drops surface as `connecting`. It never said how long `connecting` can hold. Under the engine's backoff the answer is minutes, and nothing is emitted while it runs, so a consumer has no way to tell "the engine is retrying" from "this hung".

New section, `When connecting lasts minutes`, plus a gotchas bullet pointing at it. It states three things a consumer could not learn from the current docs:

- `connecting` on this socket also covers every retry the engine owns, and the gap between retries grows with each consecutive failure. Upstream emits `connecting` once per socket and resolves it within seconds, because upstream never retries.
- During the backoff there is exactly one `connection.update`, with no `lastDisconnect` and no status code, and `isConnected` / `isLoggedIn` are both `false`, the same as during a first connection. So neither the event stream nor the getters distinguish a scheduled retry from a fresh socket.
- Restarting the process is the worst available response, and says what to key off instead: `open` and `close` as the only decision points, `open` then `connecting` as "the engine owns this drop", a liveness watchdog budgeted past the ladder and wired to alert rather than kill.

## The incident

Two bots stuck in recurring `429 rate-overlimit`. The reconnect ladder, measured against the production path:

| failure | next attempt in | offline so far |
| --- | --- | --- |
| `429` #1 | 8.4s | 8.4s |
| `429` #2 | 146.2s | 154.6s |
| `429` #3 | 813.9s | 968.5s |
| `429` #4 | 903.5s | 1872.0s |

Roughly 16 minutes offline once the third retry delay has run, about 31 once the fourth has, all of it behind a single `connection: 'connecting'`.

Restarting makes it worse because the backoff counter lives in the Rust client the socket owns. It dies with the process, so the next boot starts a new attempt immediately, replays the whole startup burst against a server that just asked for less traffic, and earns the next `429` sooner. The consumer's readiness timeout is what produced the restart, and the timeout was written against an upstream where `connecting` means "seconds away from open".

## Scope

Documentation only. The two code options were considered and dropped:

- **A reading of the engine's reconnect state.** The bridge does not have one. On `0.7.1`, the version this repo consumes, `WasmWhatsAppClient` exposes `isConnected`, `isLoggedIn`, `setAutoReconnect`, `reconnect` and `waitForConnected`. Nothing reports a scheduled attempt, an attempt count, or a delay. Any getter added here would have to keep its own shadow copy of a schedule the core owns, which would be wrong the moment the core's ladder changes.
- **A field on the `connecting` update.** Nothing arrives to put in it. The bridge's `WhatsAppEvent` union types `disconnected` as `data: Record<string, never>`, there is no rate-limit or backoff variant, and the core's `429` branch dispatches nothing. Checked that this repo is not discarding something on the way through: the `disconnected` dispatcher in `src/Socket/events.ts` ignores its payload, but the payload is empty at this bridge version. There is no event to translate.

What is left is a consumer taking the wrong decision for lack of information, and a paragraph fixes that. A getter nobody needs would not have.

Deliberately untouched: when `connecting` is emitted (`src/Socket/events.ts`, `emitRetrying`), the backoff ladder itself (core), and any client-side rate-limit policy such as queueing or throttling. The last one is named in the docs as the consumer's call, which is also where upstream leaves it.

## Upstream

Upstream ends the socket on any `<stream:error>`, `429` included: `socket.ts` `CB:stream:error` calls `end()` with the code parsed straight off the node's `code` attribute, so the consumer gets `connection: 'close'` with `statusCode: 429` and reconnects on its own schedule. `connecting` is emitted once, at socket construction, and resolves to `open` or `close` in seconds.

So the migration divergence is real and one-directional: the same failure that upstream reports as a `close` you act on, baileyrs reports as a `connecting` you must not act on, and it lasts three orders of magnitude longer. On upstream a process restart also costs nothing, because there is no accumulated penalty anywhere to lose. That assumption travels with the ported handler and is exactly what this section exists to break.

## Depends on

Nothing. There is an open investigation in the core about whether a `429` should produce an observable event; that repository is not present in this environment, and this change does not wait on it. If it lands, the third option above becomes available on its own merits, and the section here is what a new field would be documented against rather than something that has to be rewritten.

## Validation

```
npm run format
npm run lint
npm test          # 985 pass, 0 fail
npm run compat:audit
```

No test added, and none adapted. No behavior changed, so there is no central line to revert and no assertion that could fail on one. The existing `connecting` and auto-reconnect tests, including `still reports connecting while auto-reconnect is on`, pass untouched. The audit is unchanged from baseline (exports 85.78%, functions 97.10%, fields 98.66%, events 100.00%): no public surface was added.