### PR TITLE
fix(deps): bump @oxidezap/whatsapp-rust-bridge to 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.7.1",
+        "@oxidezap/whatsapp-rust-bridge": "0.7.2",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.7.1.tgz",
-      "integrity": "sha512-FYcwASL56G7vadQ6QXD5kBr7pdjE7aN1gOATHtKgeUIscWcCQ76SN+F3A3UNSrm7lHON3FyQOBPgwNBqFPZYFg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.7.2.tgz",
+      "integrity": "sha512-XeBOge5vl2OnafW1Is/TLoReUPzZrC1lkT7mTnp5IKJWR7x3jI36FbtHeRpGE1dm0bVmto94k5EUR5BfRQRUgw==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@oxidezap/whatsapp-rust-bridge": "0.7.1",
+    "@oxidezap/whatsapp-rust-bridge": "0.7.2",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"


### PR DESCRIPTION
## Summary

Bumps `@oxidezap/whatsapp-rust-bridge` from `0.7.1` to `0.7.2`. Pin stays exact, matching how this dependency was already pinned (the other four use caret; this one does not, and that looks deliberate).

No source change was needed.

## What comes with it

The bridge release itself lists one fix, but it also carries a core bump underneath:

- **`fix(codegen)`** — the generated TypeScript no longer emits `Cow<string>`. A consumer type-checking the bridge's published declarations without `skipLibCheck` was getting `TS2304: Cannot find name 'Cow'`.
- **A `<stream:error code="429">` now dispatches `StreamError`** in the core. Until then the 429 branch adjusted internal state and dispatched nothing, so a rate-limited client was indistinguishable from a disconnected one.
- **Per-`<enc>` decrypt failure reporting** in the core, behind a lease. Not exposed by the bridge (neither is its pair, `DecryptedPayload`), so nothing changes here.

## The 429 event reaches this layer and stops here

Worth stating plainly, because the bump makes it possible without making it work:

`src/Socket/events.ts:422` handles `streamError` by logging a warning and nothing else, and its message reads `stream error; the connection is preserved`. That was accurate for every code that used to arrive there — unknown codes, an owed `<ack/>`, `<xml-not-well-formed>` — all of which keep or deliberately recycle the connection.

**It is not accurate for 429.** That one drops the connection and reconnects on a backoff that reaches ~15 minutes after three of them. So a consumer still sees only `connecting`, and the one signal that could tell it otherwise now arrives and is swallowed.

Out of scope for a dependency bump. There is a prompt covering it: `agent_prompts/compat-connecting-can-last-minutes.md` — and it can now be narrowed, since the event exists rather than needing to be invented.

## Validation

```
npm run lint            clean (tsc + oxlint)
npm run format:check    clean
npm test                985 pass, 0 fail
npm run compat:audit    97.92% (21896/22361) — unchanged
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@oxidezap/whatsapp-rust-bridge` from 0.7.1 to 0.7.2 to pull in a TS codegen fix and a new 429 stream error event. No source changes.

- **Dependencies**
  - Codegen: published types no longer reference `Cow<string>` (avoids TS2304 without `skipLibCheck`).
  - Core: 429 stream errors now emit `StreamError`; we currently only log it, so behavior is unchanged.

<sup>Written for commit 4700962b19350ea258776a8e575e0401375593a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

