### PR TITLE
fix(history): return undefined when there is no history sync notification

### DIFF
--- a/src/Utils/process-history-message.ts
+++ b/src/Utils/process-history-message.ts
@@ -16,7 +16,6 @@ import { proto } from '../WAProto/runtime.ts'
 import type { Chat, Contact, LIDMapping, WAMessage } from '../Types/index.ts'
 import { WAProto } from '../Types/index.ts'
 import { isHostedLidUser, isHostedPnUser, isLidUser, isPnUser } from '../WABinary/jid-utils.ts'
-import { Boom } from './boom.ts'
 import { toNumber } from './generics.ts'
 import type { ILogger } from './logger.ts'
 import { downloadContentFromMessage, normalizeMessageContent } from './messages.ts'
@@ -234,12 +233,17 @@ export const downloadAndProcessHistorySyncNotification = async (
 	return processHistoryMessage(historyMsg, logger)
 }
 
-/** Extract a history-sync notification through the same wrapper normalization as upstream. */
-export const getHistoryMsg = (message: proto.IMessage): proto.Message.IHistorySyncNotification => {
+/**
+ * Extract a history-sync notification through the same wrapper normalization as
+ * upstream.
+ *
+ * Returns `undefined` when the message carries none. It used to throw a Boom
+ * 400, which breaks the shape every caller writes against a drop-in API —
+ * `const h = getHistoryMsg(msg); if (!h) return` crashed instead of returning.
+ * "Absent" is the ordinary case here, not an error: any message that is not a
+ * history sync takes this path.
+ */
+export const getHistoryMsg = (message: proto.IMessage): proto.Message.IHistorySyncNotification | undefined => {
 	const normalizedContent = message ? normalizeMessageContent(message) : undefined
-	const historySyncNotification = normalizedContent?.protocolMessage?.historySyncNotification
-	if (!historySyncNotification) {
-		throw new Boom('Message does not contain a history sync notification', { statusCode: 400 })
-	}
-	return historySyncNotification
+	return normalizedContent?.protocolMessage?.historySyncNotification ?? undefined
 }

--- a/src/__fuzz__/harness/divergence.ts
+++ b/src/__fuzz__/harness/divergence.ts
@@ -960,25 +960,6 @@ export const KNOWN_DIVERGENCES: readonly KnownDivergence[] = [
 		review: '2026-11-01'
 	},
 	{
-		id: 'get-history-msg-throws-instead-of-undefined',
-		target: 'pure:getHistoryMsg',
-		status: 'open',
-		// The generator now emits valid history-sync notifications, so the entry has
-		// to say which half of that it covers: only the *missing* one. Read
-		// structurally rather than by searching the serialised input — a
-		// notification nested under `deviceSentMessage` appears in the text but is
-		// not where either helper looks, and both correctly ignore it.
-		when: divergence => {
-			if (!isThrow(divergence.local) || divergence.upstream !== undefined) return false
-			const message = Array.isArray(divergence.input) ? divergence.input[0] : undefined
-			const protocol = (message as { protocolMessage?: Record<string, unknown> } | undefined)?.protocolMessage
-			return protocol?.historySyncNotification === undefined
-		},
-		reason:
-			'Upstream returns `undefined` when the message carries no history-sync notification; baileyrs throws a Boom 400. Drop-in consumer code written as `const h = getHistoryMsg(msg); if (!h) return` therefore crashes against baileyrs. The fix is a signature change on a published API, so it belongs in its own commit rather than in the change that found it.',
-		review: '2026-11-01'
-	},
-	{
 		id: 'clean-message-empty-jid-normalisation',
 		target: /^pure:cleanMessage/u,
 		status: 'open',

--- a/src/__tests__/public-helpers-compatibility.test.ts
+++ b/src/__tests__/public-helpers-compatibility.test.ts
@@ -290,7 +290,11 @@ describe('public helper compatibility', () => {
 	it('extracts wrapped history notifications', () => {
 		const notification = { syncType: proto.HistorySync.HistorySyncType.RECENT }
 		assert.deepEqual(getHistoryMsg({ protocolMessage: { historySyncNotification: notification } }), notification)
-		assert.throws(() => getHistoryMsg({ conversation: 'not a history sync' }), /history sync notification/)
+		// Upstream returns undefined here. Throwing broke `const h = getHistoryMsg(m); if (!h) return`,
+		// which is the shape a drop-in caller writes.
+		assert.equal(getHistoryMsg({ conversation: 'not a history sync' }), undefined)
+		assert.equal(getHistoryMsg({}), undefined)
+		assert.equal(getHistoryMsg(undefined as never), undefined)
 	})
 
 	it('matches message-device inference and bulk receipt grouping', () => {


### PR DESCRIPTION
`getHistoryMsg` threw a `Boom` 400 for any message that is not a history sync — which is most messages.

That breaks the shape a drop-in caller writes:

```ts
const h = getHistoryMsg(msg)
if (!h) return   // never reached: the line above already threw
```

Upstream returns `undefined` here. Absent is the ordinary case for this helper, not an error condition: every message that is not a history sync takes that path.

## Change

Returns `undefined`, and the return type says `| undefined` so a caller who ignores it gets a type error rather than a runtime one. The `Boom` import is dropped along with the throw — it was the only use in the file.

The compatibility test asserted the throw; it now asserts the value, and covers two cases it did not before: a message with no content at all, and a missing argument.

```ts
assert.equal(getHistoryMsg({ conversation: 'not a history sync' }), undefined)
assert.equal(getHistoryMsg({}), undefined)
assert.equal(getHistoryMsg(undefined as never), undefined)
```

## Registry

`get-history-msg-throws-instead-of-undefined` is deleted. After the change the deep `pure:getHistoryMsg` target runs 5001 inputs with 0 findings and 0 excused, so the entry excuses nothing and an allowlist that outlives its divergence is how the same bug comes back. Open findings 22 → 21.

## Breaking change

Callers who relied on the throw to signal "not a history sync" — via `try`/`catch` — stop seeing it. That behaviour was the defect, and no caller inside this repository depended on it: `getHistoryMsg` has no internal call sites, only the export and its test.

## Validation

`tsc --noEmit`, `oxlint`, `oxfmt --check` clean. `npm test` 1182 pass / 0 fail. `npm run fuzz` 185 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvtvVVWQs8AeBqSzS1JpCg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvtvVVWQs8AeBqSzS1JpCg)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return `undefined` from `getHistoryMsg` when a message has no history-sync notification, matching upstream and preventing crashes in common code paths. This fixes the drop-in pattern where callers check for absence instead of handling exceptions.

- **Bug Fixes**
  - `getHistoryMsg` returns `undefined` instead of throwing for non-history messages.
  - Removed `Boom` usage and updated tests (added no-content and missing-arg cases).
  - Deleted the obsolete divergence registry entry.

- **Migration**
  - If you relied on an exception to signal “not a history sync,” replace try/catch with an `undefined` check.

<sup>Written for commit cb112099576c57d9807171fb130f1376ad0bea81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated history message handling to return no result for messages without history data instead of raising an error.
  * Preserved normalization for messages containing valid history notifications.

* **Tests**
  * Updated compatibility checks to cover missing, empty, and undefined message inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->