### PR TITLE
fix(event-buffer): let a contacts.upsert win over an update buffered before it

### DIFF
--- a/src/Utils/event-buffer.ts
+++ b/src/Utils/event-buffer.ts
@@ -225,12 +225,33 @@ const append = (
 		case 'contacts.upsert': {
 			for (const contact of eventData as Contact[]) {
 				const existing = data.contactUpserts[contact.id] || data.historySets.contacts[contact.id]
-				if (existing) Object.assign(existing, trimUndefined(contact))
-				else data.contactUpserts[contact.id] = contact
+				// A `contacts.update` already buffered for this id arrived *before*
+				// this upsert, so it is folded in first and the upsert's own values
+				// win where the two carry the same field. Folding it last — which is
+				// what this did — let a stale name overwrite the one that came after
+				// it, and the buffer released the older of the two. Fields only the
+				// update carried still survive, which upstream drops.
 				const pending = data.contactUpdates[contact.id]
-				if (pending) {
-					Object.assign(existing || contact, pending)
-					delete data.contactUpdates[contact.id]
+				if (pending) delete data.contactUpdates[contact.id]
+				if (existing) {
+					if (pending) Object.assign(existing, pending)
+					Object.assign(existing, trimUndefined(contact))
+				} else {
+					// Filling the gaps in `contact` rather than merging onto `pending`
+					// and storing that: `pending` was grown from `{}` by the update
+					// branch, and accumulating into it — or into a fresh literal —
+					// measured about twice the cost of writing into the contact the
+					// caller handed us, which arrives with a settled shape. An
+					// explicitly-`undefined` field counts as absent, which is what
+					// `trimUndefined` would decide and costs no second pass.
+					if (pending) {
+						const target = contact as unknown as Record<string, unknown>
+						const source = pending as Record<string, unknown>
+						for (const field in source) {
+							if (target[field] === undefined) target[field] = source[field]
+						}
+					}
+					data.contactUpserts[contact.id] = contact
 				}
 			}
 			break

--- a/src/__fuzz__/harness/__tests__/harness.test.ts
+++ b/src/__fuzz__/harness/__tests__/harness.test.ts
@@ -362,8 +362,20 @@ describe('fuzz harness — known-divergence allowlist', () => {
 		const group = (subject: string) => ({ released: 'groups.update', data: [{ id: 'g@g.us', subject }] })
 		const receipt = { released: 'message-receipt.update', data: [{ key: { id: 'B2' } }] }
 
-		assert.ok(excused([upsert('first')], [upsert('second')]), 'a pinned field may differ in value')
-		assert.ok(excused([group('second')], [group('first')]), 'the same, on the other kind')
+		// `subject` on a group is the one field whose *value* the two may disagree
+		// on, and only there. A contact's `name` was pinned the same way until the
+		// upsert fold was corrected; a value difference on one is a regression of
+		// that fix, so this entry must not absorb it.
+		assert.ok(excused([group('second')], [group('first')]), 'the pinned field may differ in value')
+		assert.ok(!excused([upsert('first')], [upsert('second')]), 'a contact name may not — the two agree on it now')
+		// What the contact half of the entry does document: a field only this side kept.
+		assert.ok(
+			excused(
+				[{ released: 'contacts.upsert', data: [{ id: 'a@s.whatsapp.net', name: 'x', notify: 'n' }] }],
+				[{ released: 'contacts.upsert', data: [{ id: 'a@s.whatsapp.net', name: 'x' }] }]
+			),
+			'a field upstream dropped folding an earlier update is what this entry is for'
+		)
 		// The shape the entry actually documents: upstream lost a field this side kept.
 		assert.ok(
 			excused(

--- a/src/__fuzz__/harness/divergence.ts
+++ b/src/__fuzz__/harness/divergence.ts
@@ -634,14 +634,19 @@ const MERGE_PRECEDENCE_KINDS: ReadonlySet<string> = new Set(['contacts.upsert', 
 /**
  * The fields whose *value* the two buffers are allowed to disagree on.
  *
- * Measured: `subject` on a group, `name` on a contact. Everything else about a
- * paired release has to match, so a consolidation that started emitting a wrong
- * `announce`, `id` or timestamp is reported rather than folded into this entry.
- * Pinning the field is the same treatment `KNOWN_OMITTED_FIELDS` and
- * `PRESENCE_DROPPED_FIELDS` get, and for the same reason: "some field differs"
- * is not a description of a defect.
+ * `subject` on a group, and nothing else. `name` on a contact was here until the
+ * `contacts.upsert` fold was corrected to apply a buffered update *before* the
+ * upsert that follows it; the two now agree on every value a contact carries and
+ * differ only by the fields upstream drops. Leaving `name` pinned would have
+ * meant the fuzzer excusing a regression of exactly that fix.
+ *
+ * Everything else about a paired release has to match, so a consolidation that
+ * started emitting a wrong `announce`, `id` or timestamp is reported rather than
+ * folded into this entry. Pinning the field is the same treatment
+ * `KNOWN_OMITTED_FIELDS` and `PRESENCE_DROPPED_FIELDS` get, and for the same
+ * reason: "some field differs" is not a description of a defect.
  */
-const MERGE_PRECEDENCE_VALUE_FIELDS: ReadonlySet<string> = new Set(['name', 'subject'])
+const MERGE_PRECEDENCE_VALUE_FIELDS: ReadonlySet<string> = new Set(['subject'])
 
 /**
  * True when `mine` is `theirs` plus fields, disagreeing only on the pinned ones.
@@ -1108,7 +1113,7 @@ export const KNOWN_DIVERGENCES: readonly KnownDivergence[] = [
 		// still fails.
 		when: divergence => mergePrecedenceFieldsOnly(divergence.local, divergence.upstream),
 		reason:
-			"The two buffers consolidate `groups.update` and `contacts.upsert` differently, and on both kinds it is upstream that loses data rather than the two picking different winners. On groups, upstream stores only the *first* update for an id and discards every later one: `src/Utils/event-buffer.ts` merges with `Object.assign(data.groupUpdates[id] || {}, update)` where upstream guards the whole assignment with `if (!data.groupUpdates[id])`, which makes its own merge unreachable. Measured by buffering each pair and flushing: two updates for the same id with subjects 'first' then 'second' release 'second' here and 'first' upstream; and with *disjoint* fields — a subject then an announce — this releases both while upstream releases only the subject and drops the announce outright. On contacts, a buffered `contacts.update` carrying a name is folded into a later `contacts.upsert` here and is not folded upstream, so the released upsert carries the name here and does not upstream. baileyrs is the accumulating side on both, which is what the surrounding branches do for chats and messages and what 'consolidate' means for a buffer; matching upstream would mean deliberately dropping updates a consumer sent. `chats.update` twice, a `groups.update` whose second event carries nothing but the id, and the four message-level consolidation branches all agree, measured at the same time — the id-only case agreeing because there is no field to merge, which is why the `announce` case above does not. Found only once the buffer generator started drawing ids from a shared pool: before that no two buffered events ever referred to the same entity, so none of this ran.",
+			"The two buffers consolidate `groups.update` and `contacts.upsert` differently, and on both kinds it is upstream that loses data rather than the two picking different winners. On groups, upstream stores only the *first* update for an id and discards every later one: `src/Utils/event-buffer.ts` merges with `Object.assign(data.groupUpdates[id] || {}, update)` where upstream guards the whole assignment with `if (!data.groupUpdates[id])`, which makes its own merge unreachable. Measured by buffering each pair and flushing: two updates for the same id with subjects 'first' then 'second' release 'second' here and 'first' upstream; and with *disjoint* fields — a subject then an announce — this releases both while upstream releases only the subject and drops the announce outright. On contacts, a `contacts.update` buffered before a `contacts.upsert` for the same id contributes the fields only *it* carried: measured with an update carrying `notify` and a later upsert carrying `name`, this releases both fields and upstream releases only `name`. The two agree on every field both carry — the upsert wins, because it arrived last — so this is an added-field difference and no longer a value one. baileyrs is the accumulating side on both, which is what the surrounding branches do for chats and messages and what 'consolidate' means for a buffer; matching upstream would mean deliberately dropping updates a consumer sent. `chats.update` twice, a `groups.update` whose second event carries nothing but the id, and the four message-level consolidation branches all agree, measured at the same time — the id-only case agreeing because there is no field to merge, which is why the `announce` case above does not. Found only once the buffer generator started drawing ids from a shared pool: before that no two buffered events ever referred to the same entity, so none of this ran.",
 		review: '2026-11-01'
 	},
 	{

--- a/src/__tests__/event-buffer-compatibility.test.ts
+++ b/src/__tests__/event-buffer-compatibility.test.ts
@@ -191,6 +191,57 @@ describe('event buffer — upstream process() contract', () => {
 	})
 
 	/**
+	 * A buffered `contacts.update` is older than an upsert that follows it.
+	 *
+	 * The fold used to apply the pending update *after* the incoming upsert, so a
+	 * name the consumer had already superseded won and the buffer released the
+	 * older of the two. Found by the buffer differential in deep mode, on a
+	 * sequence that folded the pair into a `messaging-history.set`. The fields
+	 * only the update carried still survive, which upstream drops — that half is
+	 * the documented divergence, and is asserted separately below.
+	 */
+	it('lets a contacts.upsert win over an update buffered before it', () => {
+		const ev = makeEventBuffer(logger)
+		const released: BaileysEventMap['contacts.upsert'] = []
+		ev.on('contacts.upsert', contacts => released.push(...contacts))
+
+		ev.buffer()
+		ev.emit('contacts.update', [{ id: 'c@s.whatsapp.net', name: 'older', notify: 'kept' }])
+		ev.emit('contacts.upsert', [{ id: 'c@s.whatsapp.net', name: 'newer' }])
+		ev.flush()
+
+		expect(released.length).toEqual(1)
+		// The upsert arrived last, so its value wins...
+		expect(released[0]?.name).toEqual('newer')
+		// ...and the field only the update carried is still there.
+		expect(released[0]?.notify).toEqual('kept')
+	})
+
+	/**
+	 * The same precedence once a history set owns the contact.
+	 *
+	 * A different code path: the update and the upsert both fold into the object
+	 * the history set holds, rather than into a pending upsert, and that object is
+	 * released inside `messaging-history.set` instead of `contacts.upsert`. This
+	 * is the shape the fuzzer actually minimised to.
+	 */
+	it('applies the same precedence when the contact lives in a buffered history set', () => {
+		const ev = makeEventBuffer(logger)
+		const sets: BaileysEventMap['messaging-history.set'][] = []
+		ev.on('messaging-history.set', set => sets.push(set))
+
+		ev.buffer()
+		ev.emit('contacts.update', [{ id: 'c@s.whatsapp.net', name: 'older', notify: 'kept' }])
+		ev.emit('messaging-history.set', { chats: [], contacts: [{ id: 'c@s.whatsapp.net' }], messages: [] } as never)
+		ev.emit('contacts.upsert', [{ id: 'c@s.whatsapp.net', name: 'newer' }])
+		ev.flush()
+
+		expect(sets[0]?.contacts?.length).toEqual(1)
+		expect(sets[0]?.contacts?.[0]?.name).toEqual('newer')
+		expect(sets[0]?.contacts?.[0]?.notify).toEqual('kept')
+	})
+
+	/**
 	 * A flush walks `Object.keys()` of the consolidated map, so the order that
 	 * `consolidateEvents` writes its keys is the order a `process()` handler
 	 * iterates and the order the individual events reach `.on()` listeners. The


### PR DESCRIPTION
## Summary

Buffering a `contacts.update` and then a `contacts.upsert` for the same id released the **older** of the two. The fold applied the pending update *after* the incoming contact, so a name the consumer had already superseded overwrote the one that arrived later.

Measured against `baileys/lib/Utils/event-buffer.js`:

| sequence | upstream | before | after |
|---|---|---|---|
| `update{name:'FROM_UPDATE'}` → `upsert{name:'FROM_UPSERT'}` | `FROM_UPSERT` | ❌ `FROM_UPDATE` | ✅ `FROM_UPSERT` |
| the same, with a `messaging-history.set` for the id in between | `FROM_UPSERT` | ❌ `FROM_UPDATE` | ✅ `FROM_UPSERT` |
| `update{notify:'N'}` → `upsert{name:'X'}` | `{name:'X'}` | `{name:'X', notify:'N'}` | `{name:'X', notify:'N'}` |

The first two rows are the defect: last-write-wins is what every other consolidation branch in this file does, and this one inverted it. The third row is unchanged and stays a documented divergence — upstream loses the field only the update carried, this buffer keeps it.

## How it was found

The buffer differential in **deep** mode, on `main`. Fixed-seed mode — what pull requests run — never reached it, so CI was green on both sides; the nightly job is where it showed. Minimised, the sequence folded the pair into a `messaging-history.set`, which is why the released difference appeared on that event rather than on `contacts.upsert`.

## Registry

`event-buffer-merge-precedence` is narrowed, not removed — the added-field half is still real.

- `name` comes out of `MERGE_PRECEDENCE_VALUE_FIELDS`, leaving only `subject` (groups still resolve to different winners). The two buffers now agree on **every value** a contact carries, so leaving `name` pinned would have meant the fuzzer excusing a regression of exactly this fix.
- The entry's reason is rewritten: the contacts half is an added-field difference now, not a value one, and it says which fields were measured.
- The harness test that asserted a contact `name` may differ in value asserts the opposite, and gains the shape the entry does still cover.

## Validation

```
npx tsc --noEmit -p tsconfig.json                      clean
node --test                                            1187 tests, 0 fail
FUZZ_MODE=deep … src/__fuzz__/bridge-events.fuzz.test.ts   8/8   (was 1 failing on main)
npx oxlint / oxfmt                                     clean
```

Two regression tests, one per code path — the merge target is the incoming contact in one and a buffered history-set entry in the other. Reverting only `src/Utils/event-buffer.ts`:

```
not ok 9 - lets a contacts.upsert win over an update buffered before it
not ok 10 - applies the same precedence when the contact lives in a buffered history set
# pass 9  # fail 2
```

## Performance

The first implementation of this fix was **2.1× slower**, and the benchmark is what caught it. Recording that, because the shape of the fix is a direct consequence.

The obvious way to write it is to merge the incoming contact onto the pending update and store that object as the upsert. Bisected across seven variants in separate processes, that is where the cost was — not the reordering, not the extra branch, not the size of `append`:

| variant | cpu-user | |
|---|---|---|
| before | 1891 ms | baseline |
| reorder only, same structure | 1974 ms | the ordering itself is free |
| baseline + 6 filler statements | 1976 ms | rules out function size |
| reorder + a never-taken extra branch | 1864 ms | rules out branch count |
| **merge onto the pending update** | **3979 ms** | ← the cost |
| merge into a fresh `{}` literal | 4092 ms | worse |
| **fill the gaps in the incoming contact** | **1962 ms** | shipped |

The pending update was itself grown from `{}` by the update branch; the incoming contact arrives with a settled shape. Writing into the caller's contact — filling only the fields it does not already carry — costs what the old code cost. A field explicitly set to `undefined` counts as absent, which is what `trimUndefined` would decide, without a second pass over the object.

Instrumenting the branch is what located it: the path assumed cold ran **7992 of 8000 times**, because the history cache dedupes a repeated `messaging-history.set` and the contact is no longer there to merge into.

### Final numbers

Three workloads, one emitter reused per run (`flush()` swaps in a fresh buffer), 20k warm-up then 200k measured iterations, 5 alternating rounds, medians:

| workload | wall before | wall after | Δ | cpu before | cpu after |
|---|---|---|---|---|---|
| W1 `update` → `history-set` → `upsert` | 1207 ms | 1236 ms | **+2.4%** | 1238 ms | 1277 ms |
| W2 `upsert` → `update` → `upsert` | 1783 ms | 1778 ms | −0.3% | 1799 ms | 1804 ms |
| W3 `upsert` → `upsert`, no fold | 471 ms | 416 ms | −11.6% | 490 ms | 437 ms |

W1 is the synthetic worst case: every upsert has a pending update to fold, which is where the gap-filling loop runs. W3 is the ordinary case — no buffered update for the id — and the fold never executes.

**Allocation pressure**, 400k iterations of W1 under `--trace-gc`, two independent process pairs:

| impl | scavenges | major GCs | peak RSS |
|---|---|---|---|
| before | 373 | 1 | 130.0 / 131.7 MiB |
| after | **367** | 1 | 128.3 / 131.9 MiB |

Six fewer scavenges per 400k iterations, identically in both pairs: the fold no longer grows a second object into the released payload. Heap retained after a forced GC is within ±10 KiB of zero on both sides in every workload — nothing accumulates.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RvtvVVWQs8AeBqSzS1JpCg)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes event-buffer precedence so a `contacts.upsert` wins over a previously buffered `contacts.update`, restoring last-write-wins and preventing older names from overwriting newer ones. Fields present only in the earlier update are still kept.

- **Bug Fixes**
  - Fold pending `contacts.update` before `contacts.upsert` so the upsert’s values win; keep fields only the update carried (e.g. `notify`).
  - Apply the same precedence when the contact lives inside a buffered `messaging-history.set`.
  - Update fuzz harness divergence: remove `name` from pinned value fields (only `subject` stays); rewrite the entry’s reason; add regression tests for both code paths.

<sup>Written for commit 0103935c7ce207e1453c548fb4d6e5796de39057. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

