### PR TITLE
test(fuzz): document the NaN half of the toNumber divergence

### DIFF
--- a/src/__fuzz__/harness/__tests__/harness.test.ts
+++ b/src/__fuzz__/harness/__tests__/harness.test.ts
@@ -428,6 +428,34 @@ describe('fuzz harness — known-divergence allowlist', () => {
 		assert.ok(!excused([upsert('same'), receipt], [receipt, upsert('same')]), 'a pure reordering is a finding')
 	})
 
+	// Four separate rules under one id — the dropped high word, the non-Long
+	// passthrough, and the two falsy numbers — so each one is held to its own
+	// outcome rather than to "the argument had the right shape".
+	it('excuses toNumber only where each side did what the entry says it does', async () => {
+		const { KNOWN_DIVERGENCES } = await import('../divergence.ts')
+		const registry = KNOWN_DIVERGENCES.filter(entry => entry.id === 'to-number-high-word')
+		assert.equal(registry.length, 1, 'the entry under test is still in the registry')
+
+		const excused = (input: unknown[], local: unknown, upstream: unknown): boolean =>
+			applyAllowlist([{ target: 'pure:toNumber', input, local, upstream }], new Date('2026-01-01'), registry).unexcused
+				.length === 0
+
+		// The documented shapes.
+		assert.ok(excused([{ low: 5, high: 1 }], 0x1_0000_0005, 5), 'upstream drops the high word')
+		assert.ok(excused(['x'], 0, 'x'), 'upstream hands a non-Long straight back')
+		assert.ok(excused([-0], -0, 0), 'upstream folds negative zero to +0')
+		assert.ok(excused([Number.NaN], Number.NaN, 0), 'upstream folds NaN to +0')
+
+		// ...and each side held to its own rule. A NaN that this side turned into a
+		// number, or that upstream propagated, is not what the entry describes.
+		assert.ok(!excused([Number.NaN], 0, 0), 'this side manufacturing a value is not this entry')
+		assert.ok(!excused([Number.NaN], Number.NaN, Number.NaN), 'both reaching NaN is not a divergence to excuse')
+		assert.ok(!excused([Number.NaN], Number.NaN, 1), 'upstream returning anything but +0 is unexplained')
+		// A finite number is the case where the two agree, so any difference on one
+		// is a regression rather than a documented rule.
+		assert.ok(!excused([7], 8, 7), 'a finite number must not differ at all')
+	})
+
 	it('excuses the cleanMessage JID rewrite only in the shape it documents', async () => {
 		const { KNOWN_DIVERGENCES } = await import('../divergence.ts')
 		const registry = KNOWN_DIVERGENCES.filter(entry => entry.id === 'clean-message-empty-user-jid-server')

--- a/src/__fuzz__/harness/divergence.ts
+++ b/src/__fuzz__/harness/divergence.ts
@@ -860,7 +860,7 @@ export const KNOWN_DIVERGENCES: readonly KnownDivergence[] = [
 		target: 'pure:toNumber',
 		status: 'intended',
 		reason:
-			'Upstream returns `t.low` for a Long without a toNumber method, silently dropping the high word and truncating any value past 2^32 (a millisecond timestamp, for one). baileyrs reconstructs `high * 2^32 + (low >>> 0)`, which is documented at the call site. Upstream also returns its argument unchanged for a non-Long, non-number input, where baileyrs returns 0 to honour its `number` return type. And `toNumber(-0)` returns `-0` from baileyrs and `+0` from upstream, because `t || 0` treats negative zero as falsy — observable through `Object.is` and `1 / result`.',
+			"Upstream returns `t.low` for a Long without a toNumber method, silently dropping the high word and truncating any value past 2^32 (a millisecond timestamp, for one). baileyrs reconstructs `high * 2^32 + (low >>> 0)`, which is documented at the call site. Upstream also returns its argument unchanged for a non-Long, non-number input, where baileyrs returns 0 to honour its `number` return type. And on a falsy *number* the two part ways for the same reason: `t || 0` treats it as absent, so upstream answers `+0` where baileyrs hands the argument straight back. `toNumber(-0)` is `-0` here and `+0` upstream, observable through `Object.is` and `1 / result`; `toNumber(NaN)` is `NaN` here and `0` upstream, which is the sharper of the two — a caller's arithmetic error stays visible instead of being silently rounded into a real timestamp. `0` itself agrees, since `+0` is what both return.",
 		review: '2027-02-01',
 		when: divergence => {
 			// `??` only replaces null/undefined, and a corpus entry or a shrunk input
@@ -886,12 +886,22 @@ export const KNOWN_DIVERGENCES: readonly KnownDivergence[] = [
 					? Object.is(divergence.local, (typeof high === 'number' ? high : 0) * 0x1_0000_0000 + (low >>> 0))
 					: divergence.local === 0
 			}
-			// `-0` is the one number the two disagree on, and for the same reason as
-			// the rest of this entry: upstream's `t || 0` treats it as falsy and hands
-			// back `+0`, baileyrs returns the argument. Surfaced once `normalise`
-			// stopped folding the sign away under strict comparison.
+			// `-0` and `NaN` are the numbers the two disagree on, for one reason:
+			// upstream's `t || 0` treats every falsy number as absent and hands back
+			// `+0`, where baileyrs returns the argument — a `number` in is the one
+			// case with nothing to convert. `0` is falsy too and agrees, because `+0`
+			// is what it returns anyway. `-0` surfaced once `normalise` stopped
+			// folding the sign away under strict comparison; `NaN` only in deep mode,
+			// which is the one that draws it.
 			if (Object.is(argument, -0)) {
 				return Object.is(divergence.local, -0) && Object.is(divergence.upstream, 0)
+			}
+			// Not `Object.is(local, NaN)` on the upstream side: it returns `+0` here,
+			// and holding each side to its own rule is what stops this clause from
+			// excusing a run where *both* went to NaN, or where baileyrs started
+			// manufacturing a number of its own.
+			if (typeof argument === 'number' && Number.isNaN(argument)) {
+				return Number.isNaN(divergence.local) && Object.is(divergence.upstream, 0)
 			}
 			if (typeof argument === 'number') return false
 			// Non-object, non-number: upstream is `t || 0`, baileyrs is 0.


### PR DESCRIPTION
## Summary

`pure:toNumber` fails in deep mode on `main`, 17 divergences, all one shape:

```
toNumber(NaN)   baileyrs  NaN     baileys  0
```

Upstream is a one-liner — `typeof t === 'object' && t ? ('toNumber' in t ? t.toNumber() : t.low) : t || 0` — and `t || 0` treats **every falsy number** as absent. This port returns the argument, because a `number` in is the one case with nothing to convert.

The registry entry already documented `-0` for exactly that reason and stopped there. `NaN` is the same rule; the difference is only that the fixed-seed budget never draws it, so pull requests stayed green while the nightly job did not. `0` is falsy too and agrees, since `+0` is what both return.

| argument | baileyrs | baileys | status before | after |
|---|---|---|---|---|
| `{low: 5, high: 1}` | `4294967301` | `5` | excused | excused |
| `'x'` | `0` | `'x'` | excused | excused |
| `-0` | `-0` | `+0` | excused | excused |
| **`NaN`** | **`NaN`** | **`0`** | **unexcused** | excused |
| `0`, `1`, `±Infinity`, `null`, `undefined`, `''` | — | — | agree | agree |

## Why documented rather than aligned

Every call site feeds `toNumber` something that came out of the protobuf decoder — `messageTimestamp` in `process-history-message.ts` and `events.ts`, `fileLength` in `messages.ts`. None of them can produce a `NaN`, so a `NaN` reaching this function is a caller's arithmetic error. Returning it keeps that visible; upstream's `0` turns "unknown" into a real 1970 timestamp. Nothing internal depends on either behaviour.

If the preference is to match upstream instead, the change is one line in `toNumber` and this entry loses its fourth rule — say the word and I'll switch it.

## Tests

The entry had **no test of its own**, which is how a rule went missing in the first place. It carries four separate rules under one id, so each is pinned with its counter-cases:

- the documented four shapes are excused;
- `NaN → 0` on this side (manufacturing a value) is **not** excused;
- `NaN → NaN` on both sides (no divergence to explain) is **not** excused;
- `NaN → 1` upstream (anything but `+0`) is **not** excused;
- a finite number differing at all is **not** excused.

## Validation

```
npx tsc --noEmit -p tsconfig.json                                     clean
node --test                                                          1188 tests, 0 fail
FUZZ_MODE=deep FUZZ_ONLY=pure:toNumber … pure-differential.fuzz.test.ts   92/92 (was 17 divergences)
npx oxlint / oxfmt                                                   clean
```

**Negative test.** Reverting only `divergence.ts`:

```
not ok 8 - excuses toNumber only where each side did what the entry says it does
  error: 'upstream folds NaN to +0'
```

## Performance

No runtime code is touched — the diff is two files under `src/__fuzz__/`, and `src/Utils/generics.ts` is unchanged:

```
src/__fuzz__/harness/__tests__/harness.test.ts | 28 ++++++++++++++++++++++++++
src/__fuzz__/harness/divergence.ts             | 20 +++++++++++++-----
```

Nothing in the published package changes, so allocations, memory and CPU are identical by construction rather than by measurement. The added predicate clause runs only when a fuzz run has already found a divergence to classify.

## Still red in deep mode, not this PR

Three `proto:*` failures remain — `decodes the same bytes to the same object`, `agrees with upstream whenever both decoders accept the bytes`, `re-encodes what it accepts to something it reads the same way`. Verified identical on `main` and on the two buffer branches merged today, so they predate all of it. Next up, separately.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RvtvVVWQs8AeBqSzS1JpCg)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the `NaN` behavior for `pure:toNumber` in the fuzz divergence registry and added a focused test, so deep-mode fuzz runs stop flagging it as unexcused. No runtime code changed.

- **Bug Fixes**
  - Extended the allowlist to cover `NaN` inputs: we return `NaN`, upstream returns `+0`. Keeps arithmetic errors visible instead of silently rounding.
  - Added a test that pins all four rules under `to-number-high-word` and rejects non-documented cases (e.g., local `NaN → 0`, both `NaN`, finite mismatches).

<sup>Written for commit 9744a31eeb3441c538ec9528ab373fcca2cc4276. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of numeric edge cases, including high-word truncation, negative zero, and `NaN` normalization.
  * Preserved expected behavior for non-Long and falsy numeric inputs.

* **Tests**
  * Added regression coverage for documented numeric conversion differences and unrelated mismatch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->