### PR TITLE
fix(auth): rebuild the credential mirror from the persisted device

### DIFF
--- a/src/Utils/use-multi-file-auth-state.ts
+++ b/src/Utils/use-multi-file-auth-state.ts
@@ -1,8 +1,46 @@
 import { mkdir, stat } from 'node:fs/promises'
-import type { AuthenticationState } from '../Types/index.ts'
+import type { JsStoreCallbacks } from '@oxidezap/whatsapp-rust-bridge'
+import type { AuthenticationCreds, AuthenticationState } from '../Types/index.ts'
+import { createDeviceProjection } from '../Compatibility/legacy-store/device.ts'
 import { projectNativeStore } from '../Compatibility/legacy-store/native-projection.ts'
 import { initAuthCreds } from './generics.ts'
 import { useBridgeStore } from './use-bridge-store.ts'
+
+/**
+ * The store namespace and keys the engine writes its own device under.
+ *
+ * `<folder>/device-device.bin` and `<folder>/device-account.bin` on disk.
+ */
+const DEVICE_STORE = 'device'
+const DEVICE_RECORDS = ['device', 'account'] as const
+
+/**
+ * Rebuild the credential mirror from the device the engine persisted.
+ *
+ * Without this the mirror is whatever `initAuthCreds()` just made up: every
+ * restart handed back `registered: false` and `me: undefined` for a session
+ * that was paired and working, because nothing on this path ever read the
+ * device back. The hydration itself already existed for `wrapLegacyStore`
+ * (`Compatibility/legacy-store/adapter.ts`), which only runs for callers that
+ * bring their own `{ creds, keys }`; a caller using this function goes straight
+ * to the bridge store and used to skip it entirely.
+ *
+ * A record that fails to decode is skipped rather than fatal: a mirror missing
+ * a field is worth less than a socket that will not start, and the engine reads
+ * its own device from the same bytes regardless of what this makes of them.
+ */
+const hydrateFromStore = async (store: JsStoreCallbacks, creds: AuthenticationCreds): Promise<void> => {
+	const projection = createDeviceProjection(creds)
+	for (const record of DEVICE_RECORDS) {
+		const payload = await store.get(DEVICE_STORE, record)
+		if (!payload) continue
+		try {
+			projection.prepare(record, payload)()
+		} catch {
+			/* a record we cannot read leaves that part of the mirror at its default */
+		}
+	}
+}
 
 /**
  * Creates a file-based authentication state for the Rust bridge.
@@ -36,6 +74,14 @@ export const useMultiFileAuthState = async (
 
 	const store = await useBridgeStore(folder)
 	const creds = initAuthCreds()
+	// Before `projectNativeStore`, and that ordering is the whole point: the
+	// projection captures `signedIdentityKey.public` and `registrationId` off
+	// `creds` when it is called, and builds the Signal codecs around them.
+	// Hydrating afterwards would leave those codecs holding the identity of the
+	// throwaway `initAuthCreds()` rather than the device's, so a legacy session
+	// written through this store would be imported under the wrong local
+	// identity.
+	await hydrateFromStore(store, creds)
 	const keys: AuthenticationState['keys'] = projectNativeStore(store, creds)
 
 	return {

--- a/src/__tests__/auth-state-device-hydration.test.ts
+++ b/src/__tests__/auth-state-device-hydration.test.ts
@@ -130,12 +130,33 @@ describe('useMultiFileAuthState device hydration', () => {
 		// its own device from these bytes whatever this makes of them.
 		const folder = makeFolder()
 		const store = await useBridgeStore(folder)
-		await store.set('device', 'device', new Uint8Array([0x7b, 0x00, 0x01]))
+		await store.set('device', 'device', GARBAGE)
 
 		const { state } = await useMultiFileAuthState(folder)
 		assert.equal(state.creds.registered, false)
 	})
+
+	it('keeps the device when only the account record is unreadable', async () => {
+		// The two records are read in one loop, and each is only worth what it
+		// carries: an account that will not decode must cost the account and
+		// nothing else. Guarded because the two are easy to collapse into one
+		// try, and the loss would be silent — the mirror would just be emptier.
+		const source = pairedCreds()
+		const folder = makeFolder()
+		const store = await useBridgeStore(folder)
+		await store.set('device', 'device', createDeviceProjection(source).read('device')!)
+		await store.set('device', 'account', GARBAGE)
+
+		const { state } = await useMultiFileAuthState(folder)
+		assert.equal(state.creds.registered, true)
+		assert.equal(state.creds.me?.id, PN)
+		// And the unreadable half is left absent rather than half-applied.
+		assert.equal(state.creds.account, undefined)
+	})
 })
+
+/** Not a device record under any codec: `illegal tag: field no 0 wire type 0`. */
+const GARBAGE = new Uint8Array([0x7b, 0x00, 0x01])
 
 /** A real baileys@7.0.0-rc.9 session, deep-copied so no test can leak into another. */
 function legacySessionRecord(): unknown {

--- a/src/__tests__/auth-state-device-hydration.test.ts
+++ b/src/__tests__/auth-state-device-hydration.test.ts
@@ -1,0 +1,158 @@
+/**
+ * `useMultiFileAuthState` has to rebuild its credential mirror from the device
+ * the engine persisted.
+ *
+ * The mirror starts life as `initAuthCreds()`, which invents everything, and
+ * nothing on this path used to read the device back: every restart handed the
+ * caller `registered: false` and `me: undefined` for a paired, working session.
+ * Upstream bots read both — `creds.me.id` is how they know who they are, and
+ * they branch on `registered` to decide whether pairing is still owed — so the
+ * mirror being wrong is a compatibility break even though the socket itself
+ * connects fine off the engine's own copy.
+ *
+ * The device bytes here are produced by the same codec that reads them
+ * (`createDeviceProjection().read`), so these are round-trips through the real
+ * format rather than fixtures that can drift away from it.
+ */
+
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, describe, it } from 'node:test'
+import { createDeviceProjection } from '../Compatibility/legacy-store/device.ts'
+import { nativeKey } from '../Compatibility/legacy-store/routing.ts'
+import type { AuthenticationCreds } from '../Types/index.ts'
+import { initAuthCreds } from '../Utils/generics.ts'
+import { useBridgeStore } from '../Utils/use-bridge-store.ts'
+import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
+
+const SESSION_PEER = '5511900000001.0'
+const fixture = JSON.parse(readFileSync(new URL('./fixtures/legacy-session-rc9.json', import.meta.url), 'utf-8')) as {
+	bob: { store: { session: Record<string, unknown> } }
+}
+
+const folders: string[] = []
+const makeFolder = () => {
+	const folder = mkdtempSync(join(tmpdir(), 'auth-hydration-'))
+	folders.push(folder)
+	return folder
+}
+
+const PN = '559980000002:80@s.whatsapp.net'
+const LID = '100000024691356:80@lid'
+
+/** A device as the engine would have left it after a successful pairing. */
+const pairedCreds = (): AuthenticationCreds => {
+	const creds = initAuthCreds()
+	creds.me = { id: PN, lid: LID, name: 'tester' }
+	creds.registered = true
+	return creds
+}
+
+/**
+ * Write `source` into `folder` the way the engine does, then hand back what a
+ * restart sees.
+ */
+const restartOn = async (folder: string, source: AuthenticationCreds) => {
+	const store = await useBridgeStore(folder)
+	const projection = createDeviceProjection(source)
+	for (const record of ['device', 'account'] as const) {
+		const payload = projection.read(record)
+		if (payload) await store.set('device', record, payload)
+	}
+	return await useMultiFileAuthState(folder)
+}
+
+describe('useMultiFileAuthState device hydration', () => {
+	after(() => {
+		for (const folder of folders) rmSync(folder, { recursive: true, force: true })
+	})
+
+	it('rebuilds identity from the persisted device', async () => {
+		const source = pairedCreds()
+		const { state } = await restartOn(makeFolder(), source)
+
+		// The named regression: both were `false` / `undefined` on every restart.
+		assert.equal(state.creds.registered, true)
+		assert.equal(state.creds.me?.id, PN)
+		assert.equal(state.creds.me?.lid, LID)
+		assert.equal(state.creds.me?.name, 'tester')
+	})
+
+	it('rebuilds the Signal material, not just the labels', async () => {
+		// `initAuthCreds()` generates fresh keys, so a mirror that kept them
+		// would describe a device that never existed — worse than an empty one,
+		// because it looks populated.
+		const source = pairedCreds()
+		const { state } = await restartOn(makeFolder(), source)
+
+		assert.equal(state.creds.registrationId, source.registrationId)
+		assertSameBytes(state.creds.signedIdentityKey.public, source.signedIdentityKey.public, 'identity key')
+		assertSameBytes(state.creds.noiseKey.public, source.noiseKey.public, 'noise key')
+		assert.equal(state.creds.signedPreKey.keyId, source.signedPreKey.keyId)
+		assertSameBytes(state.creds.signedPreKey.keyPair.public, source.signedPreKey.keyPair.public, 'signed pre-key')
+		assert.equal(state.creds.advSecretKey, source.advSecretKey)
+	})
+
+	it('projects the key store around the device identity, not the throwaway one', async () => {
+		// The ordering guard. Hydration has to run before `projectNativeStore`,
+		// which snapshots `signedIdentityKey.public` and `registrationId` into
+		// the Signal codecs when it is called. Reverse the two and everything
+		// above still passes — the mirror is the same object, mutated later —
+		// while the codecs quietly keep the invented identity.
+		const source = pairedCreds()
+		const folder = makeFolder()
+		const { state } = await restartOn(folder, source)
+
+		// A real rc.9 session, because the local identity is written into the
+		// imported record and an empty one carries nothing to look at.
+		await state.keys.set({ session: { [SESSION_PEER]: legacySessionRecord() } as never })
+
+		const store = await useBridgeStore(folder)
+		const written = await store.get('session', nativeKey('session', SESSION_PEER))
+		assert.ok(written, 'the session was not written through the projection')
+		assert.ok(
+			indexOfBytes(written, source.signedIdentityKey.public) >= 0,
+			'the imported session does not carry the device identity, so the codecs were built before hydration'
+		)
+	})
+
+	it('leaves the mirror at its defaults when there is no device yet', async () => {
+		// A first run has nothing to read, and must not be reported as paired.
+		const { state } = await useMultiFileAuthState(makeFolder())
+		assert.equal(state.creds.registered, false)
+		assert.equal(state.creds.me, undefined)
+	})
+
+	it('survives a device record it cannot decode', async () => {
+		// Losing the mirror is better than refusing to start: the engine reads
+		// its own device from these bytes whatever this makes of them.
+		const folder = makeFolder()
+		const store = await useBridgeStore(folder)
+		await store.set('device', 'device', new Uint8Array([0x7b, 0x00, 0x01]))
+
+		const { state } = await useMultiFileAuthState(folder)
+		assert.equal(state.creds.registered, false)
+	})
+})
+
+/** A real baileys@7.0.0-rc.9 session, deep-copied so no test can leak into another. */
+function legacySessionRecord(): unknown {
+	return JSON.parse(JSON.stringify(fixture.bob.store.session[SESSION_PEER]))
+}
+
+/** Byte equality without caring whether the value arrived as a Buffer or a Uint8Array. */
+function assertSameBytes(actual: Uint8Array, expected: Uint8Array, what: string) {
+	assert.deepEqual(Array.from(actual), Array.from(expected), `${what} was not restored from the device`)
+}
+
+function indexOfBytes(haystack: Uint8Array, needle: Uint8Array): number {
+	outer: for (let start = 0; start + needle.length <= haystack.length; start++) {
+		for (let index = 0; index < needle.length; index++) {
+			if (haystack[start + index] !== needle[index]) continue outer
+		}
+		return start
+	}
+	return -1
+}

--- a/src/__tests__/e2e/auth-restart.test-e2e.ts
+++ b/src/__tests__/e2e/auth-restart.test-e2e.ts
@@ -1,0 +1,70 @@
+/**
+ * E2E: what a bot sees in `creds` after restarting on a paired auth folder.
+ *
+ * The offline suite builds the device bytes with the same codec that reads
+ * them, which proves the hydration but not that the engine writes what the
+ * hydration expects. This one pairs for real, drops the socket, and reopens the
+ * folder the way a restarted bot does.
+ *
+ * The regression it guards: every restart used to hand back `registered: false`
+ * and `me: undefined` for a working session, because nothing on the native
+ * store path ever read the device back into the mirror.
+ */
+
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, describe, test } from 'node:test'
+import { jidNormalizedUser, useMultiFileAuthState } from '../../index.ts'
+import { createTestClient } from './test-client.ts'
+
+describe('E2E: creds after a restart', { timeout: 120_000 }, () => {
+	let folder: string
+	let pairedJid: string
+
+	before(async () => {
+		folder = mkdtempSync(join(tmpdir(), 'baileys-e2e-auth-restart-'))
+		const client = await createTestClient({ label: 'alice', authFolder: folder })
+		pairedJid = client.jid
+		// Not `destroyTestClient`: it deletes the auth folder, which is the
+		// whole subject of this test.
+		client.sock.setAutoReconnect(false)
+		await client.sock.end(undefined)
+	})
+
+	after(() => {
+		rmSync(folder, { recursive: true, force: true })
+	})
+
+	test('a restarted bot reads back its own identity', async () => {
+		const { state } = await useMultiFileAuthState(folder)
+
+		assert.equal(state.creds.registered, true, '`registered` did not survive the restart')
+		assert.ok(state.creds.me, '`me` did not survive the restart')
+		assert.equal(jidNormalizedUser(state.creds.me.id), jidNormalizedUser(pairedJid))
+		// The engine addresses the account by LID, and a mirror without it sends
+		// a bot back to resolving its own identity over the wire.
+		assert.ok(state.creds.me.lid, '`me.lid` did not survive the restart')
+	})
+
+	test('the restarted mirror carries the device Signal material', async () => {
+		// A mirror that kept `initAuthCreds()`'s invented keys describes a device
+		// that never paired, which is worse than an empty one because it reads as
+		// populated.
+		const first = await useMultiFileAuthState(folder)
+		const second = await useMultiFileAuthState(folder)
+
+		assert.equal(first.state.creds.registrationId, second.state.creds.registrationId)
+		assert.deepEqual(
+			Array.from(first.state.creds.signedIdentityKey.public),
+			Array.from(second.state.creds.signedIdentityKey.public),
+			'two reads of the same folder disagree on the identity key'
+		)
+		assert.deepEqual(
+			Array.from(first.state.creds.noiseKey.public),
+			Array.from(second.state.creds.noiseKey.public),
+			'two reads of the same folder disagree on the noise key'
+		)
+	})
+})


### PR DESCRIPTION
## Summary

A bot restarting on a paired auth folder read `creds.registered === false` and `creds.me === undefined`, for a session that pairs, connects and delivers messages. Reported by a user migrating from upstream, who noticed `registered` never leaving `false` "regardless of session state".

`useMultiFileAuthState` builds its mirror with `initAuthCreds()`, which invents everything, and nothing on that path ever read the engine's device back into it. The hydration exists and is correct — `prepareNativeDevice` restores `me`, `registered`, the Signal material and the rest — but its only caller is `wrapLegacyStore`, which runs for callers that bring their own `{ creds, keys }`. A caller using `useMultiFileAuthState` gets a `store` in its state, so the socket goes straight to the bridge store and the wrap never happens.

During pairing the mirror is right, because `pairSuccess` emits `creds.update` and the socket merges it. It is the next process that gets the invented one back. That inconsistency is what the report described.

## Reproduction

Pair against the mock server, drop the socket, reopen the same folder:

```
[1st run] registered = true  | me = {"id":"5599…@s.whatsapp.net", …}
folder:   device-device.bin, device-account.bin, identity-….bin, …
[2nd run] registered = false | me = undefined
```

The device is on disk the whole time.

## Changes

- `useMultiFileAuthState` hydrates the mirror from `device-device.bin` and `device-account.bin` through the existing `createDeviceProjection`. A record that fails to decode is skipped rather than fatal: an incomplete mirror beats a socket that will not start, and the engine reads its own device from those bytes regardless.
- The hydration runs **before** `projectNativeStore`. That call snapshots `signedIdentityKey.public` and `registrationId` into the Signal codecs, so hydrating afterwards would leave them holding the identity of the throwaway `initAuthCreds()` — and a legacy session written through the store would then be imported under the wrong local identity. That was already the case on this path before this PR.

## Compatibility note

`creds.me` empty after a restart is a straight break: upstream reads it back from `creds.json` and it is populated. `registered` is subtler — upstream only ever sets it in the 8-digit pairing-code flow (`Socket/messages-recv.ts`), so a QR-paired bot sees `false` there too. What was ours is the inconsistency, `true` while pairing and `false` on the next start.

## Validation

- `npm test` — 1194 passing, no existing test needed adapting.
- `npm run test:e2e` — the new file included, against the live mock server.
- `tsc`, `oxlint`, `oxfmt` clean.

Both failure modes were verified by reverting:

| reverted | result |
|---|---|
| hydration removed | 3 of 5 unit tests fail, both e2e tests fail |
| hydration moved after the projection | only the ordering test fails |

The second one is why that test exists: swapping the order leaves the mirror correct, since it is the same object mutated later, and every other assertion still passes.

New tests:

- `src/__tests__/auth-state-device-hydration.test.ts` — device bytes produced by the same codec that reads them, so these are round-trips through the real format rather than fixtures that drift. Covers identity, the Signal material, the codec ordering (using the real rc.9 session fixture, whose imported record carries the local identity), a first run with no device, and an undecodable record.
- `src/__tests__/e2e/auth-restart.test-e2e.ts` — pairs for real, drops the socket, reopens the folder as a restarted bot would. The unit tests prove the hydration; this one proves the engine writes what it expects.

## Left out

`creds.platform` does not survive a round trip through our own device serializer: `prepareNativeDevice` reads `native.platform` on the way in, but `deviceFromCreds` does not write it on the way out. It only affects callers writing the device through `wrapLegacyStore`, and I did not check whether the engine populates the field, so the test asserts what it can prove instead of pretending to cover it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the auth credential mirror from the persisted device on startup so restarted bots keep `registered` and `me`. Fixes restarts that showed `registered: false` and `me: undefined` despite a paired, working session.

- **Bug Fixes**
  - `useMultiFileAuthState` now hydrates `creds` from `device-device.bin` and `device-account.bin` via `createDeviceProjection`.
  - Runs hydration before `projectNativeStore` to snapshot the correct identity and `registrationId` into Signal codecs.
  - Skips undecodable device or account records per-record instead of failing, allowing startup while preserving valid mirror data.
  - Added unit and E2E tests covering hydration, ordering, and per-record decode failures.

<sup>Written for commit d179b6b7d2ce5f971a98a52ae4a1247fb70bd6c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication-state restoration when restarting with existing saved credentials.
  * Preserved account identity, registration status, registration ID, and security keys across sessions.
  * Added graceful handling when stored device data cannot be decoded.
  * Ensured default credentials are used when no saved device data is available.

* **Tests**
  * Added coverage for credential hydration, session persistence, and end-to-end authentication restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->