### PR TITLE
test(compat): audit the connection lifecycle contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "compat:audit:missing": "npm run build --silent && node scripts/compatibility/audit.ts --only-missing",
     "compat:audit:proto": "node scripts/compatibility/proto-runtime-audit.ts --details --strict",
     "compat:audit:wire": "node scripts/compatibility/wire-fidelity-audit.ts --details --strict",
+    "compat:audit:lifecycle": "node scripts/compatibility/lifecycle-contract-audit.ts --strict",
     "compat:audit:strict": "npm run build --silent && node scripts/compatibility/audit.ts --strict --only-missing",
     "compat:sync-waproto": "node scripts/compatibility/waproto-facade.ts --sync",
     "compat:check-waproto": "node scripts/compatibility/waproto-facade.ts --check",
@@ -77,7 +78,7 @@
     "fuzz:report": "node scripts/fuzz/report.ts",
     "test:compat-auditor": "node --test scripts/compatibility/__tests__/audit.test.ts",
     "typecheck:compat-auditor": "npm run build --silent && npm run compat:check-waproto --silent && npm run compat:layers --silent && tsc -p scripts/compatibility/tsconfig.json",
-    "test:e2e": "NODE_TLS_REJECT_UNAUTHORIZED=0 ADV_SECRET_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= node --expose-gc --test --test-concurrency=1 ./src/__tests__/e2e/*.test-e2e.ts"
+    "test:e2e": "NODE_TLS_REJECT_UNAUTHORIZED=0 ADV_SECRET_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= node --expose-gc --test --test-concurrency=1 ./src/__tests__/e2e/*.test-e2e.ts ./scripts/compatibility/__tests__/*.test-e2e.ts"
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",

--- a/scripts/compatibility/__tests__/lifecycle-contract.test-e2e.ts
+++ b/scripts/compatibility/__tests__/lifecycle-contract.test-e2e.ts
@@ -16,9 +16,12 @@
  */
 
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import process from 'node:process'
 import { after, before, describe, test } from 'node:test'
-import { createTestClient, destroyTestClient, type TestClient } from '../../../src/__tests__/e2e/test-client.ts'
+import { createTestClient, type TestClient } from '../../../src/__tests__/e2e/test-client.ts'
 import {
 	evaluateLifecycle,
 	recordLifecycle,
@@ -56,15 +59,24 @@ const OPEN_DEADLINE_MS = 30_000
 const KNOWN_VIOLATIONS = new Set(['LC-009', 'LC-011'])
 
 describe('E2E: lifecycle contract', { timeout: 180_000 }, () => {
-	let alice: TestClient | undefined
 	let recorder: LifecycleRecorder | undefined
 	let setupError: Error | undefined
+	/**
+	 * The socket and folder as seen from outside the factory.
+	 *
+	 * The factory only hands back a client once it has connected, so on the
+	 * failure this file exists to diagnose there is nothing to tear down through
+	 * it — while the socket it built is live, reconnecting, and holding an auth
+	 * folder. Owning both here is what lets the teardown run either way.
+	 */
+	let socket: TestClient['sock'] | undefined
+	const folder = mkdtempSync(join(tmpdir(), 'baileys-e2e-lifecycle-'))
 
 	before(async () => {
 		try {
-			alice = await createTestClient({
+			await createTestClient({
 				label: 'alice',
-				folderPrefix: 'baileys-e2e-lifecycle',
+				authFolder: folder,
 				// Longer than the deadline the trace is judged by, so a socket
 				// that authenticates and then goes quiet has already breached
 				// LC-004 by the time the factory gives up. Matched the other way
@@ -75,6 +87,7 @@ describe('E2E: lifecycle contract', { timeout: 180_000 }, () => {
 				// published from a microtask queued inside `makeWASocket`, so a
 				// listener added afterwards has already missed the first state.
 				onSocket: sock => {
+					socket = sock
 					recorder = recordLifecycle(sock, { label: 'fresh-pair-live' })
 				}
 			})
@@ -92,7 +105,18 @@ describe('E2E: lifecycle contract', { timeout: 180_000 }, () => {
 		// Before the teardown, so a trace still open at this point cannot read
 		// our own disposal as the library going quiet.
 		recorder?.noteConsumerEnd()
-		if (alice) await destroyTestClient(alice)
+		if (socket) {
+			// Not `destroyTestClient`: there may be no client, and the socket is
+			// what actually has to be stopped. Auto-reconnect goes first or the
+			// engine keeps the process alive retrying an account nobody wants.
+			try {
+				socket.setAutoReconnect(false)
+				await socket.end(undefined)
+			} catch {
+				/* best effort: the run is over either way */
+			}
+		}
+		rmSync(folder, { recursive: true, force: true })
 	})
 
 	test('a freshly paired session keeps every promise upstream makes', () => {

--- a/scripts/compatibility/__tests__/lifecycle-contract.test-e2e.ts
+++ b/scripts/compatibility/__tests__/lifecycle-contract.test-e2e.ts
@@ -56,31 +56,47 @@ const OPEN_DEADLINE_MS = 30_000
 const KNOWN_VIOLATIONS = new Set(['LC-009', 'LC-011'])
 
 describe('E2E: lifecycle contract', { timeout: 180_000 }, () => {
-	let alice: TestClient
+	let alice: TestClient | undefined
 	let recorder: LifecycleRecorder | undefined
+	let setupError: Error | undefined
 
 	before(async () => {
-		alice = await createTestClient({
-			label: 'alice',
-			folderPrefix: 'baileys-e2e-lifecycle',
-			// Attached before the factory returns: the bootstrap `connecting` is
-			// published from a microtask queued inside `makeWASocket`, so a
-			// listener added afterwards has already missed the first state.
-			onSocket: sock => {
-				recorder = recordLifecycle(sock, { label: 'fresh-pair-live' })
-			}
-		})
+		try {
+			alice = await createTestClient({
+				label: 'alice',
+				folderPrefix: 'baileys-e2e-lifecycle',
+				// Longer than the deadline the trace is judged by, so a socket
+				// that authenticates and then goes quiet has already breached
+				// LC-004 by the time the factory gives up. Matched the other way
+				// round, the run would end inside the deadline and the finding
+				// would report as unexercised.
+				connectTimeoutMs: OPEN_DEADLINE_MS + 15_000,
+				// Attached before the factory returns: the bootstrap `connecting` is
+				// published from a microtask queued inside `makeWASocket`, so a
+				// listener added afterwards has already missed the first state.
+				onSocket: sock => {
+					recorder = recordLifecycle(sock, { label: 'fresh-pair-live' })
+				}
+			})
+		} catch (error) {
+			// Kept rather than thrown. The factory waits for `open`, so the exact
+			// regression this file exists to catch — authenticates, never opens —
+			// would surface as its connect timeout and the trace explaining why
+			// would never be read. The test body reports the finding first and
+			// falls back to this only if the trace turns out to be clean.
+			setupError = error instanceof Error ? error : new Error(String(error))
+		}
 	})
 
 	after(async () => {
 		// Before the teardown, so a trace still open at this point cannot read
 		// our own disposal as the library going quiet.
 		recorder?.noteConsumerEnd()
-		await destroyTestClient(alice)
+		if (alice) await destroyTestClient(alice)
 	})
 
 	test('a freshly paired session keeps every promise upstream makes', () => {
-		assert.ok(recorder, 'the recorder never attached')
+		assert.ok(recorder, `the recorder never attached${setupError ? `: ${setupError.message}` : ''}`)
 		const report = evaluateLifecycle([recorder.stop()], { openDeadlineMs: OPEN_DEADLINE_MS })
 		const rendered = renderLifecycleReport(report, true)
 		if (process.env.LOG_LEVEL === 'debug') process.stdout.write(`${rendered}\n`)
@@ -99,6 +115,11 @@ describe('E2E: lifecycle contract', { timeout: 180_000 }, () => {
 			.filter(finding => finding.status === 'holds' && KNOWN_VIOLATIONS.has(finding.invariant))
 			.map(finding => finding.invariant)
 		assert.deepEqual(fixed, [], `${rendered}\n\nfixed — remove from KNOWN_VIOLATIONS: ${fixed.join(', ')}`)
+
+		// Only once the trace has had its say: a setup that failed for a reason
+		// the contract does not describe still has to fail the run, but the
+		// findings above are the better explanation when there are any.
+		assert.equal(setupError, undefined, `${setupError?.message}\n\n${rendered}`)
 
 		// The session has to have got far enough to be worth judging. `LC-004`
 		// is the one that fails when a socket pairs and never announces, so a

--- a/scripts/compatibility/__tests__/lifecycle-contract.test-e2e.ts
+++ b/scripts/compatibility/__tests__/lifecycle-contract.test-e2e.ts
@@ -1,0 +1,108 @@
+/**
+ * E2E: the lifecycle contract, judged on a real session.
+ *
+ * The offline suite drives the dispatcher with bridge events we choose, so it
+ * proves the translation is right and nothing about what the engine actually
+ * dispatches. This file records a live socket from the instant it is built and
+ * hands the trace to the same invariants, which is the only place a missing
+ * `Connected` from the engine can surface.
+ *
+ * It lives here rather than under `src/__tests__/e2e/` because compatibility
+ * tooling never ships and `src` never imports it; the dependency only runs the
+ * other way. `npm run test:e2e` picks up both directories.
+ *
+ * Needs the live mock server. An unexercised invariant is reported and not
+ * failed: one session is not expected to reach every state. A violation fails.
+ */
+
+import assert from 'node:assert/strict'
+import process from 'node:process'
+import { after, before, describe, test } from 'node:test'
+import { createTestClient, destroyTestClient, type TestClient } from '../../../src/__tests__/e2e/test-client.ts'
+import {
+	evaluateLifecycle,
+	recordLifecycle,
+	renderLifecycleReport,
+	unexercisedInvariants,
+	type LifecycleRecorder
+} from '../lifecycle-contract-core.ts'
+
+/**
+ * The socket authenticates, syncs and settles well inside this. It exists so a
+ * session that hangs is reported as a contract break instead of as a bare
+ * timeout with nothing to read.
+ */
+const OPEN_DEADLINE_MS = 30_000
+
+/**
+ * Violations a live session produces today, pinned so a third one fails.
+ *
+ * Both come from the same place: the engine leaves passive mode
+ * (`client/node_io.rs:1221`) well before it dispatches `Connected`, which it
+ * withholds until the critical app state sync finishes
+ * (`client/node_io.rs:1467`). Everything that follows leaving passive mode
+ * therefore reaches the consumer while this socket still reads as `connecting`.
+ * Upstream has no such gap: `open` goes out on `<success>`
+ * (`Socket/socket.ts:1138`), before the offline batch it later flushes.
+ *
+ * `LC-011` has a second cause on our side: upstream buffers events from
+ * `process.nextTick` and flushes on `CB:ib,,offline` (`Socket/socket.ts:1206`
+ * and `1224`), and this socket never calls `ev.buffer()`, so a message is
+ * published the moment it decodes.
+ *
+ * Not silenced: the assertions below fail if one of these starts holding, so
+ * the entry cannot outlive the fix.
+ */
+const KNOWN_VIOLATIONS = new Set(['LC-009', 'LC-011'])
+
+describe('E2E: lifecycle contract', { timeout: 180_000 }, () => {
+	let alice: TestClient
+	let recorder: LifecycleRecorder | undefined
+
+	before(async () => {
+		alice = await createTestClient({
+			label: 'alice',
+			folderPrefix: 'baileys-e2e-lifecycle',
+			// Attached before the factory returns: the bootstrap `connecting` is
+			// published from a microtask queued inside `makeWASocket`, so a
+			// listener added afterwards has already missed the first state.
+			onSocket: sock => {
+				recorder = recordLifecycle(sock, { label: 'fresh-pair-live' })
+			}
+		})
+	})
+
+	after(async () => {
+		// Before the teardown, so a trace still open at this point cannot read
+		// our own disposal as the library going quiet.
+		recorder?.noteConsumerEnd()
+		await destroyTestClient(alice)
+	})
+
+	test('a freshly paired session keeps every promise upstream makes', () => {
+		assert.ok(recorder, 'the recorder never attached')
+		const report = evaluateLifecycle([recorder.stop()], { openDeadlineMs: OPEN_DEADLINE_MS })
+		const rendered = renderLifecycleReport(report, true)
+		if (process.env.LOG_LEVEL === 'debug') process.stdout.write(`${rendered}\n`)
+
+		const violated = report.findings.filter(finding => finding.status === 'violated').map(finding => finding.invariant)
+		assert.deepEqual(
+			violated.filter(id => !KNOWN_VIOLATIONS.has(id)),
+			[],
+			rendered
+		)
+
+		// A pinned violation that now holds has been fixed, and the entry has to
+		// go with it. Keyed on `holds` and not on the absence of a violation: an
+		// invariant this run never exercised proves nothing either way.
+		const fixed = report.findings
+			.filter(finding => finding.status === 'holds' && KNOWN_VIOLATIONS.has(finding.invariant))
+			.map(finding => finding.invariant)
+		assert.deepEqual(fixed, [], `${rendered}\n\nfixed — remove from KNOWN_VIOLATIONS: ${fixed.join(', ')}`)
+
+		// The session has to have got far enough to be worth judging. `LC-004`
+		// is the one that fails when a socket pairs and never announces, so a
+		// run that left even that unexercised proves nothing.
+		assert.equal(unexercisedInvariants(report).includes('LC-004'), false, rendered)
+	})
+})

--- a/scripts/compatibility/__tests__/lifecycle-contract.test.ts
+++ b/scripts/compatibility/__tests__/lifecycle-contract.test.ts
@@ -294,13 +294,13 @@ describe('lifecycle contract auditor', () => {
 })
 
 describe('lifecycle contract scenarios', () => {
-	it('holds for every session the engine produces', () => {
-		const report = auditLifecycleScenarios()
+	it('holds for every session the engine produces', async () => {
+		const report = await auditLifecycleScenarios()
 		assert.equal(report.summary.violated, 0, renderLifecycleReport(report, true))
 	})
 
-	it('exercises every invariant', () => {
-		assert.deepEqual(unexercisedInvariants(auditLifecycleScenarios()), [])
+	it('exercises every invariant', async () => {
+		assert.deepEqual(unexercisedInvariants(await auditLifecycleScenarios()), [])
 	})
 
 	/**
@@ -343,22 +343,22 @@ describe('lifecycle contract scenarios', () => {
 })
 
 describe('lifecycle contract CLI', () => {
-	it('passes on the built-in suite under --strict', () => {
-		assert.equal(runCli(['--strict']), 0)
+	it('passes on the built-in suite under --strict', async () => {
+		assert.equal(await runCli(['--strict']), 0)
 	})
 
-	it('fails on a recorded trace that breaks the contract', () => {
+	it('fails on a recorded trace that breaks the contract', async () => {
 		const folder = mkdtempSync(join(tmpdir(), 'lifecycle-contract-'))
 		try {
 			const file = join(folder, 'trace.json')
 			writeFileSync(file, JSON.stringify([VIOLATIONS[0]!.subject]))
-			assert.equal(runCli(['--trace', file, '--strict']), 1)
+			assert.equal(await runCli(['--trace', file, '--strict']), 1)
 		} finally {
 			rmSync(folder, { recursive: true, force: true })
 		}
 	})
 
-	it('rejects a non-positive deadline instead of judging with it', () => {
-		assert.throws(() => runCli(['--open-deadline', '0']), /--open-deadline/)
+	it('rejects a non-positive deadline instead of judging with it', async () => {
+		await assert.rejects(() => runCli(['--open-deadline', '0']), /--open-deadline/)
 	})
 })

--- a/scripts/compatibility/__tests__/lifecycle-contract.test.ts
+++ b/scripts/compatibility/__tests__/lifecycle-contract.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -9,6 +10,7 @@ import {
 	LIFECYCLE_INVARIANTS,
 	lifecycleAuditFailed,
 	normalizeUpdate,
+	recordLifecycle,
 	renderLifecycleReport,
 	runScenario,
 	unexercisedInvariants,
@@ -134,6 +136,27 @@ const VIOLATIONS: Array<{ id: string; subject: LifecycleTrace; also?: string[] }
 	{
 		id: 'LC-011',
 		subject: trace('messages-before-open', [connecting(0), { at: 1, name: 'messages.upsert' }])
+	},
+	{
+		// A socket that opened once is not open forever. Judging against the
+		// first `open` ever seen would wave through everything a reconnect
+		// publishes while it is still re-establishing.
+		id: 'LC-009',
+		subject: trace('pending-while-reconnecting', [
+			connecting(0),
+			conn(1, { connection: 'open' }),
+			connecting(2),
+			conn(3, { receivedPendingNotifications: true })
+		])
+	},
+	{
+		id: 'LC-011',
+		subject: trace('messages-while-reconnecting', [
+			connecting(0),
+			conn(1, { connection: 'open' }),
+			connecting(2),
+			{ at: 3, name: 'messages.upsert' }
+		])
 	}
 ]
 
@@ -211,6 +234,42 @@ describe('lifecycle contract auditor', () => {
 			consumerEndedAt: 45_000
 		})
 		assert.ok(violationsOf(late).has('LC-004'))
+	})
+
+	it('orders by position, not by the millisecond they share', () => {
+		// `Date.now()` has millisecond resolution and a socket publishes several
+		// events inside one, so a message emitted just before `open` carries the
+		// same timestamp. Ordering on `at` would read that as simultaneous and
+		// let it through.
+		const sameMillisecond = trace('all-at-once', [
+			connecting(0),
+			{ at: 0, name: 'messages.upsert' },
+			conn(0, { connection: 'open' })
+		])
+		assert.ok(violationsOf(sameMillisecond).has('LC-011'))
+	})
+
+	it('leaves LC-010 unexercised when the socket never opened', () => {
+		// Its premise is what follows an `open`. Counting a QR-only session as
+		// holding would let `--strict` keep claiming coverage even if every
+		// opening scenario regressed.
+		const qrOnly = trace('qr-only', [connecting(0), conn(1, { qr: 'code' })])
+		const finding = evaluateLifecycle([qrOnly]).findings.find(entry => entry.invariant === 'LC-010')
+		assert.equal(finding?.status, 'not-exercised')
+	})
+
+	it('takes an already-authenticated socket as authenticated', () => {
+		// A socket resuming a stored session publishes no `creds.update` merely
+		// because it is logged in, so without this LC-004 has no premise and a
+		// resumed session that hangs reports as unexercised.
+		const ev = new EventEmitter()
+		const recorder = recordLifecycle({ ev } as never, {
+			label: 'resumed',
+			authenticatedAtStart: true,
+			now: () => 0
+		})
+		const recorded = { ...recorder.stop(), settled: true }
+		assert.ok(violationsOf(recorded).has('LC-004'))
 	})
 
 	it('rejects a trace whose clock runs backwards', () => {

--- a/scripts/compatibility/__tests__/lifecycle-contract.test.ts
+++ b/scripts/compatibility/__tests__/lifecycle-contract.test.ts
@@ -1,0 +1,305 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+import {
+	auditLifecycleScenarios,
+	evaluateLifecycle,
+	LIFECYCLE_INVARIANTS,
+	lifecycleAuditFailed,
+	normalizeUpdate,
+	renderLifecycleReport,
+	runScenario,
+	unexercisedInvariants,
+	type LifecycleEvent,
+	type LifecycleTrace,
+	type LifecycleUpdate
+} from '../lifecycle-contract-core.ts'
+import { runCli } from '../lifecycle-contract-audit.ts'
+import { Boom } from '../../../src/Utils/boom.ts'
+import { DisconnectReason } from '../../../src/Types/index.ts'
+
+const update = (partial: Partial<LifecycleUpdate>): LifecycleUpdate => ({
+	qr: 'absent',
+	lastDisconnect: 'absent',
+	...partial
+})
+
+const conn = (at: number, partial: Partial<LifecycleUpdate>): LifecycleEvent => ({
+	at,
+	name: 'connection.update',
+	update: update(partial)
+})
+
+const authenticated = (at: number): LifecycleEvent => ({ at, name: 'creds.update', authenticated: true })
+
+const trace = (label: string, events: LifecycleEvent[], extra: Partial<LifecycleTrace> = {}): LifecycleTrace => ({
+	label,
+	fromSocketStart: true,
+	settled: true,
+	observedUntil: events.length ? events[events.length - 1]!.at : 0,
+	events,
+	...extra
+})
+
+const connecting = (at: number) =>
+	conn(at, { connection: 'connecting', qr: 'cleared', receivedPendingNotifications: false })
+const closed = (at: number, status = DisconnectReason.loggedOut) =>
+	conn(at, { connection: 'close', lastDisconnect: 'present', lastDisconnectStatus: status })
+
+/** A session that keeps every promise, used as the false-positive baseline. */
+const CONFORMING = trace('conforming', [
+	connecting(0),
+	conn(1, { qr: 'code' }),
+	authenticated(2),
+	conn(3, { connection: 'open' }),
+	conn(4, { receivedPendingNotifications: true }),
+	{ at: 5, name: 'messages.upsert' },
+	connecting(6),
+	conn(7, { connection: 'open' }),
+	closed(8)
+])
+
+const violationsOf = (subject: LifecycleTrace) =>
+	new Set(
+		evaluateLifecycle([subject])
+			.findings.filter(finding => finding.status === 'violated')
+			.map(finding => finding.invariant)
+	)
+
+/**
+ * One trace per invariant that breaks exactly that promise.
+ *
+ * `also` lists the invariants the same trace legitimately breaks, because some
+ * violations are not separable: a second `close` is also a state published
+ * after a close. Anything outside `id` and `also` is a false positive and fails
+ * the run.
+ */
+const VIOLATIONS: Array<{ id: string; subject: LifecycleTrace; also?: string[] }> = [
+	{
+		id: 'LC-001',
+		subject: trace('opens-without-connecting', [conn(0, { connection: 'open' })])
+	},
+	{
+		id: 'LC-002',
+		subject: trace('connecting-keeps-the-qr', [
+			conn(0, { connection: 'connecting', qr: 'absent', receivedPendingNotifications: false })
+		])
+	},
+	{
+		id: 'LC-002',
+		subject: trace('connecting-keeps-pending-notifications', [conn(0, { connection: 'connecting', qr: 'cleared' })])
+	},
+	{
+		id: 'LC-003',
+		subject: trace('opens-twice', [connecting(0), conn(1, { connection: 'open' }), conn(2, { connection: 'open' })])
+	},
+	{
+		id: 'LC-004',
+		subject: trace('authenticates-and-goes-quiet', [connecting(0), authenticated(1)])
+	},
+	{
+		id: 'LC-005',
+		subject: trace('speaks-after-close', [connecting(0), closed(1), connecting(2)])
+	},
+	{
+		id: 'LC-006',
+		subject: trace('closes-twice', [connecting(0), closed(1), closed(2)]),
+		also: ['LC-005']
+	},
+	{
+		id: 'LC-007',
+		subject: trace('last-disconnect-on-connecting', [
+			conn(0, {
+				connection: 'connecting',
+				qr: 'cleared',
+				receivedPendingNotifications: false,
+				lastDisconnect: 'present'
+			})
+		])
+	},
+	{
+		id: 'LC-008',
+		subject: trace('close-without-status', [connecting(0), conn(1, { connection: 'close' })])
+	},
+	{
+		id: 'LC-009',
+		subject: trace('pending-before-open', [connecting(0), conn(1, { receivedPendingNotifications: true })])
+	},
+	{
+		id: 'LC-010',
+		subject: trace('qr-after-open', [connecting(0), conn(1, { connection: 'open' }), conn(2, { qr: 'code' })])
+	},
+	{
+		id: 'LC-011',
+		subject: trace('messages-before-open', [connecting(0), { at: 1, name: 'messages.upsert' }])
+	}
+]
+
+describe('lifecycle contract auditor', () => {
+	it('reports no violation for a conforming session', () => {
+		const report = evaluateLifecycle([CONFORMING])
+		assert.equal(report.summary.violated, 0, renderLifecycleReport(report, true))
+		assert.equal(lifecycleAuditFailed(report), false)
+	})
+
+	it('exercises every invariant on the conforming session', () => {
+		// A baseline that skips an invariant would let a false positive there go
+		// unnoticed, so the false-positive test above is only worth as much as
+		// this one.
+		assert.deepEqual(unexercisedInvariants(evaluateLifecycle([CONFORMING])), [])
+	})
+
+	for (const { id, subject, also } of VIOLATIONS) {
+		it(`catches ${id} on \`${subject.label}\``, () => {
+			const violated = violationsOf(subject)
+			assert.ok(
+				violated.has(id),
+				`${id} not reported for ${subject.label}: got ${[...violated].join(', ') || 'nothing'}`
+			)
+			const allowed = new Set([id, ...(also ?? [])])
+			const extra = [...violated].filter(entry => !allowed.has(entry))
+			assert.deepEqual(extra, [], `${subject.label} produced false positives`)
+		})
+	}
+
+	it('covers every invariant with a violation case', () => {
+		// Adding an invariant without a failing case would ship a check nobody
+		// has ever seen fail.
+		const covered = new Set(VIOLATIONS.map(entry => entry.id))
+		const uncovered = LIFECYCLE_INVARIANTS.filter(invariant => !covered.has(invariant.id)).map(
+			invariant => invariant.id
+		)
+		assert.deepEqual(uncovered, [])
+	})
+
+	it('treats an unexercised premise as coverage, never as a violation', () => {
+		const report = evaluateLifecycle([trace('nothing-happened', [])])
+		assert.equal(report.summary.violated, 0, renderLifecycleReport(report, true))
+		assert.equal(report.summary.holds, 0)
+		assert.equal(report.summary['not-exercised'], LIFECYCLE_INVARIANTS.length)
+	})
+
+	it('does not judge ordering on a recording that started late', () => {
+		const late = trace('attached-late', [conn(0, { connection: 'open' })], { fromSocketStart: false })
+		assert.equal(violationsOf(late).has('LC-001'), false)
+	})
+
+	it('waits out the deadline before calling a live socket silent', () => {
+		const live = trace('still-connecting', [connecting(0), authenticated(1)], { settled: false, observedUntil: 5_000 })
+		assert.equal(violationsOf(live).has('LC-004'), false)
+		const expired = { ...live, observedUntil: 60_000 }
+		assert.ok(violationsOf(expired).has('LC-004'))
+	})
+
+	it('does not blame the library for a socket the consumer put down first', () => {
+		// `sock.end()` publishes nothing by design, so this trace has the same
+		// shape as the engine going quiet. Only the recording knows who stopped.
+		const disposed = trace('ended-right-after-pairing', [connecting(0), authenticated(1)], {
+			settled: false,
+			observedUntil: 60_000,
+			consumerEndedAt: 100
+		})
+		assert.equal(violationsOf(disposed).has('LC-004'), false)
+	})
+
+	it('still blames the library when the socket stayed up past the deadline', () => {
+		const late = trace('quiet-then-disposed', [connecting(0), authenticated(1)], {
+			settled: false,
+			observedUntil: 60_000,
+			consumerEndedAt: 45_000
+		})
+		assert.ok(violationsOf(late).has('LC-004'))
+	})
+
+	it('rejects a trace whose clock runs backwards', () => {
+		const scrambled = trace('backwards', [connecting(5), connecting(1)])
+		assert.throws(() => evaluateLifecycle([scrambled]), /clock went backwards/)
+	})
+
+	it('normalizes the three states of the `qr` key', () => {
+		assert.equal(normalizeUpdate({ connection: 'open' }).qr, 'absent')
+		assert.equal(normalizeUpdate({ qr: undefined }).qr, 'cleared')
+		assert.equal(normalizeUpdate({ qr: '2@abc' }).qr, 'code')
+	})
+
+	it('reads the Boom status a close carries', () => {
+		const normalized = normalizeUpdate({
+			connection: 'close',
+			lastDisconnect: { error: new Boom('gone', { statusCode: DisconnectReason.loggedOut }), date: new Date() }
+		})
+		assert.equal(normalized.lastDisconnect, 'present')
+		assert.equal(normalized.lastDisconnectStatus, DisconnectReason.loggedOut)
+	})
+})
+
+describe('lifecycle contract scenarios', () => {
+	it('holds for every session the engine produces', () => {
+		const report = auditLifecycleScenarios()
+		assert.equal(report.summary.violated, 0, renderLifecycleReport(report, true))
+	})
+
+	it('exercises every invariant', () => {
+		assert.deepEqual(unexercisedInvariants(auditLifecycleScenarios()), [])
+	})
+
+	/**
+	 * The session that started all this: the engine pairs, the consumer is told
+	 * it paired, and no `Connected` ever follows. Upstream publishes `open` off
+	 * `<success>` with nothing in between (`Socket/socket.ts:1138`), so a socket
+	 * that authenticates and then goes quiet is a contract break, not a slow
+	 * connect.
+	 */
+	it('catches a pairing that never reaches `open`', () => {
+		const paired = runScenario({
+			label: 'pair-success-without-connected',
+			events: [
+				{ type: 'qr', data: { code: '2@abc', timeout: 60 } },
+				{
+					type: 'pair_success',
+					data: { id: '5511999999999@s.whatsapp.net', lid: '1@lid', business_name: '', platform: 'android' }
+				}
+			]
+		})
+		const report = evaluateLifecycle([paired])
+		const violated = report.findings.filter(finding => finding.status === 'violated').map(finding => finding.invariant)
+		assert.deepEqual(violated, ['LC-004'], renderLifecycleReport(report, true))
+	})
+
+	it('accepts the same pairing once `connected` arrives', () => {
+		const paired = runScenario({
+			label: 'pair-success-with-connected',
+			events: [
+				{ type: 'qr', data: { code: '2@abc', timeout: 60 } },
+				{
+					type: 'pair_success',
+					data: { id: '5511999999999@s.whatsapp.net', lid: '1@lid', business_name: '', platform: 'android' }
+				},
+				{ type: 'connected', data: {} }
+			]
+		})
+		assert.equal(evaluateLifecycle([paired]).summary.violated, 0)
+	})
+})
+
+describe('lifecycle contract CLI', () => {
+	it('passes on the built-in suite under --strict', () => {
+		assert.equal(runCli(['--strict']), 0)
+	})
+
+	it('fails on a recorded trace that breaks the contract', () => {
+		const folder = mkdtempSync(join(tmpdir(), 'lifecycle-contract-'))
+		try {
+			const file = join(folder, 'trace.json')
+			writeFileSync(file, JSON.stringify([VIOLATIONS[0]!.subject]))
+			assert.equal(runCli(['--trace', file, '--strict']), 1)
+		} finally {
+			rmSync(folder, { recursive: true, force: true })
+		}
+	})
+
+	it('rejects a non-positive deadline instead of judging with it', () => {
+		assert.throws(() => runCli(['--open-deadline', '0']), /--open-deadline/)
+	})
+})

--- a/scripts/compatibility/lifecycle-contract-audit.ts
+++ b/scripts/compatibility/lifecycle-contract-audit.ts
@@ -40,7 +40,7 @@ const readTraces = (file: string): LifecycleTrace[] => {
 	return parsed as LifecycleTrace[]
 }
 
-export const runCli = (argv: string[]): number => {
+export const runCli = async (argv: string[]): Promise<number> => {
 	let details = false
 	let strict = false
 	let traceFile: string | undefined
@@ -86,7 +86,7 @@ export const runCli = (argv: string[]): number => {
 	const options = { openDeadlineMs }
 	const report = traceFile
 		? evaluateLifecycle(readTraces(traceFile), options)
-		: auditLifecycleScenarios(undefined, options)
+		: await auditLifecycleScenarios(undefined, options)
 	process.stdout.write(`${renderLifecycleReport(report, details)}\n`)
 
 	if (!strict) return 0
@@ -98,7 +98,7 @@ export const runCli = (argv: string[]): number => {
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
 	try {
-		process.exitCode = runCli(process.argv.slice(2))
+		process.exitCode = await runCli(process.argv.slice(2))
 	} catch (error) {
 		process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
 		process.exitCode = 2

--- a/scripts/compatibility/lifecycle-contract-audit.ts
+++ b/scripts/compatibility/lifecycle-contract-audit.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+	auditLifecycleScenarios,
+	DEFAULT_LIFECYCLE_OPTIONS,
+	evaluateLifecycle,
+	lifecycleAuditFailed,
+	renderLifecycleReport,
+	unexercisedInvariants,
+	type LifecycleTrace
+} from './lifecycle-contract-core.ts'
+
+const usage = `Baileyrs lifecycle contract auditor
+
+Checks the order upstream Baileys promises on 'connection.update', which the
+declaration auditor cannot see: a socket that publishes nothing at all still
+matches every '.d.ts' shape. Runs the real dispatcher through the sessions the
+engine produces, or judges a trace recorded from a live socket.
+
+Usage:
+  node scripts/compatibility/lifecycle-contract-audit.ts [options]
+
+Options:
+  --trace <file>          Judge recorded traces (JSON array of LifecycleTrace)
+                          instead of the built-in scenarios
+  --open-deadline <ms>    Silence after authenticating that counts as evidence
+                          (default: ${DEFAULT_LIFECYCLE_OPTIONS.openDeadlineMs})
+  --details               List every trace, not just the violations
+  --strict                Exit 1 on a violation, and on an invariant no scenario
+                          exercised (coverage loss is silent otherwise)
+  --help                  Show this help
+`
+
+const readTraces = (file: string): LifecycleTrace[] => {
+	const parsed: unknown = JSON.parse(readFileSync(resolve(file), 'utf8'))
+	if (!Array.isArray(parsed)) throw new Error(`${file}: expected a JSON array of traces`)
+	return parsed as LifecycleTrace[]
+}
+
+export const runCli = (argv: string[]): number => {
+	let details = false
+	let strict = false
+	let traceFile: string | undefined
+	let openDeadlineMs = DEFAULT_LIFECYCLE_OPTIONS.openDeadlineMs
+
+	for (let index = 0; index < argv.length; index++) {
+		const option = argv[index]!
+		const inlineAt = option.indexOf('=')
+		const [name, inline] = inlineAt >= 0 ? [option.slice(0, inlineAt), option.slice(inlineAt + 1)] : [option, undefined]
+		const takeValue = () => {
+			if (inline !== undefined) return inline
+			const value = argv[index + 1]
+			if (!value || value.startsWith('--')) throw new Error(`${name} requires a value`)
+			index++
+			return value
+		}
+		switch (name) {
+			case '--help':
+			case '-h':
+				process.stdout.write(usage)
+				return 0
+			case '--details':
+				details = true
+				break
+			case '--strict':
+				strict = true
+				break
+			case '--trace':
+				traceFile = takeValue()
+				break
+			case '--open-deadline':
+				openDeadlineMs = Number(takeValue())
+				break
+			default:
+				throw new Error(`unknown option: ${option}`)
+		}
+	}
+
+	if (!Number.isInteger(openDeadlineMs) || openDeadlineMs <= 0) {
+		throw new Error('--open-deadline must be a positive integer')
+	}
+
+	const options = { openDeadlineMs }
+	const report = traceFile
+		? evaluateLifecycle(readTraces(traceFile), options)
+		: auditLifecycleScenarios(undefined, options)
+	process.stdout.write(`${renderLifecycleReport(report, details)}\n`)
+
+	if (!strict) return 0
+	if (lifecycleAuditFailed(report)) return 1
+	// Only for the built-in suite: a recorded trace is one session and is not
+	// expected to reach every state, but the scenarios are the coverage claim.
+	return !traceFile && unexercisedInvariants(report).length ? 1 : 0
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	try {
+		process.exitCode = runCli(process.argv.slice(2))
+	} catch (error) {
+		process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+		process.exitCode = 2
+	}
+}

--- a/scripts/compatibility/lifecycle-contract-core.ts
+++ b/scripts/compatibility/lifecycle-contract-core.ts
@@ -1,8 +1,13 @@
 import { EventEmitter } from 'node:events'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { makeWASocket } from '../../src/index.ts'
 import { makeEventHandlers } from '../../src/Socket/events.ts'
 import type { SocketContext } from '../../src/Socket/types.ts'
 import type { BaileysEventEmitter, BaileysEventMap, ConnectionState } from '../../src/Types/index.ts'
 import type { Boom } from '../../src/Utils/boom.ts'
+import { useMultiFileAuthState } from '../../src/Utils/use-multi-file-auth-state.ts'
 
 /**
  * Lifecycle contract auditor.
@@ -560,6 +565,11 @@ export const recordLifecycle = (
 // ─────────────────────────────────────────────────────────────────────────────
 
 const noopLogger = {
+	// `level` included because a real socket reads it. Without it `init()`
+	// throws before it queues the bootstrap update, and the failure is swallowed
+	// by the socket's own `initPromise.catch`, so the recording just comes back
+	// empty with nothing to say why.
+	level: 'silent',
 	trace() {},
 	debug() {},
 	info() {},
@@ -570,23 +580,23 @@ const noopLogger = {
 	}
 }
 
-/** The bootstrap update `makeWASocket` publishes before the client exists (`src/Socket/index.ts:462`). */
-const BOOTSTRAP_UPDATE: Partial<ConnectionState> = {
-	connection: 'connecting',
-	receivedPendingNotifications: false,
-	qr: undefined
-}
-
 export interface LifecycleScenario {
 	label: string
 	/** Bridge events, in the order the engine would dispatch them. */
 	events: readonly { type: string; data?: unknown }[]
-	/** Omit the socket's own bootstrap `connecting`, for scenarios about a late listener. */
-	skipBootstrap?: boolean
 	autoReconnect?: boolean
 }
 
 /**
+ * Run a scenario through the real dispatcher.
+ *
+ * `fromSocketStart` is false for all of them, and deliberately: a scenario
+ * starts at the dispatcher, which is downstream of the socket's own bootstrap
+ * update. Claiming otherwise would have LC-001 judging a `connecting` written
+ * here rather than the one `makeWASocket` publishes, and a fixture cannot
+ * regress with the implementation it stands in for. `recordBootstrap` covers
+ * that one against a real socket.
+ *
  * Every scenario ends `settled`: the dispatcher is synchronous, so once the
  * last bridge event has been handed over, nothing else can arrive. That is what
  * lets a missing `open` count as evidence here without waiting out a deadline.
@@ -622,14 +632,51 @@ export const runScenario = (scenario: LifecycleScenario): LifecycleTrace => {
 		isAutoReconnectEnabled: () => scenario.autoReconnect ?? true
 	})
 
-	if (!scenario.skipBootstrap) ev.emit('connection.update', BOOTSTRAP_UPDATE)
 	for (const event of scenario.events) {
 		clock += 1
 		handlers.onEvent?.(event as never)
 	}
 
 	const trace = recorder.stop()
-	return { ...trace, settled: true, fromSocketStart: !scenario.skipBootstrap }
+	return { ...trace, settled: true, fromSocketStart: false }
+}
+
+/**
+ * Record what a real socket publishes before it has a client at all.
+ *
+ * The one invariant a dispatcher scenario cannot cover: the bootstrap update is
+ * published from a microtask queued inside `makeWASocket` (`src/Socket/index.ts`),
+ * upstream of everything the dispatcher does. Standing in for it with a literal
+ * would leave LC-001 and LC-002 asserting a fixture, green forever even if the
+ * socket stopped publishing `connecting` first or dropped one of the fields
+ * that clears the previous QR.
+ *
+ * No server is involved: the socket is pointed at an unreachable port and torn
+ * down as soon as the update lands, which happens before any I/O is attempted.
+ */
+export const recordBootstrap = async (): Promise<LifecycleTrace> => {
+	const folder = await mkdtemp(join(tmpdir(), 'lifecycle-bootstrap-'))
+	try {
+		const { state } = await useMultiFileAuthState(folder)
+		const sock = makeWASocket({
+			auth: state,
+			// Reserved as "discard" and unreachable, so the socket cannot connect
+			// to anything a developer happens to be running.
+			waWebSocketUrl: 'wss://127.0.0.1:9/ws',
+			logger: noopLogger as never
+		})
+		const recorder = recordLifecycle(sock, { label: 'socket-bootstrap' })
+		// One macrotask: the update is queued as a microtask during construction,
+		// so it has already landed by the time this resolves.
+		await new Promise(resolve => setTimeout(resolve, 0))
+		recorder.noteConsumerEnd()
+		const trace = recorder.stop()
+		sock.setAutoReconnect(false)
+		await sock.end(undefined).catch(() => {})
+		return { ...trace, settled: true, fromSocketStart: true }
+	} finally {
+		await rm(folder, { recursive: true, force: true })
+	}
 }
 
 /**
@@ -720,7 +767,14 @@ function MESSAGE_FIXTURE() {
 	}
 }
 
-export const auditLifecycleScenarios = (
+/**
+ * The suite: the real bootstrap, then every dispatcher scenario.
+ *
+ * Async because the bootstrap is a real socket. It is the only invariant here
+ * that no dispatcher scenario can reach, and leaving it to a literal was the
+ * one place this auditor claimed coverage it did not have.
+ */
+export const auditLifecycleScenarios = async (
 	scenarios: readonly LifecycleScenario[] = LIFECYCLE_SCENARIOS,
 	options: LifecycleOptions = DEFAULT_LIFECYCLE_OPTIONS
-): LifecycleReport => evaluateLifecycle(scenarios.map(runScenario), options)
+): Promise<LifecycleReport> => evaluateLifecycle([await recordBootstrap(), ...scenarios.map(runScenario)], options)

--- a/scripts/compatibility/lifecycle-contract-core.ts
+++ b/scripts/compatibility/lifecycle-contract-core.ts
@@ -121,13 +121,46 @@ const holds = (detail?: string): CheckResult => ({ status: 'holds', detail })
 const violated = (detail: string): CheckResult => ({ status: 'violated', detail })
 const notExercised = (detail: string): CheckResult => ({ status: 'not-exercised', detail })
 
-const connectionUpdates = (trace: LifecycleTrace) =>
-	trace.events.filter((event): event is LifecycleEvent & { update: LifecycleUpdate } => event.update !== undefined)
+/**
+ * An event with the position it was recorded at.
+ *
+ * Order comes from the position, never from `at`: `Date.now()` has millisecond
+ * resolution and a socket publishes several events inside one, so a message
+ * emitted just before `open` shares its timestamp and would read as
+ * simultaneous. `at` still answers "how long", which is what the deadline in
+ * LC-004 needs; it just does not answer "before or after".
+ */
+type PositionedEvent = LifecycleEvent & { at_: number }
+type PositionedUpdate = PositionedEvent & { update: LifecycleUpdate }
 
-const statefulUpdates = (trace: LifecycleTrace) => connectionUpdates(trace).filter(event => event.update.connection)
+const positioned = (trace: LifecycleTrace): PositionedEvent[] =>
+	trace.events.map((event, index) => ({ ...event, at_: index }))
 
-const firstOpenAt = (trace: LifecycleTrace): number | undefined =>
-	statefulUpdates(trace).find(event => event.update.connection === 'open')?.at
+const connectionUpdates = (trace: LifecycleTrace): PositionedUpdate[] =>
+	positioned(trace).filter((event): event is PositionedUpdate => event.update !== undefined)
+
+const statefulUpdates = (trace: LifecycleTrace): PositionedUpdate[] =>
+	connectionUpdates(trace).filter(event => event.update.connection)
+
+const firstOpen = (trace: LifecycleTrace): PositionedUpdate | undefined =>
+	statefulUpdates(trace).find(event => event.update.connection === 'open')
+
+/**
+ * The connection state in effect when the event at `position` was published.
+ *
+ * The state a socket is in, not the state it once reached: after
+ * `open → connecting`, a socket is connecting, and something that may only
+ * happen while open may not happen there either. Comparing against the first
+ * `open` instead would let everything after a reconnect through.
+ */
+const stateAt = (trace: LifecycleTrace, position: number): LifecycleConnection | undefined => {
+	let state: LifecycleConnection | undefined
+	for (const event of statefulUpdates(trace)) {
+		if (event.at_ > position) break
+		state = event.update.connection
+	}
+	return state
+}
 
 /**
  * The contract, one entry per promise upstream makes.
@@ -195,11 +228,11 @@ export const LIFECYCLE_INVARIANTS: readonly LifecycleInvariant[] = [
 		title: 'a socket that authenticates reaches `open` or `close`',
 		upstream: 'Socket/socket.ts:1138',
 		check: (trace, options) => {
-			const authenticated = trace.events.find(event => event.authenticated === true)
+			const authenticated = positioned(trace).find(event => event.authenticated === true)
 			if (!authenticated) return notExercised('the socket did not authenticate during the recording')
 			const settledState = statefulUpdates(trace).find(
 				event =>
-					event.at >= authenticated.at && (event.update.connection === 'open' || event.update.connection === 'close')
+					event.at_ >= authenticated.at_ && (event.update.connection === 'open' || event.update.connection === 'close')
 			)
 			if (settledState) {
 				return holds(
@@ -280,15 +313,19 @@ export const LIFECYCLE_INVARIANTS: readonly LifecycleInvariant[] = [
 	},
 	{
 		id: 'LC-009',
-		title: 'pending notifications are only reported once the socket is open',
+		title: 'pending notifications are only reported while the socket is open',
 		upstream: 'Socket/socket.ts:1228',
 		check: trace => {
 			const targets = connectionUpdates(trace).filter(event => event.update.receivedPendingNotifications === true)
 			if (!targets.length) return notExercised('pending notifications were never reported')
-			const openAt = firstOpenAt(trace)
-			if (openAt === undefined) return violated('pending notifications were reported by a socket that never opened')
-			const early = targets.find(event => event.at < openAt)
-			return early ? violated(`reported at ${early.at}ms, before the socket opened at ${openAt}ms`) : holds()
+			// Judged against the state in effect, not against the first `open`
+			// ever seen: `open → connecting → reported` is a socket reporting an
+			// offline batch for a connection it is still re-establishing, and
+			// comparing with the first `open` would call that fine.
+			const stray = targets.find(event => stateAt(trace, event.at_) !== 'open')
+			return stray
+				? violated(`reported at ${stray.at}ms while the socket was \`${stateAt(trace, stray.at_) ?? 'in no state'}\``)
+				: holds(`${targets.length} checked`)
 		}
 	},
 	{
@@ -298,24 +335,32 @@ export const LIFECYCLE_INVARIANTS: readonly LifecycleInvariant[] = [
 		check: trace => {
 			const codes = connectionUpdates(trace).filter(event => event.update.qr === 'code')
 			if (!codes.length) return notExercised('no QR was published')
-			const openAt = firstOpenAt(trace)
-			if (openAt === undefined) return holds('QR published, socket never opened')
-			const late = codes.find(event => event.at > openAt)
-			return late ? violated(`QR published at ${late.at}ms, after the socket opened at ${openAt}ms`) : holds()
+			const open = firstOpen(trace)
+			// The premise is what happens *after* opening, so a session that
+			// only ever showed a QR has not exercised this. Reporting it as
+			// holding would let `--strict` keep claiming coverage even if every
+			// scenario regressed into a QR-only session.
+			if (!open) return notExercised('the socket never opened, so nothing followed an open')
+			const late = codes.find(event => event.at_ > open.at_)
+			return late ? violated(`QR published at ${late.at}ms, after the socket opened at ${open.at}ms`) : holds()
 		}
 	},
 	{
 		id: 'LC-011',
-		title: 'no message reaches the consumer before the socket opens',
+		title: 'no message reaches the consumer while the socket is not open',
 		upstream: 'Socket/socket.ts:1206',
 		check: trace => {
-			const upserts = trace.events.filter(event => event.name === 'messages.upsert')
+			const upserts = positioned(trace).filter(event => event.name === 'messages.upsert')
 			if (!upserts.length) return notExercised('no message was published')
-			const openAt = firstOpenAt(trace)
-			if (openAt === undefined)
-				return violated(`${upserts.length} message batches published by a socket that never opened`)
-			const early = upserts.find(event => event.at < openAt)
-			return early ? violated(`messages published at ${early.at}ms, before the socket opened at ${openAt}ms`) : holds()
+			// Same reasoning as LC-009: upstream buffers until the offline flush
+			// that follows `<success>`, so a consumer is never handed messages
+			// for a connection that is not up, first one or fifth.
+			const stray = upserts.find(event => stateAt(trace, event.at_) !== 'open')
+			return stray
+				? violated(
+						`messages published at ${stray.at}ms while the socket was \`${stateAt(trace, stray.at_) ?? 'in no state'}\``
+					)
+				: holds(`${upserts.length} checked`)
 		}
 	}
 ]
@@ -446,12 +491,27 @@ export interface RecordableSocket {
  */
 export const recordLifecycle = (
 	sock: RecordableSocket,
-	options: { label: string; fromSocketStart?: boolean; now?: () => number } = { label: 'live' }
+	options: {
+		label: string
+		fromSocketStart?: boolean
+		/**
+		 * The socket was already authenticated when the recording started.
+		 *
+		 * A socket resuming a stored session never publishes `creds.update`
+		 * merely because it is logged in, so without this LC-004 has no premise
+		 * and a resumed session that hangs without ever opening reports as
+		 * unexercised — which is the liveness regression, missed. Pass
+		 * `Boolean(sock.authState?.creds?.me?.id)` at construction.
+		 */
+		authenticatedAtStart?: boolean
+		now?: () => number
+	} = { label: 'live' }
 ): LifecycleRecorder => {
 	const now = options.now ?? (() => Date.now())
 	const start = now()
 	const events: LifecycleEvent[] = []
 	const at = () => now() - start
+	if (options.authenticatedAtStart) events.push({ at: 0, name: 'creds.update', authenticated: true })
 
 	const onConnection = (update: BaileysEventMap['connection.update']) => {
 		events.push({ at: at(), name: 'connection.update', update: normalizeUpdate(update) })

--- a/scripts/compatibility/lifecycle-contract-core.ts
+++ b/scripts/compatibility/lifecycle-contract-core.ts
@@ -1,0 +1,666 @@
+import { EventEmitter } from 'node:events'
+import { makeEventHandlers } from '../../src/Socket/events.ts'
+import type { SocketContext } from '../../src/Socket/types.ts'
+import type { BaileysEventEmitter, BaileysEventMap, ConnectionState } from '../../src/Types/index.ts'
+import type { Boom } from '../../src/Utils/boom.ts'
+
+/**
+ * Lifecycle contract auditor.
+ *
+ * The declaration auditor compares `.d.ts` shapes, so a socket that never
+ * publishes `connection.update` at all still scores 100% compatible: the event
+ * is declared, `ConnectionState.connection` still includes `'open'`, and every
+ * type matches. What upstream actually promises is not a shape but an order —
+ * `connecting` first, exactly one `open` once the session authenticates,
+ * `close` last and never followed by anything. This file states those promises
+ * as invariants over an observed trace and reports which ones a trace breaks.
+ *
+ * Every invariant cites where upstream guarantees it. A trace that does not
+ * exercise an invariant's premise reports `not-exercised` rather than passing,
+ * so a scenario suite that stops covering a state is visible instead of silently
+ * green.
+ */
+
+export type LifecycleConnection = 'open' | 'connecting' | 'close'
+
+/**
+ * A `connection.update` reduced to the facts the invariants judge.
+ *
+ * Normalized rather than kept raw because the distinction upstream relies on —
+ * `qr` present and cleared versus absent — does not survive JSON, and a trace
+ * has to be able to travel as a file. A consumer merging partial state keeps
+ * rendering the old QR when the key is absent, which is why the two cases are
+ * not interchangeable (`src/Socket/events.ts:270`).
+ */
+export interface LifecycleUpdate {
+	connection?: LifecycleConnection
+	/** `absent`: no `qr` key. `cleared`: key present, value undefined. `code`: a QR string. */
+	qr: 'absent' | 'cleared' | 'code'
+	receivedPendingNotifications?: boolean
+	lastDisconnect: 'absent' | 'present'
+	/** `lastDisconnect.error` Boom status code, when it carries one. */
+	lastDisconnectStatus?: number
+	isNewLogin?: boolean
+}
+
+export type LifecycleEventName = 'connection.update' | 'creds.update' | 'messages.upsert' | 'messaging-history.set'
+
+export interface LifecycleEvent {
+	/** Milliseconds from the start of the recording. Monotonic, never decreasing. */
+	at: number
+	name: LifecycleEventName
+	/** Present exactly when `name` is `connection.update`. */
+	update?: LifecycleUpdate
+	/** A `creds.update` carrying `me.id`: this socket has authenticated. */
+	authenticated?: boolean
+}
+
+export interface LifecycleTrace {
+	label: string
+	/**
+	 * The recording started when the socket was built. False disables the
+	 * invariants that judge what comes first, because a trace attached late
+	 * cannot distinguish a missing `connecting` from one it never saw.
+	 */
+	fromSocketStart: boolean
+	/**
+	 * The event source is exhausted: nothing else can arrive. True for a
+	 * synchronous dispatcher run, false for a live socket, where absence is
+	 * only evidence once the deadline has passed.
+	 */
+	settled: boolean
+	/** Last instant observed, on the same clock as `event.at`. */
+	observedUntil: number
+	/**
+	 * When the consumer disposed the socket, if it did.
+	 *
+	 * `sock.end()` publishes nothing, so a socket disposed right after pairing
+	 * leaves the same trace as one the engine never announced. Recording who
+	 * stopped it is what keeps the liveness invariant from blaming the library
+	 * for a consumer's own teardown.
+	 */
+	consumerEndedAt?: number
+	events: LifecycleEvent[]
+}
+
+export type LifecycleStatus = 'holds' | 'violated' | 'not-exercised'
+
+export interface LifecycleFinding {
+	invariant: string
+	trace: string
+	status: LifecycleStatus
+	detail?: string
+}
+
+export interface LifecycleReport {
+	findings: LifecycleFinding[]
+	summary: { traces: number; holds: number; violated: number; 'not-exercised': number }
+}
+
+export interface LifecycleOptions {
+	/**
+	 * How long after authenticating a live socket may stay silent before the
+	 * absence of `open` counts as evidence rather than as a short recording.
+	 */
+	openDeadlineMs: number
+}
+
+export const DEFAULT_LIFECYCLE_OPTIONS: LifecycleOptions = { openDeadlineMs: 30_000 }
+
+type CheckResult = { status: LifecycleStatus; detail?: string }
+
+export interface LifecycleInvariant {
+	id: string
+	title: string
+	/** Where upstream Baileys guarantees this, as `file:line`. */
+	upstream: string
+	check: (trace: LifecycleTrace, options: LifecycleOptions) => CheckResult
+}
+
+const holds = (detail?: string): CheckResult => ({ status: 'holds', detail })
+const violated = (detail: string): CheckResult => ({ status: 'violated', detail })
+const notExercised = (detail: string): CheckResult => ({ status: 'not-exercised', detail })
+
+const connectionUpdates = (trace: LifecycleTrace) =>
+	trace.events.filter((event): event is LifecycleEvent & { update: LifecycleUpdate } => event.update !== undefined)
+
+const statefulUpdates = (trace: LifecycleTrace) => connectionUpdates(trace).filter(event => event.update.connection)
+
+const firstOpenAt = (trace: LifecycleTrace): number | undefined =>
+	statefulUpdates(trace).find(event => event.update.connection === 'open')?.at
+
+/**
+ * The contract, one entry per promise upstream makes.
+ *
+ * Ordered as a session runs, not by importance: reading them top to bottom is
+ * meant to read as the life of a socket.
+ */
+export const LIFECYCLE_INVARIANTS: readonly LifecycleInvariant[] = [
+	{
+		id: 'LC-001',
+		title: 'the first connection state a socket publishes is `connecting`',
+		upstream: 'Socket/socket.ts:1214',
+		check: trace => {
+			if (!trace.fromSocketStart) return notExercised('recording did not start at socket construction')
+			const [first] = statefulUpdates(trace)
+			if (!first) return notExercised('no connection state was published')
+			return first.update.connection === 'connecting'
+				? holds()
+				: violated(`first published state was \`${first.update.connection}\``)
+		}
+	},
+	{
+		id: 'LC-002',
+		title: '`connecting` clears the QR and resets pending notifications',
+		upstream: 'Socket/socket.ts:1214',
+		check: trace => {
+			const targets = statefulUpdates(trace).filter(event => event.update.connection === 'connecting')
+			if (!targets.length) return notExercised('no `connecting` was published')
+			for (const event of targets) {
+				if (event.update.qr !== 'cleared') {
+					return violated(
+						`\`connecting\` at ${event.at}ms carries qr=${event.update.qr}, expected the key present and cleared`
+					)
+				}
+				if (event.update.receivedPendingNotifications !== false) {
+					return violated(
+						`\`connecting\` at ${event.at}ms carries receivedPendingNotifications=${event.update.receivedPendingNotifications}, expected false`
+					)
+				}
+			}
+			return holds(`${targets.length} checked`)
+		}
+	},
+	{
+		id: 'LC-003',
+		title: '`open` is not republished without leaving the state first',
+		upstream: 'Socket/socket.ts:1138',
+		check: trace => {
+			const states = statefulUpdates(trace)
+			if (!states.some(event => event.update.connection === 'open')) return notExercised('the socket never opened')
+			let open = false
+			for (const event of states) {
+				if (event.update.connection === 'open') {
+					if (open) return violated(`a second \`open\` at ${event.at}ms with no \`connecting\` or \`close\` in between`)
+					open = true
+					continue
+				}
+				open = false
+			}
+			return holds()
+		}
+	},
+	{
+		id: 'LC-004',
+		title: 'a socket that authenticates reaches `open` or `close`',
+		upstream: 'Socket/socket.ts:1138',
+		check: (trace, options) => {
+			const authenticated = trace.events.find(event => event.authenticated === true)
+			if (!authenticated) return notExercised('the socket did not authenticate during the recording')
+			const settledState = statefulUpdates(trace).find(
+				event =>
+					event.at >= authenticated.at && (event.update.connection === 'open' || event.update.connection === 'close')
+			)
+			if (settledState) {
+				return holds(
+					`\`${settledState.update.connection}\` ${settledState.at - authenticated.at}ms after authenticating`
+				)
+			}
+			const silentFor = trace.observedUntil - authenticated.at
+			if (trace.settled)
+				return violated(
+					`authenticated at ${authenticated.at}ms and the event source ended with no \`open\` and no \`close\``
+				)
+			// `sock.end()` publishes nothing by design, so a consumer that
+			// disposes a socket right after pairing produces the same shape as
+			// the engine going quiet. The difference is who stopped it, and only
+			// the recording knows.
+			if (trace.consumerEndedAt !== undefined && trace.consumerEndedAt - authenticated.at < options.openDeadlineMs) {
+				return notExercised(
+					`the consumer ended the socket ${trace.consumerEndedAt - authenticated.at}ms after authenticating, before the deadline`
+				)
+			}
+			if (silentFor >= options.openDeadlineMs) {
+				return violated(`authenticated at ${authenticated.at}ms and stayed silent for ${silentFor}ms`)
+			}
+			return notExercised(
+				`only observed ${silentFor}ms after authenticating, below the ${options.openDeadlineMs}ms deadline`
+			)
+		}
+	},
+	{
+		id: 'LC-005',
+		title: '`close` is terminal: no connection state follows it',
+		upstream: 'Socket/socket.ts:829',
+		check: trace => {
+			const updates = connectionUpdates(trace)
+			const closeIndex = updates.findIndex(event => event.update.connection === 'close')
+			if (closeIndex < 0) return notExercised('the socket never closed')
+			const after = updates[closeIndex + 1]
+			return after ? violated(`a \`connection.update\` at ${after.at}ms follows the close`) : holds()
+		}
+	},
+	{
+		id: 'LC-006',
+		title: 'a socket closes at most once',
+		upstream: 'Socket/socket.ts:790',
+		check: trace => {
+			const closes = statefulUpdates(trace).filter(event => event.update.connection === 'close')
+			if (!closes.length) return notExercised('the socket never closed')
+			return closes.length === 1 ? holds() : violated(`${closes.length} closes published`)
+		}
+	},
+	{
+		id: 'LC-007',
+		title: '`lastDisconnect` rides only on `close`',
+		upstream: 'Socket/socket.ts:824',
+		check: trace => {
+			const carriers = connectionUpdates(trace).filter(event => event.update.lastDisconnect === 'present')
+			if (!carriers.length) return notExercised('no update carried `lastDisconnect`')
+			const stray = carriers.find(event => event.update.connection !== 'close')
+			return stray
+				? violated(
+						`update at ${stray.at}ms carries \`lastDisconnect\` with connection=\`${stray.update.connection ?? 'none'}\``
+					)
+				: holds(`${carriers.length} checked`)
+		}
+	},
+	{
+		id: 'LC-008',
+		title: '`close` carries a Boom status a reconnect handler can branch on',
+		upstream: 'Socket/socket.ts:824',
+		check: trace => {
+			const closes = statefulUpdates(trace).filter(event => event.update.connection === 'close')
+			if (!closes.length) return notExercised('the socket never closed')
+			const bare = closes.find(
+				event => event.update.lastDisconnect !== 'present' || event.update.lastDisconnectStatus === undefined
+			)
+			return bare ? violated(`close at ${bare.at}ms carries no Boom status code`) : holds()
+		}
+	},
+	{
+		id: 'LC-009',
+		title: 'pending notifications are only reported once the socket is open',
+		upstream: 'Socket/socket.ts:1228',
+		check: trace => {
+			const targets = connectionUpdates(trace).filter(event => event.update.receivedPendingNotifications === true)
+			if (!targets.length) return notExercised('pending notifications were never reported')
+			const openAt = firstOpenAt(trace)
+			if (openAt === undefined) return violated('pending notifications were reported by a socket that never opened')
+			const early = targets.find(event => event.at < openAt)
+			return early ? violated(`reported at ${early.at}ms, before the socket opened at ${openAt}ms`) : holds()
+		}
+	},
+	{
+		id: 'LC-010',
+		title: 'no QR is published once the socket has opened',
+		upstream: 'Socket/socket.ts:1090',
+		check: trace => {
+			const codes = connectionUpdates(trace).filter(event => event.update.qr === 'code')
+			if (!codes.length) return notExercised('no QR was published')
+			const openAt = firstOpenAt(trace)
+			if (openAt === undefined) return holds('QR published, socket never opened')
+			const late = codes.find(event => event.at > openAt)
+			return late ? violated(`QR published at ${late.at}ms, after the socket opened at ${openAt}ms`) : holds()
+		}
+	},
+	{
+		id: 'LC-011',
+		title: 'no message reaches the consumer before the socket opens',
+		upstream: 'Socket/socket.ts:1206',
+		check: trace => {
+			const upserts = trace.events.filter(event => event.name === 'messages.upsert')
+			if (!upserts.length) return notExercised('no message was published')
+			const openAt = firstOpenAt(trace)
+			if (openAt === undefined)
+				return violated(`${upserts.length} message batches published by a socket that never opened`)
+			const early = upserts.find(event => event.at < openAt)
+			return early ? violated(`messages published at ${early.at}ms, before the socket opened at ${openAt}ms`) : holds()
+		}
+	}
+]
+
+export const evaluateLifecycle = (
+	traces: readonly LifecycleTrace[],
+	options: LifecycleOptions = DEFAULT_LIFECYCLE_OPTIONS
+): LifecycleReport => {
+	const findings: LifecycleFinding[] = []
+	const summary: LifecycleReport['summary'] = { traces: traces.length, holds: 0, violated: 0, 'not-exercised': 0 }
+	for (const trace of traces) {
+		assertMonotonic(trace)
+		for (const invariant of LIFECYCLE_INVARIANTS) {
+			const result = invariant.check(trace, options)
+			findings.push({ invariant: invariant.id, trace: trace.label, status: result.status, detail: result.detail })
+			summary[result.status] += 1
+		}
+	}
+	return { findings, summary }
+}
+
+/**
+ * A trace whose clock runs backwards would make every ordering invariant
+ * meaningless, and silently so. Rejected at the door rather than judged.
+ */
+const assertMonotonic = (trace: LifecycleTrace) => {
+	let previous = Number.NEGATIVE_INFINITY
+	for (const event of trace.events) {
+		if (event.at < previous) throw new Error(`${trace.label}: trace clock went backwards at ${event.at}ms`)
+		previous = event.at
+	}
+	if (trace.observedUntil < previous) {
+		throw new Error(`${trace.label}: observedUntil (${trace.observedUntil}ms) precedes the last event (${previous}ms)`)
+	}
+}
+
+export const lifecycleAuditFailed = (report: LifecycleReport): boolean => report.summary.violated > 0
+
+/**
+ * An invariant no trace exercised is a coverage hole, not a pass: the suite
+ * stopped reaching a state the contract still promises something about.
+ */
+export const unexercisedInvariants = (report: LifecycleReport): string[] => {
+	const exercised = new Set(
+		report.findings.filter(finding => finding.status !== 'not-exercised').map(finding => finding.invariant)
+	)
+	return LIFECYCLE_INVARIANTS.filter(invariant => !exercised.has(invariant.id)).map(invariant => invariant.id)
+}
+
+export const renderLifecycleReport = (report: LifecycleReport, details: boolean): string => {
+	const lines: string[] = []
+	const byInvariant = new Map<string, LifecycleFinding[]>()
+	for (const finding of report.findings) {
+		const bucket = byInvariant.get(finding.invariant)
+		if (bucket) bucket.push(finding)
+		else byInvariant.set(finding.invariant, [finding])
+	}
+
+	lines.push(`Lifecycle contract: ${report.summary.traces} trace(s), ${LIFECYCLE_INVARIANTS.length} invariant(s)`)
+	lines.push('')
+	for (const invariant of LIFECYCLE_INVARIANTS) {
+		const bucket = byInvariant.get(invariant.id) ?? []
+		const violations = bucket.filter(finding => finding.status === 'violated')
+		const passes = bucket.filter(finding => finding.status === 'holds')
+		const mark = violations.length ? 'FAIL' : passes.length ? 'ok  ' : '--  '
+		lines.push(`${mark} ${invariant.id}  ${invariant.title}  (upstream ${invariant.upstream})`)
+		for (const violation of violations) {
+			lines.push(`       ${violation.trace}: ${violation.detail}`)
+		}
+		if (details) {
+			for (const finding of bucket.filter(entry => entry.status !== 'violated')) {
+				lines.push(
+					`       ${finding.status === 'holds' ? '·' : '~'} ${finding.trace}: ${finding.detail ?? ''}`.trimEnd()
+				)
+			}
+		}
+	}
+	lines.push('')
+	lines.push(
+		`holds ${report.summary.holds} · violated ${report.summary.violated} · not exercised ${report.summary['not-exercised']}`
+	)
+	const uncovered = unexercisedInvariants(report)
+	if (uncovered.length) lines.push(`no trace exercised: ${uncovered.join(', ')}`)
+	return lines.join('\n')
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Recording — the only place that knows what a raw `connection.update` looks
+// like. Everything above judges the normalized form.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const normalizeUpdate = (update: Partial<ConnectionState>): LifecycleUpdate => {
+	const hasQrKey = Object.prototype.hasOwnProperty.call(update, 'qr')
+	const status = (update.lastDisconnect?.error as Boom | undefined)?.output?.statusCode
+	return {
+		connection: update.connection,
+		qr: !hasQrKey ? 'absent' : typeof update.qr === 'string' ? 'code' : 'cleared',
+		receivedPendingNotifications: update.receivedPendingNotifications,
+		lastDisconnect: update.lastDisconnect ? 'present' : 'absent',
+		lastDisconnectStatus: typeof status === 'number' ? status : undefined,
+		isNewLogin: update.isNewLogin
+	}
+}
+
+export interface LifecycleRecorder {
+	/**
+	 * Mark the moment the consumer disposed the socket.
+	 *
+	 * Call it around `sock.end()` / `sock.logout()`. Without it, a socket the
+	 * consumer put down before it ever opened is indistinguishable from one the
+	 * library left hanging.
+	 */
+	noteConsumerEnd: () => void
+	/** Stop listening and return what was observed. */
+	stop: () => LifecycleTrace
+}
+
+/** Anything with the Baileys event bus on it: the real socket, or a bare emitter in a scenario. */
+export interface RecordableSocket {
+	ev: Pick<BaileysEventEmitter, 'on' | 'off'>
+}
+
+/**
+ * Record a live socket's lifecycle.
+ *
+ * `now` is injectable so a test can drive the clock instead of sleeping, and so
+ * the recorder itself has no dependency on wall time being the interesting one.
+ */
+export const recordLifecycle = (
+	sock: RecordableSocket,
+	options: { label: string; fromSocketStart?: boolean; now?: () => number } = { label: 'live' }
+): LifecycleRecorder => {
+	const now = options.now ?? (() => Date.now())
+	const start = now()
+	const events: LifecycleEvent[] = []
+	const at = () => now() - start
+
+	const onConnection = (update: BaileysEventMap['connection.update']) => {
+		events.push({ at: at(), name: 'connection.update', update: normalizeUpdate(update) })
+	}
+	// `me.id` is what upstream's own creds carry once a session exists, so it is
+	// the same signal here whether the socket paired now or loaded from disk.
+	const onCreds = (creds: BaileysEventMap['creds.update']) => {
+		events.push({ at: at(), name: 'creds.update', authenticated: typeof creds?.me?.id === 'string' })
+	}
+	const onUpsert = () => {
+		events.push({ at: at(), name: 'messages.upsert' })
+	}
+	const onHistory = () => {
+		events.push({ at: at(), name: 'messaging-history.set' })
+	}
+
+	sock.ev.on('connection.update', onConnection)
+	sock.ev.on('creds.update', onCreds)
+	sock.ev.on('messages.upsert', onUpsert)
+	sock.ev.on('messaging-history.set', onHistory)
+
+	let consumerEndedAt: number | undefined
+	return {
+		noteConsumerEnd: () => {
+			consumerEndedAt ??= at()
+		},
+		stop: () => {
+			sock.ev.off('connection.update', onConnection)
+			sock.ev.off('creds.update', onCreds)
+			sock.ev.off('messages.upsert', onUpsert)
+			sock.ev.off('messaging-history.set', onHistory)
+			return {
+				label: options.label,
+				fromSocketStart: options.fromSocketStart ?? true,
+				settled: false,
+				observedUntil: at(),
+				consumerEndedAt,
+				events
+			}
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Offline scenarios — the real dispatcher, driven by bridge events.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const noopLogger = {
+	trace() {},
+	debug() {},
+	info() {},
+	warn() {},
+	error() {},
+	child() {
+		return noopLogger
+	}
+}
+
+/** The bootstrap update `makeWASocket` publishes before the client exists (`src/Socket/index.ts:462`). */
+const BOOTSTRAP_UPDATE: Partial<ConnectionState> = {
+	connection: 'connecting',
+	receivedPendingNotifications: false,
+	qr: undefined
+}
+
+export interface LifecycleScenario {
+	label: string
+	/** Bridge events, in the order the engine would dispatch them. */
+	events: readonly { type: string; data?: unknown }[]
+	/** Omit the socket's own bootstrap `connecting`, for scenarios about a late listener. */
+	skipBootstrap?: boolean
+	autoReconnect?: boolean
+}
+
+/**
+ * Every scenario ends `settled`: the dispatcher is synchronous, so once the
+ * last bridge event has been handed over, nothing else can arrive. That is what
+ * lets a missing `open` count as evidence here without waiting out a deadline.
+ */
+export const runScenario = (scenario: LifecycleScenario): LifecycleTrace => {
+	const ev = new EventEmitter()
+	const ws = new EventEmitter()
+	const ctx: SocketContext = {
+		ev: ev as unknown as SocketContext['ev'],
+		logger: noopLogger as never,
+		fullConfig: {} as never,
+		ws,
+		getUser: () => undefined,
+		getMe: () => undefined,
+		setUser: () => {},
+		reportUnexpectedError: () => {},
+		getClient: () => Promise.reject(new Error('not used')),
+		getClientSync: () => {
+			throw new Error('not used')
+		}
+	}
+
+	let clock = 0
+	const recorder = recordLifecycle({ ev } as unknown as RecordableSocket, {
+		label: scenario.label,
+		now: () => clock
+	})
+
+	const handlers = makeEventHandlers(ctx, {
+		// The socket wires this to `end(...).finally(publish)`; here the teardown
+		// has already finished, so the close goes out immediately.
+		onTerminalClose: (_error, publish) => publish(),
+		isAutoReconnectEnabled: () => scenario.autoReconnect ?? true
+	})
+
+	if (!scenario.skipBootstrap) ev.emit('connection.update', BOOTSTRAP_UPDATE)
+	for (const event of scenario.events) {
+		clock += 1
+		handlers.onEvent?.(event as never)
+	}
+
+	const trace = recorder.stop()
+	return { ...trace, settled: true, fromSocketStart: !scenario.skipBootstrap }
+}
+
+/**
+ * The sessions the contract has to hold for. Each one is a shape the engine
+ * really produces; together they have to exercise every invariant, which
+ * `unexercisedInvariants` turns into a failure when they stop doing so.
+ */
+export const LIFECYCLE_SCENARIOS: readonly LifecycleScenario[] = [
+	{
+		label: 'fresh-pair',
+		events: [
+			{ type: 'qr', data: { code: '2@abc', timeout: 60 } },
+			{
+				type: 'pair_success',
+				data: { id: '5511999999999@s.whatsapp.net', lid: '1@lid', business_name: '', platform: 'android' }
+			},
+			{ type: 'connected', data: {} },
+			{ type: 'offline_sync_completed', data: { count: 3 } },
+			{ type: 'message', data: MESSAGE_FIXTURE() }
+		]
+	},
+	{
+		label: 'transient-drop',
+		events: [
+			{ type: 'connected', data: {} },
+			{ type: 'disconnected', data: {} },
+			{ type: 'connected', data: {} },
+			{ type: 'offline_sync_completed', data: { count: 0 } }
+		]
+	},
+	{
+		label: 'connect-failure-retryable',
+		events: [
+			{ type: 'connected', data: {} },
+			{ type: 'connect_failure', data: { reason: 503, message: 'service unavailable' } },
+			{ type: 'connected', data: {} }
+		]
+	},
+	{
+		label: 'pair-error-then-new-qr',
+		events: [
+			{ type: 'qr', data: { code: '2@abc', timeout: 60 } },
+			{ type: 'pair_error', data: { id: '', lid: '', business_name: '', platform: '', error: 'bad signature' } },
+			{ type: 'qr', data: { code: '2@def', timeout: 60 } }
+		]
+	},
+	{
+		label: 'logged-out',
+		events: [
+			{ type: 'connected', data: {} },
+			{ type: 'logged_out', data: { on_connect: false, reason: 'main device removed the session' } }
+		]
+	},
+	{
+		label: 'stream-replaced',
+		events: [
+			{ type: 'connected', data: {} },
+			{ type: 'stream_replaced', data: {} }
+		]
+	},
+	{
+		label: 'auto-reconnect-disabled-drop',
+		autoReconnect: false,
+		events: [
+			{ type: 'connected', data: {} },
+			{ type: 'disconnected', data: {} }
+		]
+	}
+]
+
+/**
+ * Minimal message the dispatcher accepts, so `LC-011` has something to order
+ * against `open`. Built as a function so no scenario can mutate a shared one.
+ */
+function MESSAGE_FIXTURE() {
+	return {
+		message: { conversation: 'hi' },
+		info: {
+			id: 'BAE5F0000000000A',
+			timestamp: 1,
+			push_name: 'tester',
+			source: {
+				chat: { user: '5511999999999', server: 's.whatsapp.net', agent: 0, device: 0, integrator: 0 },
+				is_group: false,
+				is_from_me: false
+			}
+		}
+	}
+}
+
+export const auditLifecycleScenarios = (
+	scenarios: readonly LifecycleScenario[] = LIFECYCLE_SCENARIOS,
+	options: LifecycleOptions = DEFAULT_LIFECYCLE_OPTIONS
+): LifecycleReport => evaluateLifecycle(scenarios.map(runScenario), options)

--- a/src/__tests__/e2e/presence.test-e2e.ts
+++ b/src/__tests__/e2e/presence.test-e2e.ts
@@ -23,6 +23,26 @@ import { waitForEvent } from './wait.ts'
 
 const logger = P({ level: process.env.LOG_LEVEL ?? 'warn' })
 
+/**
+ * Which key a presence for Alice arrives under.
+ *
+ * Both, depending on how the server addressed the push: WA Web's
+ * `validateLidUserJid` rejects a `<presence>` that is not addressed by LID, so
+ * a server following that sends the LID, while chat state still carries the
+ * phone number. Neither library resolves one to the other — upstream keys the
+ * event on `attrs.from` as it arrives (`Socket/chats.ts:944`) and so do we
+ * (`src/Socket/events.ts:621`) — so the test has to accept either. Pinning one
+ * of them made these tests fail against a mock that had moved to the other,
+ * which is a fact about the mock's addressing, not about presence propagating.
+ */
+const presenceOf = (update: { presences: Record<string, { lastKnownPresence?: string }> }, client: TestClient) => {
+	const keys = [jidNormalizedUser(client.jid), client.lid ? jidNormalizedUser(client.lid) : undefined]
+	for (const key of keys) {
+		if (key && update.presences[key]) return update.presences[key]
+	}
+	return undefined
+}
+
 describe('E2E: Presence + chat state', { timeout: 60_000 }, () => {
 	let alice: TestClient
 	let bob: TestClient
@@ -42,62 +62,41 @@ describe('E2E: Presence + chat state', { timeout: 60_000 }, () => {
 	})
 
 	test("composing: Alice sends 'composing' → Bob sees presence.update with composing", async () => {
-		const aliceUser = jidNormalizedUser(alice.jid)
-		const seen = waitForEvent(
-			bob.sock,
-			'presence.update',
-			u => !!u.presences[aliceUser] && u.presences[aliceUser]!.lastKnownPresence === 'composing'
-		)
+		const seen = waitForEvent(bob.sock, 'presence.update', u => presenceOf(u, alice)?.lastKnownPresence === 'composing')
 		await alice.sock.sendPresenceUpdate('composing', bob.jid)
 		const evt = await seen
-		expect(evt.presences[aliceUser]!.lastKnownPresence).toBe('composing')
+		expect(presenceOf(evt, alice)?.lastKnownPresence).toBe('composing')
 	})
 
 	test("recording: Alice sends 'recording' → Bob sees presence.update with recording (regression: composing+media=audio collapse)", async () => {
-		const aliceUser = jidNormalizedUser(alice.jid)
-		const seen = waitForEvent(
-			bob.sock,
-			'presence.update',
-			u => !!u.presences[aliceUser] && u.presences[aliceUser]!.lastKnownPresence === 'recording'
-		)
+		const seen = waitForEvent(bob.sock, 'presence.update', u => presenceOf(u, alice)?.lastKnownPresence === 'recording')
 		await alice.sock.sendPresenceUpdate('recording', bob.jid)
 		const evt = await seen
-		expect(evt.presences[aliceUser]!.lastKnownPresence).toBe('recording')
+		expect(presenceOf(evt, alice)?.lastKnownPresence).toBe('recording')
 	})
 
 	test("paused: Alice sends 'paused' → Bob sees presence.update with paused", async () => {
-		const aliceUser = jidNormalizedUser(alice.jid)
-		const seen = waitForEvent(
-			bob.sock,
-			'presence.update',
-			u => !!u.presences[aliceUser] && u.presences[aliceUser]!.lastKnownPresence === 'paused'
-		)
+		const seen = waitForEvent(bob.sock, 'presence.update', u => presenceOf(u, alice)?.lastKnownPresence === 'paused')
 		await alice.sock.sendPresenceUpdate('paused', bob.jid)
 		const evt = await seen
-		expect(evt.presences[aliceUser]!.lastKnownPresence).toBe('paused')
+		expect(presenceOf(evt, alice)?.lastKnownPresence).toBe('paused')
 	})
 
 	test("available: Alice sends global 'available' → Bob sees presence.update with available", async () => {
-		const aliceUser = jidNormalizedUser(alice.jid)
-		const seen = waitForEvent(
-			bob.sock,
-			'presence.update',
-			u => !!u.presences[aliceUser] && u.presences[aliceUser]!.lastKnownPresence === 'available'
-		)
+		const seen = waitForEvent(bob.sock, 'presence.update', u => presenceOf(u, alice)?.lastKnownPresence === 'available')
 		await alice.sock.sendPresenceUpdate('available')
 		const evt = await seen
-		expect(evt.presences[aliceUser]!.lastKnownPresence).toBe('available')
+		expect(presenceOf(evt, alice)?.lastKnownPresence).toBe('available')
 	})
 
 	test("unavailable: Alice sends global 'unavailable' → Bob sees presence.update with unavailable", async () => {
-		const aliceUser = jidNormalizedUser(alice.jid)
 		const seen = waitForEvent(
 			bob.sock,
 			'presence.update',
-			u => !!u.presences[aliceUser] && u.presences[aliceUser]!.lastKnownPresence === 'unavailable'
+			u => presenceOf(u, alice)?.lastKnownPresence === 'unavailable'
 		)
 		await alice.sock.sendPresenceUpdate('unavailable')
 		const evt = await seen
-		expect(evt.presences[aliceUser]!.lastKnownPresence).toBe('unavailable')
+		expect(presenceOf(evt, alice)?.lastKnownPresence).toBe('unavailable')
 	})
 })

--- a/src/__tests__/e2e/test-client.ts
+++ b/src/__tests__/e2e/test-client.ts
@@ -36,6 +36,15 @@ export interface CreateTestClientOptions {
 	connectTimeoutMs?: number
 	/** Pre-existing auth folder (rarely needed here; handoff uses its own factory). */
 	authFolder?: string
+	/**
+	 * Called with the socket before anything is attached to it.
+	 *
+	 * The bootstrap `connecting` is published from a microtask queued during
+	 * `makeWASocket`, so a listener attached after this factory returns has
+	 * already missed it. Anything judging the lifecycle from its first event
+	 * has to get in here.
+	 */
+	onSocket?: (sock: WASocket) => void
 }
 
 export interface TestClient {
@@ -64,6 +73,7 @@ export async function createTestClient(opts: CreateTestClientOptions): Promise<T
 		logger: defaultLogger.child({ user: opts.label })
 	})
 
+	opts.onSocket?.(sock)
 	attachQrAutoresponder(sock, url)
 	const startupSync = waitForEvent(
 		sock,


### PR DESCRIPTION
## Summary

The declaration auditor compares `.d.ts` shapes, so a socket that never publishes `connection.update` at all scores 100% compatible: the event is declared, `ConnectionState.connection` still includes `'open'`, every type matches. What upstream promises on that channel is not a shape but an order, and nothing checked it.

This came out of a user report that `connection: 'open'` never arrives on a first pairing. That defect is in the engine — it withholds `Connected` until the critical app state sync closes, and two of the four outcomes it can get returned in silence — but what let it reach a release is that no check here could see it. This is that check.

## The contract

Eleven invariants, each citing the upstream line that guarantees it:

| | invariant | upstream |
|---|---|---|
| LC-001 | the first connection state is `connecting` | `Socket/socket.ts:1214` |
| LC-002 | `connecting` clears the QR and resets pending notifications | `socket.ts:1214` |
| LC-003 | `open` is not republished without leaving the state | `socket.ts:1138` |
| LC-004 | a socket that authenticates reaches `open` or `close` | `socket.ts:1138` |
| LC-005 | `close` is terminal | `socket.ts:829` |
| LC-006 | a socket closes at most once | `socket.ts:790` |
| LC-007 | `lastDisconnect` rides only on `close` | `socket.ts:824` |
| LC-008 | `close` carries a Boom status | `socket.ts:824` |
| LC-009 | pending notifications only once open | `socket.ts:1228` |
| LC-010 | no QR after `open` | `socket.ts:1090` |
| LC-011 | no message before `open` | `socket.ts:1206` |

Three outcomes, not two: an invariant whose premise a trace never exercises reports `not-exercised` rather than passing, and `--strict` fails the built-in suite when one goes uncovered. A suite that stops reaching a state is then visible instead of silently green.

## Two sources

- **Offline scenarios** drive the real dispatcher with the bridge events the engine produces (fresh pair, transient drop, retryable connect failure, pair error, logout, stream replaced, auto-reconnect disabled). Runs under `npm test`; also `npm run compat:audit:lifecycle`.
- **A live recording** judges a real session against the mock server, under `npm run test:e2e`. It lives next to the tooling rather than in `src/__tests__/e2e/` because `src` never imports from `scripts`, only the reverse; the e2e glob covers both directories now.

Recording a live socket needs to start at construction — the bootstrap `connecting` is published from a microtask queued inside `makeWASocket` — hence the `onSocket` hook on `createTestClient`.

## Known violations, pinned

The live run reports two, both real:

```
LC-009  pending notifications reported at 78ms, socket opened at 470ms
LC-011  messages published at 443ms, socket opened at 470ms
```

Same origin: the engine leaves passive mode (`client/node_io.rs:1221`) well before it dispatches `Connected` (`node_io.rs:1467`), so everything that follows reaches the consumer while this socket still reads as `connecting`. Upstream has no such gap — `open` goes out on `<success>`, before the offline batch it later flushes. `LC-011` has a second cause on our side: upstream buffers from `process.nextTick` and flushes on `CB:ib,,offline`, and this socket never calls `ev.buffer()`.

They are pinned rather than silenced. The assertion fails on a third violation, and also on a pinned one that starts holding, so the entry cannot outlive the fix. Neither is addressed here: changing when events are published is a behaviour change for every consumer and belongs in its own PR.

## Also here

The two global presence e2e tests were failing locally while passing in CI. Not a library defect: the mock addresses a global presence push by LID, following WA Web's `validateLidUserJid`, and the image CI pins predates that change. Neither upstream nor we resolve one form to the other — both key the event on `attrs.from` as it arrives — so the test now accepts either. Without it those two would have broken CI on the next mock bump, with nothing in this repo having changed.

## Validation

- `npm test` — includes the 30 auditor tests.
- `npm run test:e2e` — 83 passing against the live mock server, including the new live recording.
- `npm run compat:audit:lifecycle` — clean, all eleven invariants exercised.
- `tsc` (both projects), `oxlint`, `oxfmt` clean.

The auditor's own tests are what make it worth having: a conforming session that exercises all eleven and reports nothing, one trace per invariant that breaks exactly that promise and asserts **nothing else** is reported, a test that fails if an invariant ships without a failing case, and cases for the two ways a liveness check produces false positives — a recording that started late, and a socket the consumer put down before the deadline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lifecycle contract auditor to verify the order of connection events and catch issues type checks miss. Now records the real socket bootstrap to validate the first `connecting` and QR reset, and hardens the live e2e recorder and teardown.

- New Features
  - Lifecycle contract auditor with 11 invariants (connecting first, open after auth, close terminal, no messages before open).
  - Records the real bootstrap from `makeWASocket` to cover LC-001/LC-002; dispatcher scenarios no longer claim socket-start coverage.
  - Robust judging: order by trace position; LC-009/LC-011 judge state-in-effect; LC-010 unexercised if no open; recorder supports `authenticatedAtStart`.
  - Offline scenarios run in `npm test`; live recording in `npm run test:e2e` with an early `onSocket` hook. CLI: `npm run compat:audit:lifecycle` (`--strict`, `--details`, `--open-deadline`).
  - Pins current engine violations `LC-009` and `LC-011`; new or “fixed” violations fail the suite.

- Bug Fixes
  - Presence e2e tests accept either LID or user JIDs to avoid mock-specific flakiness.
  - Live lifecycle e2e no longer leaks: owns the socket/auth folder, disables auto-reconnect, and cleans up reliably.

<sup>Written for commit 8210dc1fd023c2a2fcc6e00bbb64a9add2e7842e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

