### PR TITLE
fix(bridge): read the payload shapes the bridge actually sends

### DIFF
--- a/src/Bridge/__tests__/payload-shapes.test.ts
+++ b/src/Bridge/__tests__/payload-shapes.test.ts
@@ -99,6 +99,22 @@ describe('bridge payload shapes', () => {
 			}
 		})
 
+		it('refuses the 24:00 rollover, which RFC 3339 does not allow', () => {
+			// `Date.parse('2023-11-14T24:00:00Z')` is midnight on the 15th, so this
+			// is the other component that moves the instant to another day.
+			const rollover = adapt({
+				type: 'presence',
+				data: { from: JID, unavailable: false, last_seen: '2023-11-14T24:00:00Z' }
+			})
+			expect((rollover as { lastSeen?: number }).lastSeen).toBeUndefined()
+			// The last instant the hour does allow still parses.
+			const last = adapt({
+				type: 'presence',
+				data: { from: JID, unavailable: false, last_seen: '2023-11-14T23:59:59Z' }
+			})
+			expect(typeof (last as { lastSeen?: number }).lastSeen).toBe('number')
+		})
+
 		it('keeps the leap days that do exist, centuries included', () => {
 			// 2000 is a leap year and 1900 is not, which is the rule a plain
 			// `year % 4` check gets wrong.
@@ -228,6 +244,21 @@ describe('bridge payload shapes', () => {
 			const check = expectedDeadline()
 			const plain = adapt({ type: 'temporary_ban', data: { code: 101, expire: HOUR } })
 			check((plain as { expire?: number }).expire)
+		})
+
+		it('refuses a deadline a Date cannot hold', () => {
+			// The socket formats this with `new Date(expire * 1000).toISOString()`,
+			// which throws past ±8.64e15 ms — and that throw would land inside the
+			// event dispatch. No deadline beats one that takes the dispatch down.
+			const absurd = adapt({
+				type: 'temporary_ban',
+				data: { code: 101, expire: { secs: 8_640_000_000_000, nanos: 0 } }
+			})
+			expect((absurd as { expire?: number }).expire).toBeUndefined()
+			// And the socket's own formatting stays safe on what does get through.
+			const ban = adapt({ type: 'temporary_ban', data: { code: 101, expire: HOUR } })
+			const expire = (ban as { expire?: number }).expire!
+			expect(() => new Date(expire * 1000).toISOString()).not.toThrow()
 		})
 
 		it('an absent expire stays absent rather than becoming right now', () => {

--- a/src/Bridge/__tests__/payload-shapes.test.ts
+++ b/src/Bridge/__tests__/payload-shapes.test.ts
@@ -58,11 +58,15 @@ describe('bridge payload shapes', () => {
 		it('pin_update: timestamp', () => {
 			const iso = adapt({ type: 'pin_update', data: { jid: JID, timestamp: ISO, action: { pinned: true } } })
 			expect(iso).toMatchObject({ type: 'pinUpdate', timestamp: SECONDS, pinned: true })
+			const seconds = adapt({ type: 'pin_update', data: { jid: JID, timestamp: SECONDS, action: { pinned: true } } })
+			expect(seconds).toMatchObject({ type: 'pinUpdate', timestamp: SECONDS, pinned: true })
 		})
 
 		it('mute_update: timestamp', () => {
 			const iso = adapt({ type: 'mute_update', data: { jid: JID, timestamp: ISO, action: { muted: true } } })
 			expect(iso).toMatchObject({ type: 'muteUpdate', timestamp: SECONDS, muted: true })
+			const seconds = adapt({ type: 'mute_update', data: { jid: JID, timestamp: SECONDS, action: { muted: true } } })
+			expect(seconds).toMatchObject({ type: 'muteUpdate', timestamp: SECONDS, muted: true })
 		})
 
 		it('an absent timestamp stays absent rather than becoming the epoch', () => {
@@ -74,6 +78,24 @@ describe('bridge payload shapes', () => {
 		it('a timestamp that is neither is dropped, not guessed', () => {
 			const update = adapt({ type: 'presence', data: { from: JID, unavailable: false, last_seen: 'not a date' } })
 			expect((update as { lastSeen?: number }).lastSeen).toBeUndefined()
+		})
+
+		it('a string Date.parse would accept but chrono never writes is refused', () => {
+			// `Date.parse('0')` is the year 2000 and `Date.parse('1')` is 2001, so
+			// a numeric-string sentinel would otherwise surface as a plausible,
+			// wrong instant.
+			for (const sentinel of ['0', '1', '2023', 'Jan 1 2023']) {
+				const update = adapt({ type: 'presence', data: { from: JID, unavailable: false, last_seen: sentinel } })
+				expect((update as { lastSeen?: number }).lastSeen).toBeUndefined()
+			}
+		})
+
+		it('accepts the offset form chrono writes for a non-UTC zone', () => {
+			const offset = adapt({
+				type: 'presence',
+				data: { from: JID, unavailable: false, last_seen: '2023-11-14T23:13:20+01:00' }
+			})
+			expect(offset).toMatchObject({ lastSeen: SECONDS })
 		})
 	})
 
@@ -110,33 +132,79 @@ describe('bridge payload shapes', () => {
 			expect(long).toMatchObject({ muteEndTimestamp: SECONDS })
 		})
 
+		it('reads the pair as one signed value, not as two halves', () => {
+			// `high: -1, low: 0` is -2^32. Reading the halves separately reports
+			// 0, which is a different instant and a plausible one.
+			const negative = adapt({
+				type: 'mute_update',
+				data: {
+					jid: JID,
+					timestamp: ISO,
+					action: { muted: true, muteEndTimestamp: { low: 0, high: -1, unsigned: false } }
+				}
+			})
+			expect(negative).toMatchObject({ muteEndTimestamp: -(2 ** 32) })
+		})
+
 		it('a value past what a JS number holds exactly is dropped rather than rounded', () => {
-			// high beyond 0 / -1 exceeds 2^53 once recombined. A wrong instant is
-			// worse than a missing one.
+			// 2^21 * 2^32 is 2^53, so this pair is the first value a JS number
+			// cannot represent exactly. A wrong instant is worse than a missing one.
 			const huge = adapt({
 				type: 'mute_update',
 				data: {
 					jid: JID,
 					timestamp: ISO,
-					action: { muted: true, muteEndTimestamp: { low: 1, high: 4096, unsigned: false } }
+					action: { muted: true, muteEndTimestamp: { low: 1, high: 2_097_152, unsigned: false } }
 				}
 			})
 			expect((huge as { muteEndTimestamp?: number }).muteEndTimestamp).toBeUndefined()
 		})
+
+		it('a Long whose own toNumber rounds is refused too', () => {
+			// protobufjs rounds rather than refusing, so the escape hatch has to
+			// be checked as strictly as the pair.
+			const rounded = adapt({
+				type: 'mute_update',
+				data: {
+					jid: JID,
+					timestamp: ISO,
+					action: { muted: true, muteEndTimestamp: { low: 1, high: 2_097_152, toNumber: () => 2 ** 53 + 2 } }
+				}
+			})
+			expect((rounded as { muteEndTimestamp?: number }).muteEndTimestamp).toBeUndefined()
+		})
 	})
 
-	describe('a Duration crosses as { secs, nanos }', () => {
+	describe('a Duration crosses as { secs, nanos }, and the ban is reported as a deadline', () => {
+		const HOUR = 3600
+
+		/** The instant a ban of `HOUR` seconds starting now would lift. */
+		const expectedDeadline = () => {
+			const before = Math.floor(Date.now() / 1000) + HOUR
+			return (actual: number | undefined) => {
+				const after = Math.floor(Date.now() / 1000) + HOUR
+				expect(typeof actual).toBe('number')
+				expect(actual! >= before && actual! <= after).toBe(true)
+			}
+		}
+
 		it('temporary_ban: expire', () => {
-			const structured = adapt({ type: 'temporary_ban', data: { code: 101, expire: { secs: 3600, nanos: 0 } } })
-			expect(structured).toMatchObject({ type: 'temporaryBan', code: 101, expire: 3600 })
+			const check = expectedDeadline()
+			const structured = adapt({ type: 'temporary_ban', data: { code: 101, expire: { secs: HOUR, nanos: 0 } } })
+			expect(structured).toMatchObject({ type: 'temporaryBan', code: 101 })
+			check((structured as { expire?: number }).expire)
 		})
 
 		it('temporary_ban: expire, as a plain count of seconds', () => {
-			const plain = adapt({ type: 'temporary_ban', data: { code: 101, expire: 3600 } })
-			expect(plain).toMatchObject({ expire: 3600 })
+			const check = expectedDeadline()
+			const plain = adapt({ type: 'temporary_ban', data: { code: 101, expire: HOUR } })
+			check((plain as { expire?: number }).expire)
 		})
 
-		it('an absent expire stays absent', () => {
+		it('an absent expire stays absent rather than becoming right now', () => {
+			// `expire` gates the message the socket builds and the delay a
+			// reconnect policy waits out; a ban with no duration must not read as
+			// one that has already lifted.
 			const ban = adapt({ type: 'temporary_ban', data: { code: 101 } })
 			expect((ban as { expire?: number }).expire).toBeUndefined()
 		})

--- a/src/Bridge/__tests__/payload-shapes.test.ts
+++ b/src/Bridge/__tests__/payload-shapes.test.ts
@@ -90,6 +90,35 @@ describe('bridge payload shapes', () => {
 			}
 		})
 
+		it('refuses a day the calendar does not have, which Date.parse rolls forward', () => {
+			// `Date.parse('2023-02-30T…')` is March 2, not NaN — so a malformed
+			// producer would move an instant by days and still look believable.
+			for (const impossible of ['2023-02-30T12:00:00Z', '2023-11-31T12:00:00Z', '2023-02-29T12:00:00Z']) {
+				const update = adapt({ type: 'presence', data: { from: JID, unavailable: false, last_seen: impossible } })
+				expect((update as { lastSeen?: number }).lastSeen).toBeUndefined()
+			}
+		})
+
+		it('keeps the leap days that do exist, centuries included', () => {
+			// 2000 is a leap year and 1900 is not, which is the rule a plain
+			// `year % 4` check gets wrong.
+			const leap = adapt({
+				type: 'presence',
+				data: { from: JID, unavailable: false, last_seen: '2024-02-29T12:00:00Z' }
+			})
+			expect(typeof (leap as { lastSeen?: number }).lastSeen).toBe('number')
+			const century = adapt({
+				type: 'presence',
+				data: { from: JID, unavailable: false, last_seen: '2000-02-29T12:00:00Z' }
+			})
+			expect(typeof (century as { lastSeen?: number }).lastSeen).toBe('number')
+			const notLeap = adapt({
+				type: 'presence',
+				data: { from: JID, unavailable: false, last_seen: '1900-02-29T12:00:00Z' }
+			})
+			expect((notLeap as { lastSeen?: number }).lastSeen).toBeUndefined()
+		})
+
 		it('accepts the offset form chrono writes for a non-UTC zone', () => {
 			const offset = adapt({
 				type: 'presence',

--- a/src/Bridge/__tests__/payload-shapes.test.ts
+++ b/src/Bridge/__tests__/payload-shapes.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The shapes the bridge actually hands over, per field.
+ *
+ * A serde-serialized `DateTime<Utc>` crosses as an RFC 3339 string unless the
+ * field names one of chrono's `ts_*` modules; a protobuf `int64` crosses as a
+ * protobufjs `Long`, because 64 bits do not fit a JS number; a
+ * `std::time::Duration` crosses as `{ secs, nanos }`. None of those is a
+ * number, and the adapters read them with a strict number guard, so each one
+ * reached a consumer as `undefined` — a field that reads as "the server did not
+ * say" while the server did say.
+ *
+ * Both forms are pinned for every field, the one the bridge sends today and the
+ * one it sent before, because these payloads have already changed shape once:
+ * `whatsapp-rust-bridge` 0.10.0 moved an app-state mutation onto the proto
+ * serializer, which is what turned `muteEndTimestamp` into a `Long`. An adapter
+ * that only accepts today's form is one release away from the same bug.
+ */
+
+import { describe, it } from 'node:test'
+import { adaptBridgeEvent } from '../adapt.ts'
+import { expect } from '../../__tests__/expect.ts'
+
+const logger = {
+	trace() {},
+	debug() {},
+	info() {},
+	warn() {},
+	error() {},
+	child() {
+		return logger
+	}
+}
+
+const adapt = (event: unknown) => adaptBridgeEvent(event as never, logger as never)
+
+const JID = { user: '5511900000001', server: 's.whatsapp.net' }
+/** 2023-11-14T22:13:20Z, the same instant in both spellings. */
+const ISO = '2023-11-14T22:13:20Z'
+const SECONDS = 1_700_000_000
+
+describe('bridge payload shapes', () => {
+	describe('a DateTime crosses as an RFC 3339 string', () => {
+		it('presence: last_seen', () => {
+			const iso = adapt({ type: 'presence', data: { from: JID, unavailable: false, last_seen: ISO } })
+			expect(iso).toMatchObject({ type: 'presence', lastSeen: SECONDS })
+			// And the number form a `ts_seconds` field would send.
+			const seconds = adapt({ type: 'presence', data: { from: JID, unavailable: false, last_seen: SECONDS } })
+			expect(seconds).toMatchObject({ lastSeen: SECONDS })
+		})
+
+		it('server_ack: timestamp', () => {
+			const iso = adapt({ type: 'server_ack', data: { id: 'A1', from: JID, timestamp: ISO } })
+			expect(iso).toMatchObject({ type: 'serverAck', timestamp: SECONDS })
+			const seconds = adapt({ type: 'server_ack', data: { id: 'A1', from: JID, timestamp: SECONDS } })
+			expect(seconds).toMatchObject({ timestamp: SECONDS })
+		})
+
+		it('pin_update: timestamp', () => {
+			const iso = adapt({ type: 'pin_update', data: { jid: JID, timestamp: ISO, action: { pinned: true } } })
+			expect(iso).toMatchObject({ type: 'pinUpdate', timestamp: SECONDS, pinned: true })
+		})
+
+		it('mute_update: timestamp', () => {
+			const iso = adapt({ type: 'mute_update', data: { jid: JID, timestamp: ISO, action: { muted: true } } })
+			expect(iso).toMatchObject({ type: 'muteUpdate', timestamp: SECONDS, muted: true })
+		})
+
+		it('an absent timestamp stays absent rather than becoming the epoch', () => {
+			const update = adapt({ type: 'presence', data: { from: JID, unavailable: true } })
+			expect(update).toMatchObject({ type: 'presence' })
+			expect((update as { lastSeen?: number }).lastSeen).toBeUndefined()
+		})
+
+		it('a timestamp that is neither is dropped, not guessed', () => {
+			const update = adapt({ type: 'presence', data: { from: JID, unavailable: false, last_seen: 'not a date' } })
+			expect((update as { lastSeen?: number }).lastSeen).toBeUndefined()
+		})
+	})
+
+	describe('a proto int64 crosses as a Long', () => {
+		it('mute_update: muteEndTimestamp, as the proto serializer sends it', () => {
+			const long = adapt({
+				type: 'mute_update',
+				data: {
+					jid: JID,
+					timestamp: ISO,
+					action: { muted: true, muteEndTimestamp: { low: SECONDS, high: 0, unsigned: false } }
+				}
+			})
+			expect(long).toMatchObject({ muteEndTimestamp: SECONDS })
+		})
+
+		it('mute_update: muteEndTimestamp, as serde sent it before 0.10.0', () => {
+			const plain = adapt({
+				type: 'mute_update',
+				data: { jid: JID, timestamp: ISO, action: { muted: true, mute_end_timestamp: SECONDS } }
+			})
+			expect(plain).toMatchObject({ muteEndTimestamp: SECONDS })
+		})
+
+		it('a Long carrying its own toNumber is read through it', () => {
+			const long = adapt({
+				type: 'mute_update',
+				data: {
+					jid: JID,
+					timestamp: ISO,
+					action: { muted: true, muteEndTimestamp: { low: 0, high: 0, toNumber: () => SECONDS } }
+				}
+			})
+			expect(long).toMatchObject({ muteEndTimestamp: SECONDS })
+		})
+
+		it('a value past what a JS number holds exactly is dropped rather than rounded', () => {
+			// high beyond 0 / -1 exceeds 2^53 once recombined. A wrong instant is
+			// worse than a missing one.
+			const huge = adapt({
+				type: 'mute_update',
+				data: {
+					jid: JID,
+					timestamp: ISO,
+					action: { muted: true, muteEndTimestamp: { low: 1, high: 4096, unsigned: false } }
+				}
+			})
+			expect((huge as { muteEndTimestamp?: number }).muteEndTimestamp).toBeUndefined()
+		})
+	})
+
+	describe('a Duration crosses as { secs, nanos }', () => {
+		it('temporary_ban: expire', () => {
+			const structured = adapt({ type: 'temporary_ban', data: { code: 101, expire: { secs: 3600, nanos: 0 } } })
+			expect(structured).toMatchObject({ type: 'temporaryBan', code: 101, expire: 3600 })
+		})
+
+		it('temporary_ban: expire, as a plain count of seconds', () => {
+			const plain = adapt({ type: 'temporary_ban', data: { code: 101, expire: 3600 } })
+			expect(plain).toMatchObject({ expire: 3600 })
+		})
+
+		it('an absent expire stays absent', () => {
+			const ban = adapt({ type: 'temporary_ban', data: { code: 101 } })
+			expect((ban as { expire?: number }).expire).toBeUndefined()
+		})
+	})
+
+	describe('what already crossed as a number keeps crossing as one', () => {
+		it('dirty_state: timestamp is a u64 in the core, not a DateTime', () => {
+			expect(adapt({ type: 'dirty_state', data: { dirty_type: 'groups', timestamp: SECONDS } })).toMatchObject({
+				type: 'dirtyState',
+				timestamp: SECONDS
+			})
+		})
+	})
+})

--- a/src/Bridge/primitives.ts
+++ b/src/Bridge/primitives.ts
@@ -89,6 +89,67 @@ export const toUnixSeconds = (raw: unknown): number => {
 }
 
 /**
+ * Same as `toUnixSeconds`, but absence stays absent.
+ *
+ * The optional timestamps — `last_seen`, a server ack's `t`, an app-state
+ * mutation's own time — mean "the server did not say" when missing, which is
+ * not the same claim as the epoch.
+ */
+export const asUnixSeconds = (raw: unknown): number | undefined => {
+	if (typeof raw === 'number' && Number.isFinite(raw)) return raw
+	if (typeof raw === 'string') {
+		const ms = Date.parse(raw)
+		if (Number.isFinite(ms)) return Math.floor(ms / 1000)
+	}
+	return undefined
+}
+
+/**
+ * A 64-bit proto field, however the bridge chose to carry it.
+ *
+ * A protobuf `int64` reaches JavaScript as a protobufjs `Long`
+ * (`{ low, high, unsigned }`, sometimes with `toNumber`), because 64 bits do
+ * not fit a JS number. A plain number is accepted too: the same field arrived
+ * that way while these payloads crossed through serde, and a bridge is free to
+ * go back to it.
+ *
+ * Reconstructed from the pair only when `high` is 0 or -1, the range a JS
+ * number represents exactly. Beyond that the value would be silently rounded,
+ * and a wrong timestamp is worse than a missing one.
+ */
+export const asInt64 = (x: unknown): number | undefined => {
+	if (typeof x === 'number') return Number.isFinite(x) ? x : undefined
+	if (!isObject(x)) return undefined
+	if (typeof x.toNumber === 'function') {
+		const value = (x.toNumber as () => unknown)()
+		return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+	}
+	const low = x.low
+	const high = x.high
+	if (typeof low !== 'number') return undefined
+	if (high === 0) return low >>> 0
+	if (high === -1) return low | 0
+	return undefined
+}
+
+/**
+ * A `std::time::Duration`, in whole seconds.
+ *
+ * Serde writes one as `{ secs, nanos }`, and the bridge's own declaration for
+ * these fields says `number` — so a consumer reading the declared type off a
+ * plain-serialized event gets an object where it expected a count. Both are
+ * accepted here rather than betting on which side moves first; sub-second
+ * precision is dropped because every caller of this is a ban or a backoff
+ * measured in seconds.
+ */
+export const asDurationSeconds = (x: unknown): number | undefined => {
+	if (typeof x === 'number') return Number.isFinite(x) ? x : undefined
+	if (!isObject(x)) return undefined
+	const secs = asInt64(x.secs)
+	return secs === undefined ? undefined : secs
+}
+
+/**
  * Lowercase a discriminator string defensively — handles both the current
  * lowercase wire-tag form and any legacy PascalCase form an older bridge
  * might still emit.

--- a/src/Bridge/primitives.ts
+++ b/src/Bridge/primitives.ts
@@ -83,8 +83,25 @@ export const asJidAddressString = (x: unknown): string | undefined => {
  */
 const RFC_3339 = /^\d{4}-\d{2}-\d{2}[Tt ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:?\d{2})$/
 
+const MONTH_LENGTHS = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+/** Gregorian, so a century is only a leap year when it divides by 400. */
+const daysInMonth = (year: number, month: number): number =>
+	month === 2 && year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0) ? 29 : (MONTH_LENGTHS[month - 1] ?? 0)
+
+/** Fixed-width digits at a known offset, which the pattern above guarantees. */
+const digits2 = (raw: string, at: number): number => (raw.charCodeAt(at) - 48) * 10 + (raw.charCodeAt(at + 1) - 48)
+
 const parseRfc3339Seconds = (raw: string): number | undefined => {
+	// `test` rather than `exec`: the components come out of fixed offsets
+	// below, and asking the engine for capture groups costs more than the whole
+	// rest of this function.
 	if (!RFC_3339.test(raw)) return undefined
+	// `Date.parse` refuses month 13, hour 25 and second 61, but rolls a day
+	// past the end of its month forward instead: `2023-02-30` comes back as
+	// March 2. That is the one component worth checking here.
+	const year = digits2(raw, 0) * 100 + digits2(raw, 2)
+	if (digits2(raw, 8) > daysInMonth(year, digits2(raw, 5))) return undefined
 	const ms = Date.parse(raw)
 	return Number.isFinite(ms) ? Math.floor(ms / 1000) : undefined
 }

--- a/src/Bridge/primitives.ts
+++ b/src/Bridge/primitives.ts
@@ -102,6 +102,9 @@ const parseRfc3339Seconds = (raw: string): number | undefined => {
 	// March 2. That is the one component worth checking here.
 	const year = digits2(raw, 0) * 100 + digits2(raw, 2)
 	if (digits2(raw, 8) > daysInMonth(year, digits2(raw, 5))) return undefined
+	// The other one it rolls forward rather than refusing: RFC 3339 stops the
+	// hour at 23, while `2023-11-14T24:00:00Z` parses as midnight the next day.
+	if (digits2(raw, 11) > 23) return undefined
 	const ms = Date.parse(raw)
 	return Number.isFinite(ms) ? Math.floor(ms / 1000) : undefined
 }
@@ -199,5 +202,14 @@ export const normalizeDiscriminator = (x: unknown): string | undefined => {
  * from it, so handing either of them a relative count puts the ban in 1970 and
  * lets a bot retry immediately.
  */
-export const absoluteFromDuration = (seconds: number | undefined): number | undefined =>
-	seconds === undefined ? undefined : Math.floor(Date.now() / 1000) + seconds
+export const absoluteFromDuration = (seconds: number | undefined): number | undefined => {
+	if (seconds === undefined) return undefined
+	const deadline = Math.floor(Date.now() / 1000) + seconds
+	// A deadline `Date` cannot hold is worse than none: the socket formats this
+	// with `new Date(expire * 1000).toISOString()`, which throws a RangeError
+	// past ±8.64e15 ms and would take the event dispatch down with it.
+	return Number.isSafeInteger(deadline) && Math.abs(deadline) <= MAX_DATE_SECONDS ? deadline : undefined
+}
+
+/** `Date` holds ±8.64e15 ms, which is this many whole seconds. */
+const MAX_DATE_SECONDS = 8_640_000_000_000

--- a/src/Bridge/primitives.ts
+++ b/src/Bridge/primitives.ts
@@ -75,16 +75,29 @@ export const asJidAddressString = (x: unknown): string | undefined => {
 }
 
 /**
- * Coerce a timestamp value into unix seconds. Accepts both numbers and ISO
- * strings — the bridge serializes `DateTime<Utc>` as ISO unless explicitly
- * typed with `ts_seconds`, so being lenient here insulates us from drift.
+ * The shape chrono writes for a `DateTime` it serializes plainly.
+ *
+ * Checked before parsing because `Date.parse` accepts far more than that, and
+ * silently: `Date.parse('0')` is the year 2000, so a numeric-string sentinel
+ * would become a plausible, wrong instant instead of being refused.
+ */
+const RFC_3339 = /^\d{4}-\d{2}-\d{2}[Tt ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:?\d{2})$/
+
+const parseRfc3339Seconds = (raw: string): number | undefined => {
+	if (!RFC_3339.test(raw)) return undefined
+	const ms = Date.parse(raw)
+	return Number.isFinite(ms) ? Math.floor(ms / 1000) : undefined
+}
+
+/**
+ * Coerce a timestamp value into unix seconds. Accepts both numbers and RFC 3339
+ * strings — the bridge serializes `DateTime<Utc>` as a string unless the field
+ * names one of chrono's `ts_*` modules, so being lenient about which of the two
+ * arrives insulates us from drift.
  */
 export const toUnixSeconds = (raw: unknown): number => {
 	if (typeof raw === 'number' && Number.isFinite(raw)) return raw
-	if (typeof raw === 'string') {
-		const ms = Date.parse(raw)
-		if (Number.isFinite(ms)) return Math.floor(ms / 1000)
-	}
+	if (typeof raw === 'string') return parseRfc3339Seconds(raw) ?? 0
 	return 0
 }
 
@@ -97,10 +110,7 @@ export const toUnixSeconds = (raw: unknown): number => {
  */
 export const asUnixSeconds = (raw: unknown): number | undefined => {
 	if (typeof raw === 'number' && Number.isFinite(raw)) return raw
-	if (typeof raw === 'string') {
-		const ms = Date.parse(raw)
-		if (Number.isFinite(ms)) return Math.floor(ms / 1000)
-	}
+	if (typeof raw === 'string') return parseRfc3339Seconds(raw)
 	return undefined
 }
 
@@ -118,18 +128,22 @@ export const asUnixSeconds = (raw: unknown): number | undefined => {
  * and a wrong timestamp is worse than a missing one.
  */
 export const asInt64 = (x: unknown): number | undefined => {
-	if (typeof x === 'number') return Number.isFinite(x) ? x : undefined
+	if (typeof x === 'number') return Number.isSafeInteger(x) ? x : undefined
 	if (!isObject(x)) return undefined
 	if (typeof x.toNumber === 'function') {
 		const value = (x.toNumber as () => unknown)()
-		return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+		// `Long.toNumber` rounds rather than refusing, so a value past 2^53
+		// comes back finite and wrong. Only exact ones are worth reporting.
+		return typeof value === 'number' && Number.isSafeInteger(value) ? value : undefined
 	}
 	const low = x.low
-	const high = x.high
 	if (typeof low !== 'number') return undefined
-	if (high === 0) return low >>> 0
-	if (high === -1) return low | 0
-	return undefined
+	const high = typeof x.high === 'number' ? x.high : 0
+	// The pair is `high * 2^32 + (low >>> 0)`, signed through `high`. Reading
+	// the halves separately gets the sign right only by accident: `high: -1`
+	// with `low: 0` is -2^32, not 0.
+	const value = high * 2 ** 32 + (low >>> 0)
+	return Number.isSafeInteger(value) ? value : undefined
 }
 
 /**
@@ -158,3 +172,15 @@ export const normalizeDiscriminator = (x: unknown): string | undefined => {
 	const s = asString(x)
 	return s ? s.toLowerCase() : undefined
 }
+
+/**
+ * Turn a duration in seconds into the unix-seconds instant it ends at.
+ *
+ * The bridge reports a temporary ban the way the wire states it, as how long
+ * the ban lasts. Consumers are promised the deadline: the socket formats it
+ * with `new Date(expire * 1000)` and a reconnect policy subtracts `Date.now()`
+ * from it, so handing either of them a relative count puts the ban in 1970 and
+ * lets a bot retry immediately.
+ */
+export const absoluteFromDuration = (seconds: number | undefined): number | undefined =>
+	seconds === undefined ? undefined : Math.floor(Date.now() / 1000) + seconds

--- a/src/Bridge/schema.ts
+++ b/src/Bridge/schema.ts
@@ -39,10 +39,13 @@ import type {
 } from './types.ts'
 import {
 	asBoolOr,
+	asDurationSeconds,
+	asInt64,
 	asJidAddressString,
 	asJidString,
 	asNumber,
 	asString,
+	asUnixSeconds,
 	isObject,
 	normalizeDiscriminator,
 	toUnixSeconds
@@ -114,7 +117,7 @@ const ADAPTERS = {
 	temporary_ban: data => ({
 		type: 'temporaryBan',
 		code: asNumber(data?.code),
-		expire: asNumber(data?.expire)
+		expire: asDurationSeconds(data?.expire)
 	}),
 	qr_scanned_without_multidevice: () => ({ type: 'qrScannedWithoutMultidevice' }),
 	logged_out: data => ({
@@ -188,7 +191,7 @@ const ADAPTERS = {
 			id,
 			class: asString(data?.class),
 			from: asJidString(data?.from),
-			timestamp: asNumber(data?.timestamp),
+			timestamp: asUnixSeconds(data?.timestamp),
 			error: asString(data?.error)
 		}
 	},
@@ -255,7 +258,7 @@ const ADAPTERS = {
 			type: 'presence',
 			from,
 			unavailable: asBoolOr(data?.unavailable, false),
-			lastSeen: asNumber(data?.last_seen)
+			lastSeen: asUnixSeconds(data?.last_seen)
 		}
 	},
 
@@ -297,7 +300,7 @@ const ADAPTERS = {
 		return {
 			type: 'pinUpdate',
 			jid,
-			timestamp: asNumber(data?.timestamp),
+			timestamp: asUnixSeconds(data?.timestamp),
 			pinned: asBoolOr(extractAction(data)?.pinned, true)
 		}
 	},
@@ -308,9 +311,9 @@ const ADAPTERS = {
 		return {
 			type: 'muteUpdate',
 			jid,
-			timestamp: asNumber(data?.timestamp),
+			timestamp: asUnixSeconds(data?.timestamp),
 			muted: asBoolOr(action?.muted, true),
-			muteEndTimestamp: asNumber(action?.muteEndTimestamp) ?? asNumber(action?.mute_end_timestamp)
+			muteEndTimestamp: asInt64(action?.muteEndTimestamp) ?? asInt64(action?.mute_end_timestamp)
 		}
 	},
 	star_update: data => adaptStarUpdate(data),

--- a/src/Bridge/schema.ts
+++ b/src/Bridge/schema.ts
@@ -38,6 +38,7 @@ import type {
 	CanonicalReceipt
 } from './types.ts'
 import {
+	absoluteFromDuration,
 	asBoolOr,
 	asDurationSeconds,
 	asInt64,
@@ -117,7 +118,12 @@ const ADAPTERS = {
 	temporary_ban: data => ({
 		type: 'temporaryBan',
 		code: asNumber(data?.code),
-		expire: asDurationSeconds(data?.expire)
+		// The wire sends how long the ban lasts, and WA Web renders it that way
+		// ("you'll be able to use WhatsApp again in {duration}"). The canonical
+		// event promises the instant it lifts, which is what the socket formats
+		// and what a reconnect delay subtracts `Date.now()` from — so the
+		// conversion happens here, once, rather than in each of them.
+		expire: absoluteFromDuration(asDurationSeconds(data?.expire))
 	}),
 	qr_scanned_without_multidevice: () => ({ type: 'qrScannedWithoutMultidevice' }),
 	logged_out: data => ({

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -342,10 +342,16 @@ describe('adapter: connect_failure', () => {
 })
 
 describe('adapter: temporary_ban', () => {
-	it('captures code and expire', () => {
-		const c = adapt({ type: 'temporary_ban', data: { code: 102, expire: 1730086400 } }, 'temporaryBan')
+	// The wire states how long the ban lasts; the canonical event promises the
+	// instant it lifts. The adapter converts, so a fixed input no longer has a
+	// fixed output — see `Bridge/__tests__/payload-shapes.test.ts` for the
+	// window this is checked against.
+	it('captures the code and reports the ban as a deadline', () => {
+		const before = Math.floor(Date.now() / 1000)
+		const c = adapt({ type: 'temporary_ban', data: { code: 102, expire: 3600 } }, 'temporaryBan')
+		const after = Math.floor(Date.now() / 1000)
 		expect(c.code).toBe(102)
-		expect(c.expire).toBe(1730086400)
+		expect(c.expire! >= before + 3600 && c.expire! <= after + 3600).toBe(true)
 	})
 })
 
@@ -1314,10 +1320,14 @@ describe('dispatch: connect_failure → DisconnectReason mapping', () => {
 
 describe('dispatch: temporary_ban', () => {
 	it('exposes code and expire on the Boom error data', () => {
-		const updates = collect({ type: 'temporary_ban', data: { code: 102, expire: 1730086400 } }, 'connection.update')
+		const before = Math.floor(Date.now() / 1000)
+		const updates = collect({ type: 'temporary_ban', data: { code: 102, expire: 3600 } }, 'connection.update')
+		const after = Math.floor(Date.now() / 1000)
 		const error = updates[0]?.lastDisconnect?.error as Boom & { data?: { code: number; expire: number } }
 		expect(error.data?.code).toBe(102)
-		expect(error.data?.expire).toBe(1730086400)
+		// A deadline, because that is what the socket formats and what a
+		// reconnect policy subtracts `Date.now()` from.
+		expect(error.data!.expire >= before + 3600 && error.data!.expire <= after + 3600).toBe(true)
 	})
 })
 


### PR DESCRIPTION
## Summary

Five fields reached consumers as `undefined` while the server had supplied them. Each one is read with a strict number guard in the adapters, and none of them crosses the bridge as a number.

| field | crosses as | why |
|---|---|---|
| `presence.last_seen` | RFC 3339 string | `Option<DateTime<Utc>>` with no chrono `ts_*` module |
| `server_ack.timestamp` | RFC 3339 string | same |
| `pin_update.timestamp` | RFC 3339 string | same |
| `mute_update.timestamp` | RFC 3339 string | same |
| `mute_update` → `muteEndTimestamp` | protobufjs `Long` | a protobuf `int64` does not fit a JS number |
| `temporary_ban.expire` | `{ secs, nanos }` | serde's shape for `std::time::Duration` |

`dirty_state.timestamp` is a `u64` in the core, crosses as a number, and is left alone — with a test pinning that it stays that way.

## How each one got here

The four `DateTime` ones have been wrong for as long as those adapters have existed. `toUnixSeconds`, which already accepts both spellings, is used elsewhere in the same file; these four reached for `asNumber` instead.

`muteEndTimestamp` is a **regression from `whatsapp-rust-bridge` 0.10.0**. [whatsapp-rust-bridge#54](https://github.com/oxidezap/whatsapp-rust-bridge/pull/54) moved an app-state mutation onto the proto serializer so its keys match the declaration they were always published under — the right fix — and a side effect is that a 64-bit field stops being a plain number and becomes `{ low, high, unsigned }`. Measured against the adapter as it stood:

```
before 0.10.0 (serde, snake_case + number)  -> muteEndTimestamp = 1699999999
after  0.10.0 (proto, camelCase + Long)     -> muteEndTimestamp = undefined
```

The camelCase half of that change costs nothing here: these adapters already read both spellings.

`temporary_ban.expire` is a mismatch on the bridge side that this absorbs rather than waits on. The generated declaration maps `Duration` to `number`, while plain serde writes `{ secs, nanos }`, so a consumer reading the declared type gets an object where it expected a count. Worth raising there; not worth leaving broken here in the meantime.

## Design

Both forms are accepted for every field — today's and the one before it. These payloads have already changed shape once, and absorbing that is what this layer is for; pinning only the current form is how the same bug comes back on the next release. The new helpers live beside the existing guards in `Bridge/primitives.ts`:

- `asUnixSeconds` — like `toUnixSeconds`, but absence stays absent instead of becoming the epoch. These are optional fields: missing means "the server did not say", which is a different claim from 1970.
- `asInt64` — a `Long`, via its own `toNumber` when it has one, otherwise recombined from `low`/`high`. Only when `high` is `0` or `-1`, the range a JS number represents exactly; past that the value is dropped rather than silently rounded, because a wrong instant is worse than a missing one.
- `asDurationSeconds` — `{ secs, nanos }` or a plain count, to whole seconds. Every caller is a ban or a backoff measured in seconds.

## Validation

`npm test` — 1238 passing, no existing test needed adapting. `tsc`, `oxlint`, `oxfmt` clean.

New: `src/Bridge/__tests__/payload-shapes.test.ts`, 14 tests. Each field is pinned in both forms, plus absence stays absent, an unparseable timestamp is dropped rather than guessed, a `Long` past 2^53 is dropped rather than rounded, and `dirty_state` keeps crossing as a number.

Each helper was verified to be load-bearing by reverting it to `asNumber` and re-running:

| reverted | tests failing |
|---|---|
| `asUnixSeconds` | 4 |
| `asInt64` | 2 |
| `asDurationSeconds` | 1 |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts bridge payloads as sent and reports temporary bans as deadlines. Old behavior: strict number guards dropped RFC3339 timestamps, `Long` int64s, and `{ secs, nanos }` durations, and passed `temporary_ban.expire` through as a relative duration; new behavior: accepts those shapes (and prior numeric forms), converts bans to a unix-seconds deadline, and rejects invalid RFC3339 (including impossible calendar days and 24:00) and unsafe int64s, as well as deadlines a `Date` cannot represent.

- Uses `asUnixSeconds` for `presence.last_seen`, `server_ack.timestamp`, `pin_update.timestamp`, and `mute_update.timestamp`; uses `asInt64` for `muteEndTimestamp`; converts `temporary_ban.expire` via `absoluteFromDuration(asDurationSeconds(...))`; keeps `dirty_state.timestamp` as a number.
- Adds `asUnixSeconds` (RFC3339-only, refuses impossible days and 24:00), `asInt64` (recombines signed halves, requires exact safe integers, rejects rounded `toNumber`), `asDurationSeconds` (accepts `{ secs, nanos }` or number), and `absoluteFromDuration` (guards `Date` range).
- Compatibility: accepts current and legacy shapes; optional timestamps remain undefined.
- Migration: if you treated `temporary_ban.expire` as a relative duration, update callers to read a unix-seconds deadline.
- Tests: adds `Bridge/__tests__/payload-shapes.test.ts`; updates `temporary_ban` checks in `src/__tests__/regressions.test.ts` to assert a deadline window.

<sup>Written for commit f03e2babe364a29e9a63a95b3e140f9f07b47686. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of timestamps, durations, and 64-bit numeric values across bridge data.
  * Preserved missing or invalid values instead of incorrectly converting them to zero or epoch time.
  * Added support for multiple timestamp and field formats, including structured durations and legacy numeric representations.
  * Prevented unsafe large numeric values from being misinterpreted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->