### PR TITLE
fix(send): keep a caller's <biz> working, on bridge 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.10.0",
+        "@oxidezap/whatsapp-rust-bridge": "0.11.0",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.10.0.tgz",
-      "integrity": "sha512-zsAR3hBw8EtnKq1pMfpXH2Q6b21BmTAv+LgQcAPazzga5BlcB0LQiQ7QeMLKNjoIgftlEmPNWMG5ELX12uWTlg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.11.0.tgz",
+      "integrity": "sha512-k00OYftRzbHabPnCjZOadLZVuZcvnmoCJIh0Zt+4uvHqBFtf6LCIB8urhHSbEaR0uGbUDuWNFN0LGRFtWM2zwA==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@oxidezap/whatsapp-rust-bridge": "0.10.0",
+    "@oxidezap/whatsapp-rust-bridge": "0.11.0",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"

--- a/src/Compatibility/derived-stanza-nodes.ts
+++ b/src/Compatibility/derived-stanza-nodes.ts
@@ -1,0 +1,49 @@
+import type { BinaryNode } from '../Types/index.ts'
+
+/**
+ * Upstream Baileys derives no stanza children of its own, so a caller that
+ * wants the `<biz>` on an interactive message has to attach it — which is what
+ * every payment recipe in that ecosystem tells them to do. The engine here
+ * derives it from the message content instead, and from
+ * `whatsapp-rust-bridge` 0.11.0 it refuses a caller node whose tag it already
+ * derives rather than sending both. Two of them on one `<message>` is what the
+ * client silently declines to render.
+ *
+ * That refusal is the correct behaviour and this is not an attempt to undo it.
+ * It only keeps the promise this library makes: Baileys code runs unchanged.
+ * A caller node the engine did not derive is left alone, because on a message
+ * that derives nothing the caller's node is the only one there is.
+ */
+
+/** The wire text the engine uses. Matched rather than parsed: it carries the tag. */
+const DERIVED_CONFLICT = 'conflicts with the one this send derives'
+
+interface BridgeRejection {
+	kind?: unknown
+	reason?: unknown
+	message?: unknown
+}
+
+/**
+ * The tag the engine refused, or `undefined` when the error is something else.
+ *
+ * Read off the message rather than off a field: the rejection names the tag
+ * inside its text (`extra stanza child <biz> conflicts with …`), and matching
+ * the sentence keeps this from firing on an unrelated invalid-argument — a
+ * malformed JID, an out-of-range enum — that a blanket retry would silently
+ * send twice.
+ */
+export const derivedNodeConflictTag = (error: unknown): string | undefined => {
+	if (typeof error !== 'object' || error === null) return undefined
+	const { kind, reason, message } = error as BridgeRejection
+	if (kind !== 'invalid-argument') return undefined
+	const text = typeof reason === 'string' ? reason : typeof message === 'string' ? message : ''
+	if (!text.includes(DERIVED_CONFLICT)) return undefined
+	return /<([a-z-]+)>/u.exec(text)?.[1]
+}
+
+/** The caller's nodes without the one the engine derives, or `undefined` if none matched. */
+export const withoutDerivedNode = (nodes: readonly BinaryNode[], tag: string): BinaryNode[] | undefined => {
+	const kept = nodes.filter(node => node.tag !== tag)
+	return kept.length === nodes.length ? undefined : kept
+}

--- a/src/Compatibility/derived-stanza-nodes.ts
+++ b/src/Compatibility/derived-stanza-nodes.ts
@@ -47,3 +47,35 @@ export const withoutDerivedNode = (nodes: readonly BinaryNode[], tag: string): B
 	const kept = nodes.filter(node => node.tag !== tag)
 	return kept.length === nodes.length ? undefined : kept
 }
+
+/**
+ * Send, dropping whichever derived node the engine names, until it stops
+ * naming one.
+ *
+ * A loop rather than a single retry: a DM carrying an interactive payload
+ * derives both `<biz>` and `<bot>`, and the engine reports one conflicting tag
+ * per attempt — so a caller supplying both would have the first dropped and
+ * fail on the second. Each pass removes at least one node, and the caller's own
+ * list bounds the passes, so this cannot spin.
+ *
+ * Every attempt is refused before the engine encrypts or sends, which is what
+ * makes retrying safe here and nowhere else.
+ */
+export const sendDroppingDerivedNodes = async <T>(
+	nodes: readonly BinaryNode[],
+	send: (nodes: BinaryNode[]) => Promise<T>,
+	onDrop: (tag: string) => void
+): Promise<T> => {
+	let current = [...nodes]
+	for (let passes = nodes.length; ; passes--) {
+		try {
+			return await send(current)
+		} catch (error) {
+			const tag = passes > 0 ? derivedNodeConflictTag(error) : undefined
+			const kept = tag === undefined ? undefined : withoutDerivedNode(current, tag)
+			if (tag === undefined || !kept) throw error
+			onDrop(tag)
+			current = kept
+		}
+	}
+}

--- a/src/Socket/messages.ts
+++ b/src/Socket/messages.ts
@@ -1,4 +1,4 @@
-import { derivedNodeConflictTag, withoutDerivedNode } from '../Compatibility/derived-stanza-nodes.ts'
+import { sendDroppingDerivedNodes } from '../Compatibility/derived-stanza-nodes.ts'
 import { encodeProtoCompat } from '../Compatibility/encode-proto.ts'
 import { planMessageRelay } from '../Compatibility/message-relay.ts'
 import { receiptMessageKeys } from '../Compatibility/message-keys.ts'
@@ -195,48 +195,38 @@ export const makeMessageMethods = (ctx: SocketContext) => ({
 			return plan.messageId
 		}
 
-		if (plan.kind === 'status') {
-			return client.sendStatusMessageBytesWithOptions(
-				bytes,
-				plan.recipients,
-				plan.messageId,
-				plan.nodes,
-				plan.refreshDevices
-			)
-		}
-
-		try {
-			return await client.relayMessageBytesWithOptions(
-				jid,
-				bytes,
-				plan.messageId,
-				plan.nodes,
-				plan.refreshGroupMetadata,
-				plan.refreshDevices
-			)
-		} catch (error) {
-			// Retried rather than filtered up front: only the engine knows which
-			// nodes it derives for a given message, and the refusal happens while
-			// it validates, before it encrypts or sends anything — so this cannot
-			// deliver the message twice. A caller node it did not derive never
-			// reaches here, which is what keeps the escape hatch open for the
-			// shapes it does not infer.
-			const tag = derivedNodeConflictTag(error)
-			const retained = tag === undefined ? undefined : withoutDerivedNode(plan.nodes, tag)
-			if (!retained) throw error
+		// Both sends go through the same retry: a caller node the engine derives
+		// is refused the same way whether the message is bound for a chat or for
+		// status, and the escape hatch — a node it does not derive — survives
+		// either way.
+		const drop = (tag: string) =>
 			ctx.logger.debug(
 				{ jid, messageId: plan.messageId, tag },
 				'dropped an additionalNodes entry the engine derives from the message'
 			)
-			return await client.relayMessageBytesWithOptions(
-				jid,
-				bytes,
-				plan.messageId,
-				retained,
-				plan.refreshGroupMetadata,
-				plan.refreshDevices
+
+		if (plan.kind === 'status') {
+			return sendDroppingDerivedNodes(
+				plan.nodes,
+				nodes =>
+					client.sendStatusMessageBytesWithOptions(bytes, plan.recipients, plan.messageId, nodes, plan.refreshDevices),
+				drop
 			)
 		}
+
+		return sendDroppingDerivedNodes(
+			plan.nodes,
+			nodes =>
+				client.relayMessageBytesWithOptions(
+					jid,
+					bytes,
+					plan.messageId,
+					nodes,
+					plan.refreshGroupMetadata,
+					plan.refreshDevices
+				),
+			drop
+		)
 	},
 
 	readMessages: async (keys: WAMessageKey[]) => {

--- a/src/Socket/messages.ts
+++ b/src/Socket/messages.ts
@@ -1,3 +1,4 @@
+import { derivedNodeConflictTag, withoutDerivedNode } from '../Compatibility/derived-stanza-nodes.ts'
 import { encodeProtoCompat } from '../Compatibility/encode-proto.ts'
 import { planMessageRelay } from '../Compatibility/message-relay.ts'
 import { receiptMessageKeys } from '../Compatibility/message-keys.ts'
@@ -204,14 +205,38 @@ export const makeMessageMethods = (ctx: SocketContext) => ({
 			)
 		}
 
-		return client.relayMessageBytesWithOptions(
-			jid,
-			bytes,
-			plan.messageId,
-			plan.nodes,
-			plan.refreshGroupMetadata,
-			plan.refreshDevices
-		)
+		try {
+			return await client.relayMessageBytesWithOptions(
+				jid,
+				bytes,
+				plan.messageId,
+				plan.nodes,
+				plan.refreshGroupMetadata,
+				plan.refreshDevices
+			)
+		} catch (error) {
+			// Retried rather than filtered up front: only the engine knows which
+			// nodes it derives for a given message, and the refusal happens while
+			// it validates, before it encrypts or sends anything — so this cannot
+			// deliver the message twice. A caller node it did not derive never
+			// reaches here, which is what keeps the escape hatch open for the
+			// shapes it does not infer.
+			const tag = derivedNodeConflictTag(error)
+			const retained = tag === undefined ? undefined : withoutDerivedNode(plan.nodes, tag)
+			if (!retained) throw error
+			ctx.logger.debug(
+				{ jid, messageId: plan.messageId, tag },
+				'dropped an additionalNodes entry the engine derives from the message'
+			)
+			return await client.relayMessageBytesWithOptions(
+				jid,
+				bytes,
+				plan.messageId,
+				retained,
+				plan.refreshGroupMetadata,
+				plan.refreshDevices
+			)
+		}
 	},
 
 	readMessages: async (keys: WAMessageKey[]) => {

--- a/src/__tests__/relay-derived-stanza-node.test.ts
+++ b/src/__tests__/relay-derived-stanza-node.test.ts
@@ -1,0 +1,194 @@
+/**
+ * A caller's `<biz>` on an interactive message, which upstream Baileys requires
+ * and this engine derives for itself.
+ *
+ * Upstream attaches no stanza children of its own, so every payment recipe in
+ * that ecosystem tells the caller to supply one. The engine here derives it
+ * from the message content, and from bridge 0.11.0 refuses the caller's rather
+ * than putting two on one `<message>` — which is the shape a client silently
+ * declines to render, measured on a live account.
+ *
+ * Refusing is right, and this is not undoing it. What is tested here is the
+ * promise this library makes: that Baileys code runs unchanged. The retry has
+ * to be narrow enough that a rejection meaning anything else still reaches the
+ * caller, because a blanket retry sends the message twice.
+ */
+
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { describe, it } from 'node:test'
+import { derivedNodeConflictTag, withoutDerivedNode } from '../Compatibility/derived-stanza-nodes.ts'
+import { makeMessageMethods } from '../Socket/messages.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import type { BinaryNode, WAProto } from '../Types/index.ts'
+
+/** The rejection the engine raises, as the bridge hands it to JavaScript. */
+const conflict = (tag: string) => ({
+	kind: 'invalid-argument',
+	field: 'extra_stanza_nodes',
+	reason: `extra stanza child <${tag}> conflicts with the one this send derives from the message`
+})
+
+const biz: BinaryNode = { tag: 'biz', attrs: { native_flow_name: 'payment_info' } }
+const bot: BinaryNode = { tag: 'bot', attrs: { biz_bot: '1' } }
+const unrelated: BinaryNode = { tag: 'meta', attrs: { thing: '1' } }
+
+describe('a stanza node the engine derives for itself', () => {
+	it('names the tag the engine refused', () => {
+		assert.equal(derivedNodeConflictTag(conflict('biz')), 'biz')
+		assert.equal(derivedNodeConflictTag(conflict('bot')), 'bot')
+	})
+
+	it('reads the tag off an Error as well as off a plain rejection', () => {
+		// The bridge throws an Error carrying `kind`; a plain object is what a
+		// test double hands over. Both have to be understood, or the retry works
+		// in one of the two and not the other.
+		const error = Object.assign(new Error(conflict('biz').reason), { kind: 'invalid-argument' })
+		assert.equal(derivedNodeConflictTag(error), 'biz')
+	})
+
+	it('ignores an invalid-argument that means something else', () => {
+		// The one that matters: a malformed JID is also `invalid-argument`, and
+		// retrying it would send nothing the first time and nothing the second,
+		// or worse, send twice on a rejection that had already been delivered.
+		assert.equal(
+			derivedNodeConflictTag({ kind: 'invalid-argument', field: 'jid', reason: 'jid is not addressable' }),
+			undefined
+		)
+	})
+
+	it('ignores every other rejection shape', () => {
+		for (const other of [
+			{ kind: 'not-connected' },
+			{ kind: 'timeout' },
+			{ kind: 'internal', message: 'conflicts with the one this send derives' },
+			new Error('conflicts with the one this send derives'),
+			null,
+			undefined,
+			'a string'
+		]) {
+			assert.equal(derivedNodeConflictTag(other), undefined, `${JSON.stringify(other)} should not be retried`)
+		}
+	})
+
+	it('drops only the refused tag, keeping the caller nodes around it', () => {
+		assert.deepEqual(withoutDerivedNode([biz], 'biz'), [])
+		assert.deepEqual(withoutDerivedNode([unrelated, biz], 'biz'), [unrelated])
+		assert.deepEqual(withoutDerivedNode([biz, bot], 'bot'), [biz])
+	})
+
+	it('reports nothing to retry when the refused tag is not among the caller nodes', () => {
+		// Then the rejection is about something this cannot fix, and returning an
+		// unchanged list would retry an identical send.
+		assert.equal(withoutDerivedNode([unrelated], 'biz'), undefined)
+		assert.equal(withoutDerivedNode([], 'biz'), undefined)
+	})
+})
+
+/**
+ * A relay whose first attempt is refused for `refusedTag`, recording the nodes
+ * of every attempt so the retry can be told apart from the original.
+ */
+const relayRefusing = (refusedTag: string | undefined) => {
+	const attempts: BinaryNode[][] = []
+	const logger = {
+		level: 'silent',
+		child: () => logger,
+		trace: () => undefined,
+		debug: () => undefined,
+		info: () => undefined,
+		warn: () => undefined,
+		error: () => undefined
+	}
+	const client = {
+		relayMessageBytesWithOptions: async (_jid: string, _bytes: Uint8Array, messageId: string, nodes: BinaryNode[]) => {
+			attempts.push(nodes)
+			if (attempts.length === 1 && refusedTag) throw conflict(refusedTag)
+			return messageId
+		}
+	}
+	const ctx = {
+		ev: Object.assign(new EventEmitter(), {
+			createBufferedFunction: <A extends unknown[], R>(work: (...a: A) => Promise<R>) => work
+		}),
+		logger,
+		fullConfig: { options: {}, emitOwnEvents: false },
+		getUser: () => ({ id: '15550000000@s.whatsapp.net' }),
+		getMe: () => ({ id: '15550000000@s.whatsapp.net' }),
+		getClient: async () => client
+	} as unknown as SocketContext
+	return { attempts, relay: makeMessageMethods(ctx).relayMessage }
+}
+
+const INTERACTIVE = {
+	interactiveMessage: { nativeFlowMessage: { buttons: [{ name: 'payment_info', buttonParamsJson: '{}' }] } }
+} as unknown as WAProto.IMessage
+
+describe('relayMessage against an engine that derives its own stanza children', () => {
+	it('resends without the refused node, so Baileys code sends once and works', async () => {
+		const { attempts, relay } = relayRefusing('biz')
+		const id = await relay('120363000000000000@g.us', INTERACTIVE, {
+			messageId: '3EB0DERIVED0001',
+			additionalNodes: [biz]
+		})
+
+		assert.equal(id, '3EB0DERIVED0001')
+		assert.equal(attempts.length, 2)
+		assert.deepEqual(attempts[0], [biz], 'the first attempt sends what the caller asked for')
+		assert.deepEqual(attempts[1], [], 'the retry drops only the node the engine derives')
+	})
+
+	it('keeps the caller nodes the engine did not derive', async () => {
+		const { attempts, relay } = relayRefusing('biz')
+		await relay('120363000000000000@g.us', INTERACTIVE, {
+			messageId: '3EB0DERIVED0002',
+			additionalNodes: [unrelated, biz]
+		})
+		assert.deepEqual(attempts[1], [unrelated])
+	})
+
+	it('sends once when nothing is refused', async () => {
+		const { attempts, relay } = relayRefusing(undefined)
+		await relay('120363000000000000@g.us', INTERACTIVE, {
+			messageId: '3EB0DERIVED0003',
+			additionalNodes: [biz]
+		})
+		assert.equal(attempts.length, 1)
+	})
+
+	it('propagates a rejection that is not this one, without a second send', async () => {
+		// The failure mode that matters: retrying an unrelated error is how one
+		// send becomes two messages.
+		const { attempts } = relayRefusing('biz')
+		const boom = { kind: 'not-connected' }
+		const client = { relayMessageBytesWithOptions: async () => Promise.reject(boom) }
+		const logger = {
+			level: 'silent',
+			child: () => logger,
+			trace: () => undefined,
+			debug: () => undefined,
+			info: () => undefined,
+			warn: () => undefined,
+			error: () => undefined
+		}
+		const ctx = {
+			ev: Object.assign(new EventEmitter(), {
+				createBufferedFunction: <A extends unknown[], R>(work: (...a: A) => Promise<R>) => work
+			}),
+			logger,
+			fullConfig: { options: {}, emitOwnEvents: false },
+			getUser: () => ({ id: '15550000000@s.whatsapp.net' }),
+			getMe: () => ({ id: '15550000000@s.whatsapp.net' }),
+			getClient: async () => client
+		} as unknown as SocketContext
+		await assert.rejects(
+			() =>
+				makeMessageMethods(ctx).relayMessage('120363000000000000@g.us', INTERACTIVE, {
+					messageId: '3EB0DERIVED0004',
+					additionalNodes: [biz]
+				}),
+			(error: unknown) => error === boom
+		)
+		assert.equal(attempts.length, 0)
+	})
+})

--- a/src/__tests__/relay-derived-stanza-node.test.ts
+++ b/src/__tests__/relay-derived-stanza-node.test.ts
@@ -89,7 +89,7 @@ describe('a stanza node the engine derives for itself', () => {
  * A relay whose first attempt is refused for `refusedTag`, recording the nodes
  * of every attempt so the retry can be told apart from the original.
  */
-const relayRefusing = (refusedTag: string | undefined) => {
+const relayRefusing = (...refusedTags: readonly string[]) => {
 	const attempts: BinaryNode[][] = []
 	const logger = {
 		level: 'silent',
@@ -101,9 +101,23 @@ const relayRefusing = (refusedTag: string | undefined) => {
 		error: () => undefined
 	}
 	const client = {
+		// The engine reports one conflicting tag per attempt, so the double is
+		// driven by the same list: attempt N is refused for `refusedTags[N]`.
 		relayMessageBytesWithOptions: async (_jid: string, _bytes: Uint8Array, messageId: string, nodes: BinaryNode[]) => {
 			attempts.push(nodes)
-			if (attempts.length === 1 && refusedTag) throw conflict(refusedTag)
+			const refused = refusedTags[attempts.length - 1]
+			if (refused) throw conflict(refused)
+			return messageId
+		},
+		sendStatusMessageBytesWithOptions: async (
+			_bytes: Uint8Array,
+			_recipients: string[],
+			messageId: string,
+			nodes: BinaryNode[]
+		) => {
+			attempts.push(nodes)
+			const refused = refusedTags[attempts.length - 1]
+			if (refused) throw conflict(refused)
 			return messageId
 		}
 	}
@@ -148,7 +162,7 @@ describe('relayMessage against an engine that derives its own stanza children', 
 	})
 
 	it('sends once when nothing is refused', async () => {
-		const { attempts, relay } = relayRefusing(undefined)
+		const { attempts, relay } = relayRefusing()
 		await relay('120363000000000000@g.us', INTERACTIVE, {
 			messageId: '3EB0DERIVED0003',
 			additionalNodes: [biz]
@@ -159,9 +173,14 @@ describe('relayMessage against an engine that derives its own stanza children', 
 	it('propagates a rejection that is not this one, without a second send', async () => {
 		// The failure mode that matters: retrying an unrelated error is how one
 		// send becomes two messages.
-		const { attempts } = relayRefusing('biz')
+		const attempts: BinaryNode[][] = []
 		const boom = { kind: 'not-connected' }
-		const client = { relayMessageBytesWithOptions: async () => Promise.reject(boom) }
+		const client = {
+			relayMessageBytesWithOptions: async (_jid: string, _bytes: Uint8Array, _id: string, nodes: BinaryNode[]) => {
+				attempts.push(nodes)
+				throw boom
+			}
+		}
 		const logger = {
 			level: 'silent',
 			child: () => logger,
@@ -189,6 +208,48 @@ describe('relayMessage against an engine that derives its own stanza children', 
 				}),
 			(error: unknown) => error === boom
 		)
-		assert.equal(attempts.length, 0)
+		// One attempt, not zero: the send has to have happened once and not been
+		// repeated. Counting on a client the test never installs would pass on
+		// both, which is what this assertion used to do.
+		assert.equal(attempts.length, 1)
+	})
+
+	it('drops every tag the engine names, one refusal at a time', async () => {
+		// A DM carrying an interactive payload derives both `<biz>` and `<bot>`,
+		// and the engine reports one per attempt. Stopping after the first would
+		// leave the caller failing on the second.
+		const { attempts, relay } = relayRefusing('biz', 'bot')
+		await relay('15550000001@s.whatsapp.net', INTERACTIVE, {
+			messageId: '3EB0DERIVED0005',
+			additionalNodes: [biz, bot, unrelated]
+		})
+
+		assert.equal(attempts.length, 3)
+		assert.deepEqual(attempts[1], [bot, unrelated])
+		assert.deepEqual(attempts[2], [unrelated], 'only the derived tags come off')
+	})
+
+	it('gives up rather than looping when the engine keeps naming a tag that is gone', async () => {
+		// Defensive: a refusal naming a tag the caller never sent cannot be fixed
+		// by dropping anything, and must not become an endless resend.
+		const { attempts, relay } = relayRefusing('bot', 'bot', 'bot')
+		await assert.rejects(() =>
+			relay('120363000000000000@g.us', INTERACTIVE, {
+				messageId: '3EB0DERIVED0006',
+				additionalNodes: [biz]
+			})
+		)
+		assert.equal(attempts.length, 1)
+	})
+
+	it('retries a status relay the same way', async () => {
+		const { attempts, relay } = relayRefusing('biz')
+		await relay('status@broadcast', INTERACTIVE, {
+			messageId: '3EB0DERIVED0007',
+			additionalNodes: [biz],
+			statusJidList: ['15550000002@s.whatsapp.net']
+		})
+		assert.equal(attempts.length, 2)
+		assert.deepEqual(attempts[1], [])
 	})
 })


### PR DESCRIPTION
## Summary

Bridge `0.10.0` → `0.11.0`, which carries [whatsapp-rust#1296](https://github.com/oxidezap/whatsapp-rust/pull/1296), plus the compatibility work that bump requires here.

An interactive message with a native-flow button gets a `<biz>` derived from its content. A caller that supplies its own put two on one `<message>`, and the client silently declines to render that — the server acks, delivered and read receipts come back, and the button appears nowhere. The engine now refuses the caller's node instead of stacking both, which is right: the two can disagree on `native_flow_name` and nothing at that layer knows which the server honours.

That leaves this library with a problem to absorb. Upstream Baileys derives nothing, so **attaching that node is what every payment recipe in that ecosystem tells a caller to do** — and that code is exactly what runs here. Left alone, code that works upstream would start throwing.

Found from a live bot whose PIX button stopped rendering. Measured both ways on the same account and group:

```xml
<!-- what the bot sent: nothing renders -->
<biz actual_actors="2" host_storage="2" native_flow_name="payment_info" privacy_mode_ts="…"/>
<biz native_flow_name="payment_info"/>

<!-- derived node alone: renders -->
<biz actual_actors="2" host_storage="2" native_flow_name="payment_info" privacy_mode_ts="…"/>
```

## Design

`relayMessage` retries once, without the tag the engine named, when the engine refuses for that reason.

**Retried rather than filtered up front.** Only the engine knows which nodes it derives for a given message. Replicating that rule here — "does this carry an interactive payload with buttons or a renderable envelope" — would duplicate core logic and go out of sync with the first button WhatsApp adds. The refusal happens while the engine validates, before it encrypts or sends anything, so the retry cannot deliver the message twice.

**Kept narrow.** The tag is read from the rejection's own sentence (`extra stanza child <biz> conflicts with the one this send derives`), so an unrelated `invalid-argument` — a malformed JID, an out-of-range enum — still reaches the caller untouched. A blanket retry on `invalid-argument` is how one send becomes two messages, and that case has its own test.

**The escape hatch stays open.** A caller node the engine did not derive is never dropped, because on a message that derives nothing the caller's node is the only one there is. The engine preserves that too, and this matches it rather than second-guessing it.

**Cost:** nothing is scanned on a send that succeeds. The work exists only after a refusal that would otherwise have been an error.

## Alternatives rejected

- **Filter `<biz>` unconditionally at the boundary** — breaks the escape hatch above.
- **Replicate the inference rule** — duplicates core logic, drifts on the next button name.
- **Ask the engine whether it will derive** — needs new core API for something the retry already answers.

## Validation

`npm test` — 1285 passing, no existing test needed adapting. `tsc`, `oxlint`, `oxfmt` clean.

New: `src/__tests__/relay-derived-stanza-node.test.ts`, 10 tests. Six on the predicate, including every rejection shape that must **not** be retried; four through `relayMessage` itself with a client that refuses the first attempt, asserting the retry drops only the named tag, keeps the caller's other nodes, sends once when nothing is refused, and never retries an unrelated rejection.

Reverting the retry drops two of them, both from the `relayMessage` group.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps caller-supplied `<biz>` working after upgrading to `@oxidezap/whatsapp-rust-bridge` 0.11.0. Old: duplicate derived-and-caller `<biz>` made sends fail or render nothing; new: we remove only the conflicting derived tag(s) the engine names and resend, so Baileys recipes send once and still work.

**Review notes**
- Bumps `@oxidezap/whatsapp-rust-bridge` to 0.11.0.
- Both chat and status relays go through a bounded retry that drops only the conflicting derived tag (`<biz>`, `<bot>`, etc.) named by the engine, repeating until no conflict; if the named tag is not present, the original error is rethrown.
- Unrelated errors are not retried; non-derived caller nodes are preserved.
- New helpers `sendDroppingDerivedNodes`, `derivedNodeConflictTag`, and `withoutDerivedNode` in `src/Compatibility/derived-stanza-nodes.ts`; wired in `src/Socket/messages.ts`.
- Tests added in `src/__tests__/relay-derived-stanza-node.test.ts`; no API or migration changes.

<sup>Written for commit fb0fbe92be5ae65b5739b323150e81c003ec34cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message relay reliability when an engine-generated node conflicts with supplied message data.
  * Automatically retries affected relays after removing only the conflicting node.
  * Preserves unrelated nodes and continues to surface unrelated errors normally.

* **Tests**
  * Added coverage for conflict detection, selective node removal, retry behavior, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->