### PR TITLE
perf(transport): forward ArrayBuffer-backed frames instead of rebuilding them

### DIFF
--- a/src/Socket/transport.ts
+++ b/src/Socket/transport.ts
@@ -8,10 +8,31 @@ interface TransportConfig {
 	options?: RequestInit
 }
 
+/**
+ * `WebSocket.send()` takes a `BufferSource`, which is `ArrayBufferView<ArrayBuffer>
+ * | ArrayBuffer` — a `SharedArrayBuffer`-backed view is outside that contract.
+ * The bridge hands us the wider `Uint8Array<ArrayBufferLike>`, so the backing
+ * buffer has to be discriminated at runtime; this predicate is what carries that
+ * runtime check into the type system.
+ */
+const isArrayBufferBacked = (data: Uint8Array): data is Uint8Array<ArrayBuffer> => data.buffer instanceof ArrayBuffer
+
+/**
+ * Narrows an outgoing frame to what `WebSocket.send()` accepts.
+ *
+ * The `ArrayBuffer` case returns the caller's view as-is. Rebuilding it — the
+ * `new Uint8Array(data.buffer, data.byteOffset, data.byteLength)` this used to
+ * do — produced a view over the same buffer at the same offset and length: an
+ * allocation per outgoing frame that existed only to restate the type. It also
+ * did not detach the view from WASM memory growth, so returning the original
+ * gives the payload exactly the lifetime it had before; both are aliases of the
+ * same linear memory, consumed synchronously by the `ws.send()` on the next line.
+ *
+ * The `SharedArrayBuffer` case still copies: that one is not a type formality,
+ * the send API genuinely cannot take a view over shared memory.
+ */
 const asWebSocketPayload = (data: Uint8Array): Uint8Array<ArrayBuffer> =>
-	data.buffer instanceof ArrayBuffer
-		? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
-		: new Uint8Array(data)
+	isArrayBufferBacked(data) ? data : new Uint8Array(data)
 
 export const makeTransport = (config: TransportConfig): JsTransportCallbacks => {
 	const { waWebSocketUrl, logger } = config

--- a/src/__tests__/transport-send-payload.test.ts
+++ b/src/__tests__/transport-send-payload.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Every outgoing frame goes through `asWebSocketPayload` on its way to
+ * `WebSocket.send()`, whose `BufferSource` parameter is `ArrayBufferView<ArrayBuffer>
+ * | ArrayBuffer` — it does not accept a view over a `SharedArrayBuffer`. The
+ * bridge types both `send` and `sendBorrowed` as the wider `Uint8Array`, i.e.
+ * `Uint8Array<ArrayBufferLike>`, so the transport has to discriminate the backing
+ * buffer at runtime.
+ *
+ * That check used to rebuild the view in the `ArrayBuffer` case — same buffer,
+ * same offset, same length — which is an allocation per frame that changes
+ * nothing about the bytes or their lifetime. These tests pin down the two halves
+ * of the replacement: the `ArrayBuffer` case forwards the caller's own view, and
+ * the `SharedArrayBuffer` case still copies.
+ *
+ * The last test uses a real `WebAssembly.Memory` because that is where
+ * `sendBorrowed`'s view actually comes from — the bridge's glue hands out a
+ * `subarray()` of its cached `Uint8Array` over `wasm.memory.buffer`, and growing
+ * that memory detaches the buffer under every view of it.
+ */
+
+import { beforeEach, describe, it } from 'node:test'
+
+import { makeTransport } from '../Socket/transport.ts'
+import type { ILogger } from '../Utils/logger.ts'
+import { expect } from './expect.ts'
+
+const silentLogger = {
+	level: 'silent',
+	child: () => silentLogger,
+	trace: () => {},
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {}
+} as unknown as ILogger
+
+/**
+ * Stands in for undici's `WebSocket`. `send()` snapshots its argument the way
+ * `WebsocketFrameSend.createFrame` does — `Buffer.allocUnsafe` plus an XOR mask
+ * into fresh memory — so a test can look at what was handed over *and* at what
+ * was actually put on the wire, and tell the two apart.
+ */
+class FakeWebSocket {
+	static readonly OPEN = 1
+
+	readonly url: string
+	readyState = FakeWebSocket.OPEN
+	binaryType = 'blob'
+	readonly handed: ArrayBufferView[] = []
+	readonly framed: Uint8Array[] = []
+
+	private readonly listeners = new Map<string, Set<(event: unknown) => void>>()
+
+	constructor(url: string) {
+		this.url = url
+		// The transport only settles `connect()` once `open` fires, and it
+		// subscribes after the constructor returns.
+		queueMicrotask(() => this.dispatch('open'))
+	}
+
+	addEventListener(type: string, listener: (event: never) => void) {
+		const set = this.listeners.get(type) ?? new Set()
+		set.add(listener as (event: unknown) => void)
+		this.listeners.set(type, set)
+	}
+
+	send(data: ArrayBufferView) {
+		this.handed.push(data)
+		this.framed.push(Uint8Array.from(new Uint8Array(data.buffer, data.byteOffset, data.byteLength)))
+	}
+
+	close() {
+		this.readyState = 3
+		this.dispatch('close')
+	}
+
+	private dispatch(type: string) {
+		for (const listener of this.listeners.get(type) ?? []) listener({})
+	}
+}
+
+const connect = async () => {
+	const transport = makeTransport({ waWebSocketUrl: 'ws://127.0.0.1:1/ws', logger: silentLogger })
+	await transport.connect({ onConnected: () => {}, onData: () => {}, onDisconnected: () => {} })
+	return transport
+}
+
+/** The most recent socket the transport constructed. */
+let sockets: FakeWebSocket[] = []
+const lastSocket = () => sockets[sockets.length - 1]!
+
+describe('transport: outgoing frame payloads', () => {
+	beforeEach(() => {
+		sockets = []
+		class Tracked extends FakeWebSocket {
+			constructor(url: string) {
+				super(url)
+				sockets.push(this)
+			}
+		}
+		globalThis.WebSocket = Tracked as unknown as typeof WebSocket
+	})
+
+	it('hands an ArrayBuffer-backed frame straight to the socket', async () => {
+		const transport = await connect()
+		const frame = new Uint8Array([1, 2, 3, 4])
+
+		transport.send(frame)
+
+		// Identity, not just equality: a rebuilt view would be a second object
+		// over the same bytes, which is the allocation this asserts is gone.
+		expect(lastSocket().handed[0]).toBe(frame)
+	})
+
+	it('hands a borrowed ArrayBuffer-backed frame straight to the socket', async () => {
+		const transport = await connect()
+		const frame = new Uint8Array([9, 8, 7])
+
+		transport.sendBorrowed?.(frame)
+
+		expect(lastSocket().handed[0]).toBe(frame)
+	})
+
+	it('keeps the exact window of a sub-view', async () => {
+		const transport = await connect()
+		const backing = new Uint8Array(32)
+		backing.set([10, 20, 30, 40], 8)
+		const frame = backing.subarray(8, 12)
+
+		transport.send(frame)
+
+		const handed = lastSocket().handed[0]!
+		// The old rebuild preserved buffer/offset/length; so must the passthrough.
+		expect(handed.buffer).toBe(backing.buffer)
+		expect(handed.byteOffset).toBe(8)
+		expect(handed.byteLength).toBe(4)
+		expect([...lastSocket().framed[0]!]).toEqual([10, 20, 30, 40])
+	})
+
+	it('copies a SharedArrayBuffer-backed frame, which the send API cannot take', async () => {
+		const transport = await connect()
+		const shared = new SharedArrayBuffer(4)
+		const frame = new Uint8Array(shared)
+		frame.set([5, 6, 7, 8])
+
+		transport.send(frame)
+
+		const handed = lastSocket().handed[0]!
+		expect(handed).not.toBe(frame)
+		expect(handed.buffer).toBeInstanceOf(ArrayBuffer)
+		expect(handed.buffer).not.toBe(shared)
+		expect([...new Uint8Array(handed.buffer, handed.byteOffset, handed.byteLength)]).toEqual([5, 6, 7, 8])
+		// The source is untouched — the copy is a copy, not a move.
+		expect([...frame]).toEqual([5, 6, 7, 8])
+	})
+
+	it('copies a borrowed SharedArrayBuffer-backed frame too', async () => {
+		const transport = await connect()
+		const frame = new Uint8Array(new SharedArrayBuffer(2))
+		frame.set([1, 2])
+
+		transport.sendBorrowed?.(frame)
+
+		const handed = lastSocket().handed[0]!
+		expect(handed).not.toBe(frame)
+		expect(handed.buffer).toBeInstanceOf(ArrayBuffer)
+	})
+
+	it('is consumed before WASM memory growth can invalidate the borrowed view', async () => {
+		const transport = await connect()
+		const memory = new WebAssembly.Memory({ initial: 1 })
+		// How the bridge's glue produces the borrowed view: a subarray of a
+		// Uint8Array over the wasm memory buffer, at some offset into it.
+		const frame = new Uint8Array(memory.buffer).subarray(64, 68)
+		frame.set([1, 2, 3, 4])
+		expect(memory.buffer).toBeInstanceOf(ArrayBuffer)
+
+		transport.sendBorrowed?.(frame)
+
+		// Growing detaches `memory.buffer`, and with it every view over it —
+		// including the one the transport forwarded. This is exactly as true of
+		// the view the old code rebuilt: both alias the same linear memory, so
+		// passing the caller's view through does not extend anything's lifetime.
+		memory.grow(1)
+		expect(frame.byteLength).toBe(0)
+		expect(lastSocket().handed[0]!.byteLength).toBe(0)
+		// The frame still went out intact, because the socket took its own copy
+		// inside the synchronous `send()` — which is what the bridge's borrow
+		// contract requires of this transport.
+		expect([...lastSocket().framed[0]!]).toEqual([1, 2, 3, 4])
+	})
+})

--- a/src/__tests__/transport-send-payload.test.ts
+++ b/src/__tests__/transport-send-payload.test.ts
@@ -18,7 +18,7 @@
  * that memory detaches the buffer under every view of it.
  */
 
-import { beforeEach, describe, it } from 'node:test'
+import { afterEach, beforeEach, describe, it } from 'node:test'
 
 import { makeTransport } from '../Socket/transport.ts'
 import type { ILogger } from '../Utils/logger.ts'
@@ -89,7 +89,16 @@ const connect = async () => {
 let sockets: FakeWebSocket[] = []
 const lastSocket = () => sockets[sockets.length - 1]!
 
+const platformWebSocket = globalThis.WebSocket
+
 describe('transport: outgoing frame payloads', () => {
+	// `node --test` gives each file its own process, so this suite cannot reach
+	// another one — but nothing about that is guaranteed by the file itself, and
+	// a stub for the platform WebSocket is not something to leave installed.
+	afterEach(() => {
+		globalThis.WebSocket = platformWebSocket
+	})
+
 	beforeEach(() => {
 		sockets = []
 		class Tracked extends FakeWebSocket {


### PR DESCRIPTION
## What

`asWebSocketPayload` rebuilt every outgoing frame whose backing buffer is an `ArrayBuffer`:

```ts
data.buffer instanceof ArrayBuffer
    ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)  // same buffer, same offset, same length
    : new Uint8Array(data)
```

The true branch produced a view that aliases the exact bytes it was handed — same buffer, same offset, same length. The allocation existed only to restate `Uint8Array<ArrayBufferLike>` as the `Uint8Array<ArrayBuffer>` that `WebSocket.send()` requires (`lib.dom.d.ts`: `send(data: BufferSource | Blob | string)`, and `type BufferSource = ArrayBufferView<ArrayBuffer> | ArrayBuffer`).

Replaced with a type predicate, which carries the same runtime check into the type system without allocating. Signature unchanged, no `any`, no cast:

```ts
const isArrayBufferBacked = (data: Uint8Array): data is Uint8Array<ArrayBuffer> =>
    data.buffer instanceof ArrayBuffer

const asWebSocketPayload = (data: Uint8Array): Uint8Array<ArrayBuffer> =>
    isArrayBufferBacked(data) ? data : new Uint8Array(data)
```

The `SharedArrayBuffer` branch still copies. That one is not a type formality — the send API genuinely does not accept a view over shared memory.

## Why the true branch is identical for every caller

Both callers were checked against bridge 0.11.0, not just read off the type:

- **`sendBorrowed`** — the bridge's glue caches `new Uint8Array(V.memory.buffer)` and hands out `…subarray(ptr, ptr + len)` (the standard wasm-bindgen `getArrayU8FromWasm0`). Parsing the memory section of `whatsapp_rust_bridge_bg.wasm` gives **flags `0x0`** — non-shared, no maximum. So the borrowed view is `ArrayBuffer`-backed, and this is the hot path in production.
- **`send`** — owned `Vec<u8>`, `.slice()`d out by the glue into its own `ArrayBuffer`.

## Lifetime / WASM realloc

The forwarded view does not survive longer than the rebuilt one did. The old view was an alias of the same WASM linear memory — it did not detach anything — so both die on the same `memory.grow()`, and both are consumed by the synchronous `ws.send()` on the next line. `src/__tests__/transport-send-payload.test.ts` drives this with a real `WebAssembly.Memory`: after the send, `memory.grow(1)` zeroes both the caller's view and the one the transport forwarded, and the frame still went out intact because the socket copied inside its synchronous `send()` — which is exactly what the bridge's borrow contract requires of this transport.

## Measurements

Node v22.22.2, x64. Retained bytes are measured with the result of every call kept alive in a preallocated array and a full GC before the second heap reading, so the delta is what survived rather than what a scavenge happened to leave behind.

**4 separate processes × 15 reps each = 60 repetitions**, 200 000 calls per rep, median reported.

### Retained bytes per call

| case | before | after |
| --- | --- | --- |
| wasm-backed view, 64 B frame | 96.00 B | 0.00 B |
| wasm-backed view, 512 B frame | 96.00 B | 0.00 B |
| wasm-backed view, 4096 B frame | 96.00 B | 0.00 B |
| owned view, 512 B frame | 96.00 B | 0.00 B |
| through `transport.send()`, 512 B frame | 96.03 B | 0.03 B |

Every rep of every process landed in `96.00–96.07 B` before and `0.00–0.06 B` after. The cost is the `JSTypedArray` header and is frame-size independent, as expected for a view.

Note: the figure this was filed under was 103 B. The measured value here is **96 B** — same object, and the correction does not change the conclusion.

### ns per call (microbenchmark, same runs)

| frame | before | after |
| --- | --- | --- |
| 64 B | 77.7 ns | 22.3 ns |
| 512 B | 76.7 ns | 22.4 ns |
| 4096 B | 78.6 ns | 22.7 ns |

This is the helper in a tight loop, including the GC amortization of the discarded views. It is **not** a claim about library throughput: in the real send path this is dominated by frame construction, XOR masking and the write syscall.

## What this is not

**This does not reduce process RSS, and no such claim is made.** The retention per message in this library is ~0; long-run RSS growth is V8 sizing its heap for garbage it was never forced to collect — a step function that saturates, not an accumulation. Reductions in transient allocation have not moved RSS reproducibly in prior experiments on this codebase, one of which came out ~6 MiB *worse*. The justification here is that the allocation does nothing, not that it will show up on a memory graph.

## Out of scope

- **undici.** `sendBorrowed` does not survive `WebsocketFrameSend.createFrame`, which does `Buffer.allocUnsafe` and applies the XOR mask into a fresh buffer. That is not an implementation gap — masking in place would corrupt WASM linear memory. `ws` does the same, and there is no knob on `WebSocketInit`.
- **Swapping the WebSocket client.** Moving to `ws` measured ~2.8 MiB *worse*: undici is already resident via `fetch`, `ws` is an additional module graph.

## Tests

New `src/__tests__/transport-send-payload.test.ts`, 6 cases: view identity through `send` and `sendBorrowed`, sub-view window preservation (buffer/offset/length), the `SharedArrayBuffer` copy on both methods, and the WASM-growth case above.

Checked against the *old* implementation to confirm the tests have teeth: 2 fail (exactly the two identity cases), 4 pass.

Full unit suite: **1294 pass, 0 fail, 1 skipped** (pre-existing). `tsc`, `oxlint` and `oxfmt` clean.

`npm run compat:layers` could not run in this environment — it wants the sibling `whatsapp-rust` checkout (`ENOENT: /home/user/whatsapp-rust/src`). Unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBqS4VVazySDQzkhFEYXHW)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards ArrayBuffer-backed frames directly to WebSocket.send(), removing a per-frame view allocation without changing bytes or lifetime. Previously `asWebSocketPayload` rebuilt a new `Uint8Array` for `ArrayBuffer`; now it returns the original view and still copies for `SharedArrayBuffer`.

- Adds `isArrayBufferBacked` type predicate; `asWebSocketPayload(data)` returns `data` for `ArrayBuffer`, `new Uint8Array(data)` for `SharedArrayBuffer`. Signatures unchanged.
- Behavior: socket receives the caller’s view (same buffer/offset/length); `send` and `sendBorrowed` unchanged functionally; lifetime identical and consumed synchronously; `SharedArrayBuffer` remains copied.
- Perf: removes ~96 B transient allocation per call; helper drops from ~78 ns to ~22 ns (microbench).
- Tests: new `src/__tests__/transport-send-payload.test.ts` covers view identity, sub-view windows, both `SharedArrayBuffer` copy paths, and WASM `memory.grow()` invalidation timing; restores the platform `WebSocket` after each test to avoid leaking the stub.

<sup>Written for commit 72520cc82de9535fe874f2608673ddc1de9ade60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved WebSocket payload handling to avoid unnecessary copying for compatible binary data.
  * Preserved correct payload boundaries for subviews and safely handled shared or detached memory.
* **Bug Fixes**
  * Improved reliability when sending data backed by shared memory or memory that changes during transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->