### PR TITLE
deps: move to bridge 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.11.0",
+        "@oxidezap/whatsapp-rust-bridge": "0.12.0",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.11.0.tgz",
-      "integrity": "sha512-k00OYftRzbHabPnCjZOadLZVuZcvnmoCJIh0Zt+4uvHqBFtf6LCIB8urhHSbEaR0uGbUDuWNFN0LGRFtWM2zwA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.12.0.tgz",
+      "integrity": "sha512-8gsNbIUTklowhYQQqq682wgFD0Ony544VQ4vUVsTBymlRiUszuSC+QZfY46W+90vFHAXH1sfErkCbdazCZVprw==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@oxidezap/whatsapp-rust-bridge": "0.11.0",
+    "@oxidezap/whatsapp-rust-bridge": "0.12.0",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"


### PR DESCRIPTION
Moves the bridge dependency from `0.11.0` to [`0.12.0`](https://github.com/oxidezap/whatsapp-rust-bridge/releases/tag/v0.12.0).

## What it brings

- **`fix(wire)`** ([#57](https://github.com/oxidezap/whatsapp-rust-bridge/issues/57)) — the packed string region was decoded as latin1 below 100 bytes and sliced by byte lengths against UTF-16 indices above it. Non-ASCII peer data was silently corrupted either way: `"leído"` arrived as `"leÃdo"` in the short regime, and in the long one a value ate its neighbour's first character and shifted everything behind it. Push names and message ids with accents are the everyday case.
- **`perf(wire)`!** ([#58](https://github.com/oxidezap/whatsapp-rust-bridge/issues/58)) — the message wire batch now holds its string table across batches, as the receipt path already did. Declared breaking, but both ends of that format ship inside the bridge package.
- **`perf`** ([#63](https://github.com/oxidezap/whatsapp-rust-bridge/issues/63)) — caps wasm-opt's single-caller inlining and takes the core's `msg_secrets` bound.
- **`perf`** ([#62](https://github.com/oxidezap/whatsapp-rust-bridge/issues/62)) — a source build can now drop the domains it does not use. Opt-in; the published artifact is unchanged.

## Measured effect on this library

A/B of the two **published** packages through `wabench`'s `pingpong` against Barback — `0.11.0` is this repository at `c879042`, `0.12.0` is this branch, nothing else differs. Nine rounds with the arms interleaved, 30 000 messages at 1000 msg/s, both sources frozen in detached worktrees, USS sampled in the client process, sign test over the per-round deltas.

| metric | 0.11.0 | 0.12.0 | delta | sign | p |
|---|---|---|---|---|---|
| USS after connect | 91.54 MiB | 70.59 MiB | **−20.95 MiB (−22.9 %)** | 9/9 | 0.004 |
| peak USS | 118.27 MiB | 92.64 MiB | **−25.63 MiB (−21.7 %)** | 9/9 | 0.004 |
| total CPU | 12.04 s | 12.16 s | +0.12 s (+1.0 %) | 4/9 | 1.000 |

The memory result is the whole of `0.12.0`, not one change: the bridge attributed it as ~18 MiB from the inlining cap (a per-process compile-time constant) plus ~6 MiB from the `msg_secrets` bound (which grows per message sent, so it lands on the peak). The two component figures sum to −24.3 MiB against the −25.6 MiB measured here, which is the consistency check.

CPU does not separate at this volume and should not be read as a win. The bridge measured a small decode penalty from the inlining cap that only appears once V8 has finished compiling lazily — a long-lived process at high message rates is where it would show, and this run is 30 s.

## Verification

```
npm run build                  clean
npm run lint (tsc + oxlint)    clean
npm test                       1294 passed, 1 skipped, 0 failed
npm run compat:check-waproto   clean
npm run compat:audit:proto     unchanged vs main
npm run compat:audit:wire      preserved 1970, dropped 0, altered 0, divergent 2
npm run compat:layers          unchanged vs main
```

`compat:audit:wire`'s two divergent entries and `compat:layers`'s three violations were confirmed identical on `main` before this change — both are pre-existing and unrelated.

## Not verified

- No end-to-end run against a real WhatsApp server; the measurement above is against the Barback fixture.
- The breaking change in [#58](https://github.com/oxidezap/whatsapp-rust-bridge/issues/58) is internal to the bridge's own wire format, so nothing here exercises a mismatched pairing — this library never sees that format directly.
- The memory numbers come from one machine and one scenario, with the client about 97 % idle. A busier or differently-shaped workload may trade differently.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `@oxidezap/whatsapp-rust-bridge` from 0.11.0 to 0.12.0 to fix wire string decoding that corrupted non‑ASCII data and to reduce memory usage. Previously, short strings could be decoded as latin1 or sliced against UTF‑16 indices; now strings decode correctly with no API changes.

**Review notes**
- Scope: only `package.json` and lockfile updated.
- Behavior: push names and message IDs with accents now arrive intact; no external wire/API changes.
- Compatibility: an internal bridge wire-batch format change is self-contained within the `@oxidezap/whatsapp-rust-bridge` package; no migration required.
- Performance: expect lower memory (~20–26 MiB USS reduction observed); CPU impact neutral in typical runs.
- Validation: run the test suite and spot-check accented names/IDs in fixtures; no end-to-end server verification included here.

<sup>Written for commit a5307802d1c4c8e535d8cf0622244dce19dee137. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WhatsApp integration dependency to version 0.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->