### PR TITLE
fix(release): recognise deps commits so a dependency bump reaches the changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,7 @@
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },
         { "type": "perf", "section": "Performance" },
+        { "type": "deps", "section": "Dependencies" },
         { "type": "refactor", "section": "Refactors" },
         { "type": "chore", "section": "Chores", "hidden": true },
         { "type": "docs", "section": "Documentation", "hidden": true },


### PR DESCRIPTION
Release PR [#63](https://github.com/oxidezap/baileyrs/pull/63) proposes `0.2.1` listing only [#62](https://github.com/oxidezap/baileyrs/pull/62). It is missing [#64](https://github.com/oxidezap/baileyrs/pull/64), which moved the bridge to `0.12.0`.

## Why it went missing

`#64` landed as `deps: move to bridge 0.12.0`, and `deps` is not among the types `changelog-sections` declares. Release Please parses every commit since the last tag on each run, finds no section for that type, and drops it — so the change never reaches the changelog and the release PR never regenerates for it. That is a mislabelled commit on my part, not a Release Please fault.

## The fix

Declare the type. Release Please re-parses the whole range on its next run, so the already-merged `0c049f8` is picked up retroactively and `#63` regenerates with a **Dependencies** entry alongside the existing **Performance** one. The version stays `0.2.1`: the patch bump is already justified by `perf(transport)`, and a dependency bump carrying no API change of our own does not warrant more.

Placed after `perf` so the section ordering reads features → fixes → performance → dependencies.

## What to do with #63

Do not merge it as it stands — its branch `CHANGELOG.md` is missing the entry, so merging now would publish `0.2.1` without recording that it carries the bridge `0.12.0` upgrade. Merge this first and let the workflow (`on: push: branches: [main]`) regenerate it.

## What this does not fix

The alternative was relabelling `#64` itself, which would mean rewriting merged history on `main`. This leaves `0c049f8`'s subject as it is and teaches the tooling to read it instead.

Also worth knowing when reviewing the regenerated `#63`: the bridge `0.12.0` bump is not only a performance change. It carries [oxidezap/whatsapp-rust-bridge#57](https://github.com/oxidezap/whatsapp-rust-bridge/pull/57), which fixes silent corruption of non-ASCII peer data — accented push names and message ids were arriving as mojibake or shifted by one value. A reader scanning the changelog for whether to upgrade should see that, and a single `Dependencies` line will not say it. Consider spelling it out in the release notes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include `deps:` commits in Release Please so dependency bumps reach the changelog and trigger release PR regeneration. Previously, `deps:` commits were dropped; now they appear under a Dependencies section placed after Performance.

- Merge this before #63; CI on `main` will regenerate the release PR to include the bridge `0.12.0` bump.
- Version stays `0.2.1`.
- This only changes `release-please` changelog section mapping; no runtime impact.

<sup>Written for commit 1dc155b16a3f870202f7b80301cadd95787084ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

