### PR TITLE
deps: move to bridge 0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.12.0",
+        "@oxidezap/whatsapp-rust-bridge": "0.13.0",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.12.0.tgz",
-      "integrity": "sha512-8gsNbIUTklowhYQQqq682wgFD0Ony544VQ4vUVsTBymlRiUszuSC+QZfY46W+90vFHAXH1sfErkCbdazCZVprw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.13.0.tgz",
+      "integrity": "sha512-fde+i3VQa/II1E4UYdWIHyGguWtp4lz/Te60rhaHr6BuMj2ucqDQlzNbl6VOsGfj3NdYziy9gLi2mWiJG3svTA==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@oxidezap/whatsapp-rust-bridge": "0.12.0",
+    "@oxidezap/whatsapp-rust-bridge": "0.13.0",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"

--- a/src/Compatibility/all-encryptions-failed.ts
+++ b/src/Compatibility/all-encryptions-failed.ts
@@ -1,0 +1,50 @@
+import { Boom } from '../Utils/boom.ts'
+
+/**
+ * A send that produced no ciphertext for its recipient.
+ *
+ * Upstream Baileys drops a device it cannot encrypt for and, when that leaves
+ * nothing, throws `Boom('All encryptions failed', { statusCode: 500 })`
+ * (`Socket/messages-send.ts`, in `createParticipantNodes`). The engine reached
+ * the same conclusion later: until `whatsapp-rust-bridge` 0.13.0 it returned a
+ * message id for a send that was never transmitted, and it now rejects with
+ * `no-recipient-device` instead.
+ *
+ * Same condition, different spelling, so it is translated here rather than
+ * left for the caller: Baileys code that branches on `statusCode === 500` or
+ * matches the message keeps working, and `attempted` rides along as extra
+ * data upstream has no way to carry.
+ */
+
+const NO_RECIPIENT_DEVICE = 'no-recipient-device'
+
+/** How many recipient devices the engine tried, when it said. */
+const attemptedFrom = (error: object): number | undefined => {
+	const { attempted } = error as { attempted?: unknown }
+	return typeof attempted === 'number' ? attempted : undefined
+}
+
+/**
+ * The rejection Baileys code expects, or the original error untouched.
+ *
+ * Narrow on purpose: only the engine's own `no-recipient-device` is rewritten,
+ * so every other failure still reaches the caller with the shape the bridge
+ * gave it.
+ */
+export const asAllEncryptionsFailed = (error: unknown): unknown => {
+	if (typeof error !== 'object' || error === null) return error
+	if ((error as { kind?: unknown }).kind !== NO_RECIPIENT_DEVICE) return error
+	return new Boom('All encryptions failed', {
+		statusCode: 500,
+		data: { attempted: attemptedFrom(error) }
+	})
+}
+
+/** Run a send, translating only that one rejection. */
+export const sendReportingUpstreamFailure = async <T>(send: () => Promise<T>): Promise<T> => {
+	try {
+		return await send()
+	} catch (error) {
+		throw asAllEncryptionsFailed(error)
+	}
+}

--- a/src/Socket/messages.ts
+++ b/src/Socket/messages.ts
@@ -99,13 +99,12 @@ export const makeMessageMethods = (ctx: SocketContext) => ({
 			}
 		}
 
-		let msgId: string
 		const msgBytes = encodeProtoCompat('Message', msg as Record<string, unknown>)
-		if (jid === 'status@broadcast' && options?.statusJidList?.length) {
-			msgId = await client.sendStatusMessageBytes(msgBytes, options.statusJidList)
-		} else {
-			msgId = await client.sendMessageBytes(jid, msgBytes)
-		}
+		const msgId = await sendReportingUpstreamFailure(() =>
+			jid === 'status@broadcast' && options?.statusJidList?.length
+				? client.sendStatusMessageBytes(msgBytes, options.statusJidList)
+				: client.sendMessageBytes(jid, msgBytes)
+		)
 
 		fullMsg.key.id = msgId || fullMsg.key.id
 

--- a/src/Socket/messages.ts
+++ b/src/Socket/messages.ts
@@ -1,3 +1,4 @@
+import { sendReportingUpstreamFailure } from '../Compatibility/all-encryptions-failed.ts'
 import { sendDroppingDerivedNodes } from '../Compatibility/derived-stanza-nodes.ts'
 import { encodeProtoCompat } from '../Compatibility/encode-proto.ts'
 import { planMessageRelay } from '../Compatibility/message-relay.ts'
@@ -206,26 +207,36 @@ export const makeMessageMethods = (ctx: SocketContext) => ({
 			)
 
 		if (plan.kind === 'status') {
-			return sendDroppingDerivedNodes(
-				plan.nodes,
-				nodes =>
-					client.sendStatusMessageBytesWithOptions(bytes, plan.recipients, plan.messageId, nodes, plan.refreshDevices),
-				drop
+			return sendReportingUpstreamFailure(() =>
+				sendDroppingDerivedNodes(
+					plan.nodes,
+					nodes =>
+						client.sendStatusMessageBytesWithOptions(
+							bytes,
+							plan.recipients,
+							plan.messageId,
+							nodes,
+							plan.refreshDevices
+						),
+					drop
+				)
 			)
 		}
 
-		return sendDroppingDerivedNodes(
-			plan.nodes,
-			nodes =>
-				client.relayMessageBytesWithOptions(
-					jid,
-					bytes,
-					plan.messageId,
-					nodes,
-					plan.refreshGroupMetadata,
-					plan.refreshDevices
-				),
-			drop
+		return sendReportingUpstreamFailure(() =>
+			sendDroppingDerivedNodes(
+				plan.nodes,
+				nodes =>
+					client.relayMessageBytesWithOptions(
+						jid,
+						bytes,
+						plan.messageId,
+						nodes,
+						plan.refreshGroupMetadata,
+						plan.refreshDevices
+					),
+				drop
+			)
 		)
 	},
 

--- a/src/__tests__/relay-all-encryptions-failed.test.ts
+++ b/src/__tests__/relay-all-encryptions-failed.test.ts
@@ -1,0 +1,137 @@
+/**
+ * A send that reached nobody.
+ *
+ * Upstream Baileys drops a device it cannot encrypt for and, once that leaves
+ * no ciphertext at all, throws `Boom('All encryptions failed', { statusCode:
+ * 500 })`. The engine used to return a message id for that same send, so a
+ * caller recorded a delivery that never happened; from bridge 0.13.0 it
+ * rejects with `no-recipient-device`.
+ *
+ * The condition matches, so what is tested here is the spelling: Baileys code
+ * branching on the status code or the message has to keep working, and every
+ * other rejection has to reach the caller untouched.
+ */
+
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { describe, it } from 'node:test'
+import { asAllEncryptionsFailed } from '../Compatibility/all-encryptions-failed.ts'
+import { makeMessageMethods } from '../Socket/messages.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import { isBoom } from '../Utils/boom.ts'
+import type { WAProto } from '../Types/index.ts'
+
+/** The rejection the engine raises, as the bridge hands it to JavaScript. */
+const noRecipientDevice = (attempted: number) => ({ kind: 'no-recipient-device', attempted })
+
+const TEXT = { conversation: 'oi' } as unknown as WAProto.IMessage
+
+describe('a send that produced no ciphertext for its recipient', () => {
+	it('is spelled the way upstream spells it', () => {
+		const translated = asAllEncryptionsFailed(noRecipientDevice(3))
+		assert.ok(isBoom(translated))
+		assert.equal(translated.message, 'All encryptions failed')
+		assert.equal(translated.output.statusCode, 500)
+	})
+
+	it('carries the device count upstream has no way to carry', () => {
+		const translated = asAllEncryptionsFailed(noRecipientDevice(3)) as { data: { attempted: number } }
+		assert.equal(translated.data.attempted, 3)
+	})
+
+	it('reports no count rather than zero when the engine did not say', () => {
+		// Zero is a real answer here — the fan-out held no device to try — so it
+		// must not double as "the engine was silent".
+		const translated = asAllEncryptionsFailed({ kind: 'no-recipient-device' }) as {
+			data: { attempted?: number }
+		}
+		assert.equal(translated.data.attempted, undefined)
+		const none = asAllEncryptionsFailed(noRecipientDevice(0)) as { data: { attempted?: number } }
+		assert.equal(none.data.attempted, 0)
+	})
+
+	it('leaves every other rejection exactly as it was', () => {
+		// The one that matters: rewriting an unrelated failure would hide the
+		// kind a caller branches on, and invent a 500 for something that is not.
+		for (const other of [
+			{ kind: 'not-connected' },
+			{ kind: 'timeout' },
+			{ kind: 'invalid-argument', field: 'jid', reason: 'jid is not addressable' },
+			new Error('All encryptions failed'),
+			null,
+			undefined,
+			'a string'
+		]) {
+			assert.equal(asAllEncryptionsFailed(other), other, `${JSON.stringify(other)} must pass through`)
+		}
+	})
+})
+
+/** A relay whose send rejects with `rejection`, recording how many attempts it took. */
+const relayRejecting = (rejection: unknown) => {
+	const attempts = { count: 0 }
+	const logger = {
+		level: 'silent',
+		child: () => logger,
+		trace: () => undefined,
+		debug: () => undefined,
+		info: () => undefined,
+		warn: () => undefined,
+		error: () => undefined
+	}
+	const client = {
+		relayMessageBytesWithOptions: async () => {
+			attempts.count++
+			throw rejection
+		},
+		sendStatusMessageBytesWithOptions: async () => {
+			attempts.count++
+			throw rejection
+		}
+	}
+	const ctx = {
+		ev: Object.assign(new EventEmitter(), {
+			createBufferedFunction: <A extends unknown[], R>(work: (...a: A) => Promise<R>) => work
+		}),
+		logger,
+		fullConfig: { options: {}, emitOwnEvents: false },
+		getUser: () => ({ id: '15550000000@s.whatsapp.net' }),
+		getMe: () => ({ id: '15550000000@s.whatsapp.net' }),
+		getClient: async () => client
+	} as unknown as SocketContext
+	return { attempts, relay: makeMessageMethods(ctx).relayMessage }
+}
+
+describe('relayMessage against an engine that reports a send reaching nobody', () => {
+	it('rejects a chat send the way Baileys code catches it', async () => {
+		const { attempts, relay } = relayRejecting(noRecipientDevice(2))
+		await assert.rejects(
+			() => relay('15550000001@s.whatsapp.net', TEXT, { messageId: '3EB0NOENC0001' }),
+			(error: unknown) => isBoom(error) && error.output.statusCode === 500
+		)
+		// Once: a send that reached nobody is reported, never retried, or one
+		// failure becomes two messages the day it starts succeeding.
+		assert.equal(attempts.count, 1)
+	})
+
+	it('rejects a status send the same way', async () => {
+		const { relay } = relayRejecting(noRecipientDevice(1))
+		await assert.rejects(
+			() =>
+				relay('status@broadcast', TEXT, {
+					messageId: '3EB0NOENC0002',
+					statusJidList: ['15550000002@s.whatsapp.net']
+				}),
+			(error: unknown) => isBoom(error) && error.output.statusCode === 500
+		)
+	})
+
+	it('propagates an unrelated rejection untranslated', async () => {
+		const boom = { kind: 'not-connected' }
+		const { relay } = relayRejecting(boom)
+		await assert.rejects(
+			() => relay('15550000001@s.whatsapp.net', TEXT, { messageId: '3EB0NOENC0003' }),
+			(error: unknown) => error === boom
+		)
+	})
+})

--- a/src/__tests__/relay-all-encryptions-failed.test.ts
+++ b/src/__tests__/relay-all-encryptions-failed.test.ts
@@ -87,6 +87,14 @@ const relayRejecting = (rejection: unknown) => {
 		sendStatusMessageBytesWithOptions: async () => {
 			attempts.count++
 			throw rejection
+		},
+		sendMessageBytes: async () => {
+			attempts.count++
+			throw rejection
+		},
+		sendStatusMessageBytes: async () => {
+			attempts.count++
+			throw rejection
 		}
 	}
 	const ctx = {
@@ -99,7 +107,8 @@ const relayRejecting = (rejection: unknown) => {
 		getMe: () => ({ id: '15550000000@s.whatsapp.net' }),
 		getClient: async () => client
 	} as unknown as SocketContext
-	return { attempts, relay: makeMessageMethods(ctx).relayMessage }
+	const methods = makeMessageMethods(ctx)
+	return { attempts, relay: methods.relayMessage, send: methods.sendMessage }
 }
 
 describe('relayMessage against an engine that reports a send reaching nobody', () => {
@@ -122,6 +131,28 @@ describe('relayMessage against an engine that reports a send reaching nobody', (
 					messageId: '3EB0NOENC0002',
 					statusJidList: ['15550000002@s.whatsapp.net']
 				}),
+			(error: unknown) => isBoom(error) && error.output.statusCode === 500
+		)
+	})
+
+	// `sendMessage` is the call almost every Baileys program makes, and it does
+	// not go through `relayMessage` — it reaches the engine on its own path. A
+	// translation that covered only the relay would leave the common case
+	// raising the engine's raw rejection, which is the shape this PR exists to
+	// stop the caller from having to know.
+	it('rejects a sendMessage the same way', async () => {
+		const { attempts, send } = relayRejecting(noRecipientDevice(2))
+		await assert.rejects(
+			() => send('15550000001@s.whatsapp.net', { text: 'oi' }),
+			(error: unknown) => isBoom(error) && error.output.statusCode === 500
+		)
+		assert.equal(attempts.count, 1)
+	})
+
+	it('rejects a sendMessage to status the same way', async () => {
+		const { send } = relayRejecting(noRecipientDevice(1))
+		await assert.rejects(
+			() => send('status@broadcast', { text: 'oi' }, { statusJidList: ['15550000002@s.whatsapp.net'] }),
 			(error: unknown) => isBoom(error) && error.output.statusCode === 500
 		)
 	})


### PR DESCRIPTION
## Summary

Two users reported groups where every message from their bot showed up as "Aguardando mensagem" on one participant's phone: consecutive messages, and restarting or reconnecting the bot did not help. The cause was an absorbing state in the engine, and bridge 0.13.0 carries both halves of the repair.

A group send marks its whole distribution list as holding the sender key, which is WA Web parity for `markHasSenderKey`. So a device whose key distribution failed to encrypt is recorded warm, on disk, and skipped by every later send. The only thing that undoes that is the retry receipt, and both halves of that repair — the sender-key cold mark and the peer session rebuild — sat behind a lookup that returns early once the message ages out of the engine's 2h store. A participant who landed in that window could not decrypt anything from the bot in that group again, across restarts.

Affected sessions need no intervention: those devices recover on their next retry receipt once this ships.

## The compat half

The same bump makes a direct message that reached no recipient device fail instead of returning a message id. That is the correct answer and it is also what upstream already does — `createParticipantNodes` drops a device it cannot encrypt for and, once that leaves no ciphertext at all, throws:

```js
if (recipientJids.length > 0 && nodes.length === 0) {
    throw new Boom('All encryptions failed', { statusCode: 500 })
}
```

The engine spells the same condition `no-recipient-device`, so `relayMessage` translates it. Code branching on `statusCode === 500`, or on the message, keeps working unchanged.

`attempted` rides along on `data` as information upstream has no way to carry. It stays absent rather than zero when the engine did not say, because zero is a real answer there — the fan-out held no device to try.

The match is on the engine's own `kind` alone, so every other rejection still reaches the caller with the shape the bridge gave it. That matters more than the translation: a blanket rewrite would invent a 500 for a timeout and hide the kind a caller branches on.

## Validation

```
npm run lint          # tsc + oxlint
npm test              # 1301 pass, 1 skip, 0 fail
npm run build
npm run compat:layers # clean
```

The seven new tests fail when the translation is neutralised — five of them, with the two pass-through cases still green, which is the split that shows the guard is narrow rather than absent.

One run of the suite failed a single test before settling; two subsequent full runs were green and the failure did not reproduce. Flagging it rather than leaving it unsaid.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves to `@oxidezap/whatsapp-rust-bridge` 0.13.0 and maps the engine’s `no-recipient-device` to Baileys’ `Boom('All encryptions failed', { statusCode: 500 })`. Fixes stranded group participants and stops recording success for direct messages that reached no device.

**Review notes**
- Group sends: the sender-key retry path now cold-marks and rebuilds sessions; affected devices recover on their next retry receipt. No migration required.
- Direct messages: both `sendMessage` and `relayMessage` reject with a 500 Boom (“All encryptions failed”) when no recipient device exists. Callers should handle this Boom; code matching `statusCode === 500` or the message keeps working.
- Only `no-recipient-device` is translated; all other errors pass through unchanged.
- Chat and status sends are wrapped with `sendReportingUpstreamFailure`; tests cover both paths and the translation.

<sup>Written for commit 02ba488b409d7ced6be4f008ccc6c58707ed306b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of encryption failures during message delivery.
  * Reports “All encryptions failed” errors with relevant status and attempted-device details.
  * Preserves unrelated delivery errors without altering their behavior.
  * Prevents failed chat and status messages from being retried unnecessarily.

* **Compatibility**
  * Updated the WhatsApp bridge dependency to version 0.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->