### PR TITLE
deps: move to bridge 0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.13.0",
+        "@oxidezap/whatsapp-rust-bridge": "0.14.0",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.13.0.tgz",
-      "integrity": "sha512-fde+i3VQa/II1E4UYdWIHyGguWtp4lz/Te60rhaHr6BuMj2ucqDQlzNbl6VOsGfj3NdYziy9gLi2mWiJG3svTA==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.14.0.tgz",
+      "integrity": "sha512-dmabe/GKJroLtgZOMFiUlnSuUu0odoWS5htDStCNcdlBD/Y+TuJfe+w45ekVIawS2LX3kpeUylhH0t56trkwxA==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@oxidezap/whatsapp-rust-bridge": "0.13.0",
+    "@oxidezap/whatsapp-rust-bridge": "0.14.0",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"

--- a/src/Bridge/schema.ts
+++ b/src/Bridge/schema.ts
@@ -242,10 +242,6 @@ const ADAPTERS = {
 	},
 
 	// ── Contacts ──
-	push_name_update: data => {
-		const jid = asJidString(data?.jid)
-		return jid ? { type: 'pushNameUpdate', jid, newPushName: asString(data?.new_push_name) } : null
-	},
 	contact_update: data => adaptContactUpdate(data),
 	contact_updated: data => adaptContactUpdate(data),
 
@@ -519,6 +515,7 @@ const ADAPTERS = {
 
 	// ── Acknowledged but no Baileys equivalent (noop) ──
 	self_push_name_updated: () => ({ type: 'noop', bridgeType: 'self_push_name_updated' }),
+	client_expiration_changed: () => ({ type: 'noop', bridgeType: 'client_expiration_changed' }),
 	offline_sync_completed: data => ({
 		type: 'offlineSyncCompleted',
 		count: asNumber(data?.count) ?? 0

--- a/src/Bridge/types.ts
+++ b/src/Bridge/types.ts
@@ -211,12 +211,6 @@ export interface CanonicalReceipt {
 
 // ── Contacts ──
 
-export interface CanonicalPushNameUpdate {
-	type: 'pushNameUpdate'
-	jid: string
-	newPushName?: string
-}
-
 export interface CanonicalContactUpdate {
 	type: 'contactUpdate'
 	jid: string
@@ -742,7 +736,6 @@ export type CanonicalEvent =
 	| CanonicalQrScannedWithoutMultidevice
 	| CanonicalMessage
 	| CanonicalReceipt
-	| CanonicalPushNameUpdate
 	| CanonicalContactUpdate
 	| CanonicalPictureUpdate
 	| CanonicalPresence

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -44,7 +44,7 @@ import { LabelAssociationType } from '../Types/LabelAssociation.ts'
 import { Boom } from '../Utils/boom.ts'
 import { toNumber } from '../Utils/generics.ts'
 import { CONVERSATION_HISTORY_SYNC_TYPES } from '../Utils/process-history-message.ts'
-import { isJidGroup } from '../WABinary/jid-utils.ts'
+import { isJidBroadcast, isJidGroup } from '../WABinary/jid-utils.ts'
 import {
 	buildGroupCreateStubMessage,
 	buildGroupJoinRequestEvents,
@@ -144,7 +144,12 @@ const emitInboundPushName = (
 	evt: { pushName?: string; isFromMe: boolean; senderJid?: string; chatJid: string }
 ) => {
 	if (!evt.pushName || evt.isFromMe) return
-	ctx.ev.emit('contacts.update', [{ id: evt.senderJid ?? evt.chatJid, notify: evt.pushName }])
+	const id = evt.senderJid ?? evt.chatJid
+	// A broadcast envelope resolves to the pseudo-contact (the canonical layer
+	// drops the participant for non-groups); naming `status@broadcast` after
+	// whoever posted last would corrupt it, so stay silent instead.
+	if (isJidBroadcast(id)) return
+	ctx.ev.emit('contacts.update', [{ id, notify: evt.pushName }])
 }
 
 const hasSameUpsertMetadata = (left: MessageUpsertMetadata, right: MessageUpsertMetadata) =>
@@ -1048,6 +1053,10 @@ const dispatchCanonicalBatch = (
 		}
 
 		if (ctx.fullConfig.shouldIgnoreJid?.(canonical.chatJid)) continue
+
+		// This branch bypasses the single-message dispatcher, so the push name
+		// has to be surfaced here too.
+		emitInboundPushName(ctx, canonical)
 
 		try {
 			const metadata = messageUpsertMetadata(canonical)

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -582,13 +582,15 @@ const DISPATCHERS: DispatcherMap = {
 			{ id: evt.id, chat: evt.chatJid, isUnavailable: evt.isUnavailable, fail: evt.decryptFailMode },
 			'undecryptable message received'
 		)
+		// The name is envelope metadata, independent of whether the failure
+		// may be surfaced, so it goes out even for `hide`. The stub below
+		// predates `shouldIgnoreJid` and stays unguarded; the push name
+		// emission is new, so it honors the predicate like the other two
+		// call sites do.
+		if (!ctx.fullConfig.shouldIgnoreJid?.(evt.chatJid)) emitInboundPushName(ctx, evt)
 		// `decrypt_fail_mode === 'hide'` means the server told us to
 		// silently drop — match that by NOT emitting an upsert.
 		if (evt.decryptFailMode === 'hide') return
-		// The stub below predates `shouldIgnoreJid` and stays unguarded; the
-		// push name emission is new, so it honors the predicate like the
-		// other two call sites do.
-		if (!ctx.fullConfig.shouldIgnoreJid?.(evt.chatJid)) emitInboundPushName(ctx, evt)
 		const stubMsg = WAProto.WebMessageInfo.fromObject({
 			key: {
 				remoteJid: evt.chatJid,
@@ -1057,11 +1059,12 @@ const dispatchCanonicalBatch = (
 
 		if (ctx.fullConfig.shouldIgnoreJid?.(canonical.chatJid)) continue
 
-		// This branch bypasses the single-message dispatcher, so the push name
-		// has to be surfaced here too.
-		emitInboundPushName(ctx, canonical)
-
 		try {
+			// This branch bypasses the single-message dispatcher, so the push
+			// name has to be surfaced here too. Inside the try: a throwing
+			// consumer listener skips this message only, like the containment
+			// in dispatchCanonicalEvent.
+			emitInboundPushName(ctx, canonical)
 			const metadata = messageUpsertMetadata(canonical)
 			const message = canonicalMessageToWAMessage(canonical)
 			if (pending && hasSameUpsertMetadata(pending, metadata)) {

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -136,6 +136,17 @@ const messageUpsertMetadata = (message: CanonicalMessage): MessageUpsertMetadata
 const hasMessageSideEffects = (message: CanonicalMessage) =>
 	message.messageProto.reactionMessage != null || message.messageProto.protocolMessage != null
 
+// Mirror upstream `messages-recv.ts`: every inbound envelope that carries a
+// push name surfaces it as `contacts.update` with `notify`. This is also what
+// replaces the bridge's dedicated `push_name_update` event, gone in 0.14.0.
+const emitInboundPushName = (
+	ctx: SocketContext,
+	evt: { pushName?: string; isFromMe: boolean; senderJid?: string; chatJid: string }
+) => {
+	if (!evt.pushName || evt.isFromMe) return
+	ctx.ev.emit('contacts.update', [{ id: evt.senderJid ?? evt.chatJid, notify: evt.pushName }])
+}
+
 const hasSameUpsertMetadata = (left: MessageUpsertMetadata, right: MessageUpsertMetadata) =>
 	left.type === right.type && left.requestId === right.requestId
 
@@ -446,6 +457,7 @@ const DISPATCHERS: DispatcherMap = {
 	// ── Messages ──
 	message: (evt, { ctx }) => {
 		if (ctx.fullConfig.shouldIgnoreJid?.(evt.chatJid)) return
+		emitInboundPushName(ctx, evt)
 		// Note: `emitOwnEvents=false` is NOT applied here. Upstream Baileys
 		// uses that flag to suppress the local echo when `sendMessage()`
 		// succeeds, not to drop inbound `fromMe` messages from other linked
@@ -568,6 +580,7 @@ const DISPATCHERS: DispatcherMap = {
 		// `decrypt_fail_mode === 'hide'` means the server told us to
 		// silently drop — match that by NOT emitting an upsert.
 		if (evt.decryptFailMode === 'hide') return
+		emitInboundPushName(ctx, evt)
 		const stubMsg = WAProto.WebMessageInfo.fromObject({
 			key: {
 				remoteJid: evt.chatJid,
@@ -586,7 +599,6 @@ const DISPATCHERS: DispatcherMap = {
 	},
 
 	// ── Contacts ──
-	pushNameUpdate: (evt, { ctx }) => ctx.ev.emit('contacts.update', [{ id: evt.jid, notify: evt.newPushName }]),
 	contactUpdate: (evt, { ctx }) => {
 		// Promote ContactAction fields into upstream's `Partial<Contact>`
 		// shape so consumers (sidebar UIs, contact pickers) see real names

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -585,7 +585,10 @@ const DISPATCHERS: DispatcherMap = {
 		// `decrypt_fail_mode === 'hide'` means the server told us to
 		// silently drop — match that by NOT emitting an upsert.
 		if (evt.decryptFailMode === 'hide') return
-		emitInboundPushName(ctx, evt)
+		// The stub below predates `shouldIgnoreJid` and stays unguarded; the
+		// push name emission is new, so it honors the predicate like the
+		// other two call sites do.
+		if (!ctx.fullConfig.shouldIgnoreJid?.(evt.chatJid)) emitInboundPushName(ctx, evt)
 		const stubMsg = WAProto.WebMessageInfo.fromObject({
 			key: {
 				remoteJid: evt.chatJid,

--- a/src/__fuzz__/bridge-events.fuzz.test.ts
+++ b/src/__fuzz__/bridge-events.fuzz.test.ts
@@ -134,6 +134,7 @@ const UNCONDITIONALLY_INERT: ReadonlySet<string> = new Set([
 	'pair_passkey_confirmation',
 	'pair_passkey_error',
 	'self_push_name_updated',
+	'client_expiration_changed',
 	'offline_sync_preview',
 	'device_list_update',
 	'identity_change',

--- a/src/__fuzz__/generators/bridge-event.ts
+++ b/src/__fuzz__/generators/bridge-event.ts
@@ -243,7 +243,6 @@ const SHAPED: Record<string, (random: Random) => Record<string, unknown>> = {
 		timestamp: generateNumber(random),
 		type: random.pick(['read', 'read-self', 'played', 'inactive', 'delivery', '', 'nonsense'])
 	}),
-	push_name_update: random => ({ jid: jidField(random), new_push_name: generateString(random) }),
 	contact_update: random => ({
 		jid: jidField(random),
 		action: { fullName: generateString(random), first_name: generateString(random), username: generateString(random) }

--- a/src/__tests__/bridge-free-safety.test.ts
+++ b/src/__tests__/bridge-free-safety.test.ts
@@ -114,7 +114,8 @@ describe('bridge: free() safety with a call in flight', { timeout: 90_000 }, () 
 		// mean the hazard moved. Add a signature only once a build emits it.
 		const WASM_MEMORY_FAULTS = [
 			'psize <= size + max_overhead', // dlmalloc's own check (bridge 0.6.5)
-			'memory access out of bounds' // the fault that beats it (bridge 0.7.0)
+			'memory access out of bounds', // the fault that beats it (bridge 0.7.0)
+			'finish: result should be None' // js-sys future panic that beats both (bridge 0.14.0)
 		]
 
 		// Documents the hazard rather than endorsing it. If a future bridge

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -1013,6 +1013,18 @@ describe('dispatch: inbound push name → contacts.update', () => {
 		expect(updates[0]?.[0]).toEqual({ id: '5511@s.whatsapp.net', notify: 'Foo' })
 	})
 
+	it('honors shouldIgnoreJid on the undecryptable path', () => {
+		const { ctx, ev } = makeCtx()
+		ctx.fullConfig = { shouldIgnoreJid: () => true } as never
+		const updates: BaileysEventMap['contacts.update'][] = []
+		ev.on('contacts.update', payload => updates.push(payload))
+		makeEventHandler(ctx)({
+			type: 'undecryptable_message',
+			data: { info: { ...baseMessageInfo, id: 'BAD-3' }, is_unavailable: false, decrypt_fail_mode: 'show' }
+		} as never)
+		expect(updates.length).toBe(0)
+	})
+
 	// A status post's canonical shape has the pseudo-contact as chatJid and no
 	// senderJid; attributing the poster's name to `status@broadcast` would let
 	// every poster overwrite one fake contact. Until the canonical layer

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -1013,6 +1013,41 @@ describe('dispatch: inbound push name → contacts.update', () => {
 		expect(updates[0]?.[0]).toEqual({ id: '5511@s.whatsapp.net', notify: 'Foo' })
 	})
 
+	// The engine's dedicated event used to fire for hidden ciphertexts too:
+	// the name is envelope metadata, independent of the suppressed stub.
+	it("still notifies when decrypt_fail_mode is 'hide'", () => {
+		const buckets = collectMany(
+			{
+				type: 'undecryptable_message',
+				data: { info: { ...baseMessageInfo, id: 'BAD-4' }, is_unavailable: false, decrypt_fail_mode: 'hide' }
+			},
+			'contacts.update',
+			'messages.upsert'
+		)
+		expect(buckets['contacts.update'][0]?.[0]).toEqual({ id: '5511@s.whatsapp.net', notify: 'Foo' })
+		expect(buckets['messages.upsert'].length).toBe(0)
+	})
+
+	// A consumer listener that throws must not abort the rest of the batch;
+	// dispatchCanonicalEvent contains the single path the same way.
+	it('contains a throwing contacts.update listener inside a wire batch', () => {
+		const { ctx, ev } = makeCtx()
+		const upserts: BaileysEventMap['messages.upsert'][] = []
+		let threw = false
+		ev.on('contacts.update', () => {
+			if (!threw) {
+				threw = true
+				throw new Error('consumer bug')
+			}
+		})
+		ev.on('messages.upsert', payload => upserts.push(payload))
+
+		makeEventHandlers(ctx).onMessageBatch?.(wireMessageBatch([{ id: 'BATCH-1' }, { id: 'BATCH-2' }]))
+
+		expect(threw).toBe(true)
+		expect(upserts.flatMap(u => u.messages.map(m => m.key.id))).toEqual(['BATCH-2'])
+	})
+
 	it('honors shouldIgnoreJid on the undecryptable path', () => {
 		const { ctx, ev } = makeCtx()
 		ctx.fullConfig = { shouldIgnoreJid: () => true } as never

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -999,6 +999,33 @@ describe('dispatch: inbound push name → contacts.update', () => {
 		)
 		expect(updates[0]?.[0]).toEqual({ id: '5511@s.whatsapp.net', notify: 'Foo' })
 	})
+
+	// The wire-batch aggregation branch never reaches the single-message
+	// dispatcher, so it has to emit the push name itself.
+	it('also notifies from wire-batched ordinary messages', () => {
+		const { ctx, ev } = makeCtx()
+		const updates: BaileysEventMap['contacts.update'][] = []
+		ev.on('contacts.update', payload => updates.push(payload))
+
+		makeEventHandlers(ctx).onMessageBatch?.(wireMessageBatch([{ id: 'BATCH-1' }, { id: 'BATCH-2' }]))
+
+		expect(updates.length).toBe(2)
+		expect(updates[0]?.[0]).toEqual({ id: '5511@s.whatsapp.net', notify: 'Foo' })
+	})
+
+	// A status post's canonical shape has the pseudo-contact as chatJid and no
+	// senderJid; attributing the poster's name to `status@broadcast` would let
+	// every poster overwrite one fake contact. Until the canonical layer
+	// carries the broadcast participant, staying silent is the correct shape.
+	it('never attributes a push name to a broadcast pseudo-contact', () => {
+		const updates = collect(
+			msgEvent({
+				source: { chat: jid('status', 'broadcast'), sender: jid('5511'), is_group: false, is_from_me: false }
+			}),
+			'contacts.update'
+		)
+		expect(updates.length).toBe(0)
+	})
 })
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -923,6 +923,82 @@ describe('dispatch: undecryptable_message', () => {
 		)
 		expect(upserts.length).toBe(0)
 	})
+
+	// Bridge 0.14.0 dedupes dispatched undecryptables by (chat, id, sender)
+	// instead of (chat, id): two group participants reusing an id are two
+	// messages, and both now reach the consumer.
+	it('emits one stub per sender when two participants reuse the same id', () => {
+		const { ctx, ev } = makeCtx()
+		const upserts: BaileysEventMap['messages.upsert'][] = []
+		ev.on('messages.upsert', payload => upserts.push(payload))
+		const handler = makeEventHandler(ctx)
+		const fromSender = (user: string) => ({
+			type: 'undecryptable_message',
+			data: {
+				info: {
+					source: { chat: jid('123456', 'g.us'), sender: jid(user), is_group: true, is_from_me: false },
+					id: 'DUP-1',
+					timestamp: 1730000000,
+					push_name: ''
+				},
+				is_unavailable: false,
+				decrypt_fail_mode: 'show'
+			}
+		})
+		handler(fromSender('5511') as never)
+		handler(fromSender('5522') as never)
+		const keys = upserts.map(u => u.messages[0]?.key)
+		expect(keys.map(k => k?.id)).toEqual(['DUP-1', 'DUP-1'])
+		expect(keys.map(k => k?.participant)).toEqual(['5511@s.whatsapp.net', '5522@s.whatsapp.net'])
+	})
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dispatcher — push names from inbound envelopes
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Bridge 0.14.0 dropped the dedicated `push_name_update` event; the push name
+// now reaches consumers the way upstream surfaces it (`messages-recv.ts`): a
+// `contacts.update` with `notify` derived from each inbound envelope.
+describe('dispatch: inbound push name → contacts.update', () => {
+	const msgEvent = (info: Record<string, unknown>) => ({
+		type: 'message',
+		data: { info: { ...baseMessageInfo, ...info }, message: { conversation: 'hi' } }
+	})
+
+	it('notifies the DM sender push name', () => {
+		const updates = collect(msgEvent({}), 'contacts.update')
+		expect(updates[0]?.[0]).toEqual({ id: '5511@s.whatsapp.net', notify: 'Foo' })
+	})
+
+	it('attributes a group message to the participant, not the group', () => {
+		const updates = collect(
+			msgEvent({ source: { chat: jid('123456', 'g.us'), sender: jid('5511'), is_group: true, is_from_me: false } }),
+			'contacts.update'
+		)
+		expect(updates[0]?.[0]).toEqual({ id: '5511@s.whatsapp.net', notify: 'Foo' })
+	})
+
+	it('stays silent for own messages and for envelopes without a push name', () => {
+		const own = msgEvent({ source: { chat: jid('5511'), is_group: false, is_from_me: true } })
+		expect(collect(own, 'contacts.update').length).toBe(0)
+		expect(collect(msgEvent({ push_name: undefined }), 'contacts.update').length).toBe(0)
+	})
+
+	it('also notifies from an undecryptable envelope', () => {
+		const updates = collect(
+			{
+				type: 'undecryptable_message',
+				data: {
+					info: { ...baseMessageInfo, id: 'BAD-2' },
+					is_unavailable: false,
+					decrypt_fail_mode: 'show'
+				}
+			},
+			'contacts.update'
+		)
+		expect(updates[0]?.[0]).toEqual({ id: '5511@s.whatsapp.net', notify: 'Foo' })
+	})
 })
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Moves `@oxidezap/whatsapp-rust-bridge` from 0.13.0 to 0.14.0 and adapts the library to the surface that changed. This is the base batch for the upcoming stack-translation fix (bridge rejections carrying a caller stack): 0.14.0 is where `kind: 'server'` rejections gained `errorType` and `backoffSeconds`, so that batch lands on top of this one instead of mixed into it.

What changed in the published `.d.ts` between 0.13.0 and 0.14.0, verified by diffing the two tarballs:

- `push_name_update` left the event union (the `PushNameUpdate` interface is gone).
- `client_expiration_changed` entered the union.
- `MessageInfo.type` became `StanzaMessageType | null | undefined` and `media_type` became `EncMediaType | null | undefined`.
- `MsgMetaInfo.deprecated_lid_session` was removed (`poll_type` arrived).
- Undecryptable dispatch dedup is now keyed by `(chat, id, sender)` instead of `(chat, id)` (the new `SenderMessageId` type documents why), so the same id from two group participants dispatches twice.
- `BridgeError`'s `server` variant gained `errorType?` and `backoffSeconds?` (not consumed here; consumed by the follow-up batch).

## Adaptation

**Push names.** The dedicated event is gone, and the only remaining carrier of a contact's push name is `MessageInfo.push_name` on each inbound envelope. The dispatcher now surfaces it the way upstream does in `messages-recv.ts`: every inbound message or undecryptable stub that carries a push name and is not `fromMe` emits `contacts.update` with `{ id, notify }`, attributed to the participant in groups and to the chat jid in DMs. Consumers keep receiving the same event with the same fields; the cadence changes from "on change, engine-tracked" to "per inbound envelope", which is upstream Baileys behavior (the event buffer consolidates repeats by id when buffering). `CanonicalPushNameUpdate` and its adapter/dispatch entries are removed.

**Client expiration.** `client_expiration_changed` is acknowledged as a noop, like `self_push_name_updated`: upstream has no channel for a client retirement deadline, and a dependency bump should not invent public API. The adapter table stays total, so this was a deliberate entry, not a fallthrough.

**Undecryptable double delivery.** No code change: the dispatcher is stateless per event, and each event becomes a CIPHERTEXT stub upsert whose key carries the participant, so two senders reusing an id produce two distinct-keyed stubs, which is what upstream `MsgKey` semantics say should happen. A regression test pins this.

**free() crash signature.** The free-safety suite pins how the heap hazard announces itself per build; on 0.14.0 a js-sys future panic (`finish: result should be None`) fires before either previously observed memory fault. The signature list gains that entry, following the protocol written into the test itself ("add a signature only once a build emits it"). The invariant pinned, dying from inside wasm rather than surviving, is unchanged.

**Everything else.** Nothing in-tree read `MessageInfo.type`, `media_type`, or `deprecated_lid_session`, so their type changes required no adaptation; `tsc` is green against the new declarations.

## Cost

The one hot-path change is the push-name emission inside message dispatch. Micro-benchmarked adapt+dispatch of a synthetic inbound message (200k iterations after 20k warmup, 3 runs each side, Node 22):

| case | base (862e3bc) | this branch |
| --- | --- | --- |
| message with push_name | 2515-2712 ns/op | 2497-2745 ns/op |
| message without push_name | 2405-2626 ns/op | 2418-2573 ns/op |

The added guard and emit sit below run-to-run variance; there is no measurable happy-path regression.

## Validation

`npm run lint`, `npm test` (1308 pass, 0 fail), `npm run build`, `npm run format:check` all green. The new `contacts.update` tests were written first and were red against the old dispatcher; re-removing the `emitInboundPushName` calls turns exactly those three tests red again. The pre-existing undecryptable tests pass unmodified; the only touched existing test is the free-safety signature list, which is a contract-following addition, not a relaxation. `compat:layers` and e2e need the sibling checkouts / mock server and are left to CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkWEiUqk2QVmJJEiPiCaMt)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `@oxidezap/whatsapp-rust-bridge` from 0.13.0 to 0.14.0 and adapts to the removed push-name event and new undecryptable semantics. Push names now emit as per-envelope `contacts.update` like upstream; undecryptables dedupe by sender; hidden ciphertexts still surface names; batched dispatch contains throwing listeners.

- Emits push names via a shared helper from `message`, `undecryptable_message`, and wire-batched paths; skips own messages and broadcast jids; honors `shouldIgnoreJid` on the undecryptable path; still emits for `decrypt_fail_mode: 'hide'`; moves batch emission inside the per-message try to contain listener throws.
- Removes `push_name_update` adapter/type/dispatcher; treats `client_expiration_changed` as a noop and marks it inert in fuzz tests.
- Undecryptables now dedupe by (chat, id, sender); two group participants reusing an id produce two distinct stubs; tests pin double-delivery, per-envelope emission (single, batch), broadcast suppression, the ignore predicate, hidden-envelope emission, and batch containment.
- Free-safety suite adds the “finish: result should be None” signature.

- Migration: replace any use of `push_name_update` with `contacts.update` carrying `notify`.

<sup>Written for commit eaefa2f63df4dc3979576d0226487070c762db94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact information now updates automatically when inbound messages include a sender’s push name.
  * Push-name updates are supported for direct chats, group participants, and undecryptable messages.
* **Bug Fixes**
  * Prevented contact updates for messages sent by yourself or messages without a push name.
  * Improved handling of undecryptable messages so identical message IDs from different participants remain distinct.
  * Added safer handling for client expiration events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->