### PR TITLE
fix(errors): give a bridge rejection a stack that names the caller

### DIFF
--- a/src/Socket/bridge-error-boundary.ts
+++ b/src/Socket/bridge-error-boundary.ts
@@ -29,9 +29,16 @@
 
 import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
 
-/** The bridge's rejection shape: a real `Error` with a string `kind`. */
+/**
+ * The bridge's rejection shape: a real `Error` the glue named `WhatsAppError`,
+ * carrying a string `kind`. The name check keeps consumer-owned errors that
+ * also discriminate on `kind` (a custom store or cache thrown through a
+ * bridge call) crossing by identity instead of being rebuilt.
+ */
 const isBridgeRejection = (error: unknown): error is Error & { kind: string } =>
-	error instanceof Error && typeof (error as { kind?: unknown }).kind === 'string'
+	error instanceof Error &&
+	error.name === 'WhatsAppError' &&
+	typeof (error as { kind?: unknown }).kind === 'string'
 
 /** Rebuild a bridge rejection here; return anything else untouched. */
 export const withCallerStack = (error: unknown): unknown => {

--- a/src/Socket/bridge-error-boundary.ts
+++ b/src/Socket/bridge-error-boundary.ts
@@ -1,0 +1,78 @@
+/**
+ * Recreate a bridge rejection at the JS boundary so its stack names the caller.
+ *
+ * The engine constructs its errors inside wasm, in a microtask continuation
+ * that runs after the server response arrives. V8 captures the stack at
+ * construction, so what reaches the consumer is glue plus `wasm://` frames
+ * and never the code that made the call. Recreating the error inside a catch
+ * the caller is awaiting fixes that: V8's async stack walk names the awaiting
+ * frames, so a bot sees `at async itsOwnCommand` instead of function indices.
+ *
+ * What survives translation, and how:
+ *
+ *  - The engine sets its payload (`kind`, `serverCode`, `serverText`,
+ *    `errorType`, `backoffSeconds`, and whatever it adds next) and `name`
+ *    (`WhatsAppError`) as own enumerable properties, while `message` and
+ *    `stack` are own non-enumerable ones. `Object.assign` therefore copies
+ *    exactly the payload and the name, never touches the fresh stack, and
+ *    cannot invent a key the rejection did not carry.
+ *  - The original error becomes `cause`, so the wasm-side stack stays
+ *    reachable for whoever wants the engine's half of the story.
+ *  - Anything that is not the bridge's shape (an `Error` carrying a string
+ *    `kind`) passes through with the same identity it arrived with.
+ *
+ * The wrap happens once per client: `getClient()`/`getClientSync()` hand out
+ * a `Proxy` whose method wrappers are built on first access and cached, so
+ * the happy path pays one property trap and one extra promise layer, and the
+ * error path pays for everything else.
+ */
+
+import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
+
+/** The bridge's rejection shape: a real `Error` with a string `kind`. */
+const isBridgeRejection = (error: unknown): error is Error & { kind: string } =>
+	error instanceof Error && typeof (error as { kind?: unknown }).kind === 'string'
+
+/** Rebuild a bridge rejection here; return anything else untouched. */
+export const withCallerStack = (error: unknown): unknown => {
+	if (!isBridgeRejection(error)) return error
+	return Object.assign(new Error(error.message, { cause: error }), error)
+}
+
+const rethrowWithCallerStack = async <T>(call: Promise<T>): Promise<T> => {
+	try {
+		return await call
+	} catch (error) {
+		throw withCallerStack(error)
+	}
+}
+
+const wrappedClients = new WeakMap<WasmWhatsAppClient, WasmWhatsAppClient>()
+
+/**
+ * The client the socket hands out. Methods bind to the raw client (wasm
+ * bindings need their own `this`), sync returns pass through untouched, and
+ * promise returns reject through `withCallerStack`.
+ */
+export const wrapBridgeClient = (client: WasmWhatsAppClient): WasmWhatsAppClient => {
+	const memo = wrappedClients.get(client)
+	if (memo) return memo
+
+	const methods = new Map<PropertyKey, unknown>()
+	const wrapped = new Proxy(client, {
+		get(target, prop) {
+			const hit = methods.get(prop)
+			if (hit !== undefined) return hit
+			const value = Reflect.get(target, prop)
+			if (typeof value !== 'function') return value
+			const method = (...args: unknown[]) => {
+				const out = (value as (...a: unknown[]) => unknown).apply(target, args)
+				return out instanceof Promise ? rethrowWithCallerStack(out) : out
+			}
+			methods.set(prop, method)
+			return method
+		}
+	})
+	wrappedClients.set(client, wrapped)
+	return wrapped
+}

--- a/src/Socket/bridge-error-boundary.ts
+++ b/src/Socket/bridge-error-boundary.ts
@@ -36,9 +36,7 @@ import type { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
  * bridge call) crossing by identity instead of being rebuilt.
  */
 const isBridgeRejection = (error: unknown): error is Error & { kind: string } =>
-	error instanceof Error &&
-	error.name === 'WhatsAppError' &&
-	typeof (error as { kind?: unknown }).kind === 'string'
+	error instanceof Error && error.name === 'WhatsAppError' && typeof (error as { kind?: unknown }).kind === 'string'
 
 /** Rebuild a bridge rejection here; return anything else untouched. */
 export const withCallerStack = (error: unknown): unknown => {

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -55,6 +55,7 @@ import { makeChatActionMethods } from './chat-actions.ts'
 import { makeContactMethods } from './contacts.ts'
 import { makeCommunityMethods } from './communities.ts'
 import { makeBridgeClientOwner } from './bridge-client-owner.ts'
+import { wrapBridgeClient } from './bridge-error-boundary.ts'
 import { makeTerminalCloseReporter } from './terminal-close-reporter.ts'
 import { makeEventHandlers } from './events.ts'
 import { makeGroupMethods } from './groups.ts'
@@ -257,7 +258,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			// Unregister before freeing: `free()` is swallowed, so ordering it
 			// last would leave the module-level pointer aimed at a client that is
 			// already gone if anything between them threw.
-			_unregisterActiveBridgeClient(client)
+			_unregisterActiveBridgeClient(wrapBridgeClient(client))
 			try {
 				client.free()
 			} catch {
@@ -333,7 +334,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			// `initError` check when startup later fails.
 			if (initialized) {
 				const ready = owner.peek()
-				if (ready) return Promise.resolve(ready)
+				if (ready) return Promise.resolve(wrapBridgeClient(ready))
 			}
 
 			return initPromise.then(() => {
@@ -356,7 +357,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 
 				const built = owner.peek()
 				if (!built) throw new Boom('Client not initialized', { statusCode: 500 })
-				return built
+				return wrapBridgeClient(built)
 			})
 		},
 		getClientSync: () => {
@@ -366,7 +367,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			}
 			const built = owner.peek()
 			if (!built) throw new Boom('Client not initialized', { statusCode: 500 })
-			return built
+			return wrapBridgeClient(built)
 		}
 	}
 	// The native repository delegates Signal state directly to the core and does
@@ -512,8 +513,10 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		if (!owner.adopt(created)) return owner.settled()
 
 		// Fallback for standalone helpers like `downloadContentFromMessage`
-		// that carry no socket reference.
-		_registerActiveBridgeClient(created, logger)
+		// that carry no socket reference. Registered wrapped so those helpers
+		// reject with a caller stack too; the memoized wrap keeps the
+		// unregister identity check working.
+		_registerActiveBridgeClient(wrapBridgeClient(created), logger)
 
 		// Replay a preference set before the client existed. `setAutoReconnect`
 		// forwards through `client?.`, so `makeWASocket(cfg).setAutoReconnect(false)`
@@ -826,7 +829,8 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			}
 		},
 		get waClient() {
-			return owner.peek()
+			const live = owner.peek()
+			return live && wrapBridgeClient(live)
 		},
 		get isConnected() {
 			return owner.peek()?.isConnected() ?? false

--- a/src/__tests__/bridge-error-boundary.test.ts
+++ b/src/__tests__/bridge-error-boundary.test.ts
@@ -79,6 +79,16 @@ describe('withCallerStack: what passes through by identity', () => {
 		expect(withCallerStack(plain)).toBe(plain)
 	})
 
+	// A consumer store or cache can throw its own discriminated errors through
+	// a bridge call; a string kind alone must not claim them for translation.
+	it('an Error with a kind but not the bridge name', () => {
+		class CacheError extends Error {
+			kind = 'cache-miss'
+		}
+		const foreign = new CacheError('consumer-owned')
+		expect(withCallerStack(foreign)).toBe(foreign)
+	})
+
 	it('a string, null, and a non-Error object carrying kind', () => {
 		expect(withCallerStack('boom')).toBe('boom')
 		expect(withCallerStack(null)).toBe(null)

--- a/src/__tests__/bridge-error-boundary.test.ts
+++ b/src/__tests__/bridge-error-boundary.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The translation contract, piece by piece.
+ *
+ * `bridge-rejection-caller-stack.test.ts` proves the symptom against the real
+ * wasm boundary; this file pins the mechanism with plain objects, where every
+ * edge is cheap to reach: what is copied, what is not invented, and what
+ * passes through untouched.
+ */
+
+import { describe, it } from 'node:test'
+
+import { withCallerStack, wrapBridgeClient } from '../Socket/bridge-error-boundary.ts'
+import { expect } from './expect.ts'
+
+/** An error shaped the way the engine's glue builds one. */
+const bridgeError = (payload: Record<string, unknown>): Error => {
+	const error = new Error(String(payload.message ?? 'server error 429: rate-overlimit'))
+	delete payload.message
+	return Object.assign(error, { name: 'WhatsAppError', kind: 'server', ...payload })
+}
+
+describe('withCallerStack: what survives', () => {
+	it('keeps the fields a consumer already switches on', () => {
+		const translated = withCallerStack(bridgeError({ serverCode: 429, serverText: 'rate-overlimit' })) as Record<
+			string,
+			unknown
+		>
+		expect(translated.kind).toBe('server')
+		expect(translated.serverCode).toBe(429)
+		expect(translated.serverText).toBe('rate-overlimit')
+		let branch = ''
+		switch (translated.kind) {
+			case 'server':
+				branch = 'server'
+				break
+			default:
+				branch = 'other'
+		}
+		expect(branch).toBe('server')
+	})
+
+	it('keeps name, message and instanceof Error', () => {
+		const translated = withCallerStack(bridgeError({})) as Error
+		expect(translated instanceof Error).toBe(true)
+		expect(translated.name).toBe('WhatsAppError')
+		expect(translated.message).toBe('server error 429: rate-overlimit')
+	})
+
+	it('carries the 0.14.0 server fields when the server sent them', () => {
+		const translated = withCallerStack(bridgeError({ errorType: 'rate-overlimit', backoffSeconds: 60 })) as Record<
+			string,
+			unknown
+		>
+		expect(translated.errorType).toBe('rate-overlimit')
+		expect(translated.backoffSeconds).toBe(60)
+	})
+
+	it('does not invent keys the rejection did not carry', () => {
+		const translated = withCallerStack(bridgeError({ serverCode: 429, serverText: 'rate-overlimit' })) as object
+		expect('backoffSeconds' in translated).toBe(false)
+		expect('errorType' in translated).toBe(false)
+	})
+
+	it('carries a field this repository has never heard of', () => {
+		const translated = withCallerStack(bridgeError({ nextBridgeField: 'v0.15' })) as Record<string, unknown>
+		expect(translated.nextBridgeField).toBe('v0.15')
+	})
+
+	it('chains the original as cause', () => {
+		const original = bridgeError({})
+		const translated = withCallerStack(original) as Error
+		expect(translated.cause).toBe(original)
+	})
+})
+
+describe('withCallerStack: what passes through by identity', () => {
+	it('a plain Error without kind', () => {
+		const plain = new Error('nothing to do with the bridge')
+		expect(withCallerStack(plain)).toBe(plain)
+	})
+
+	it('a string, null, and a non-Error object carrying kind', () => {
+		expect(withCallerStack('boom')).toBe('boom')
+		expect(withCallerStack(null)).toBe(null)
+		const bare = { kind: 'no-recipient-device', attempted: 2 }
+		expect(withCallerStack(bare)).toBe(bare)
+	})
+})
+
+describe('wrapBridgeClient', () => {
+	const fakeClient = () => {
+		const client = {
+			calls: [] as unknown[][],
+			isConnected() {
+				return 'sync-value'
+			},
+			async fails() {
+				await new Promise(resolve => setImmediate(resolve))
+				throw bridgeError({ serverCode: 429 })
+			},
+			async succeeds(...args: unknown[]) {
+				client.calls.push(args)
+				return args.length
+			},
+			marker: 'not-a-function'
+		}
+		return client
+	}
+
+	it('rejections gain the awaiting caller frame', async () => {
+		const wrapped = wrapBridgeClient(fakeClient() as never) as unknown as ReturnType<typeof fakeClient>
+		async function theCallerToName() {
+			return await wrapped.fails()
+		}
+
+		const error = await theCallerToName().then(
+			() => null,
+			e => e as Error
+		)
+		expect(String(error?.stack)).toContain('theCallerToName')
+	})
+
+	it('sync returns, arguments and non-function properties pass through', async () => {
+		const raw = fakeClient()
+		const wrapped = wrapBridgeClient(raw as never) as unknown as ReturnType<typeof fakeClient>
+		expect(wrapped.isConnected()).toBe('sync-value')
+		expect(wrapped.marker).toBe('not-a-function')
+		expect(await wrapped.succeeds('a', 'b')).toBe(2)
+		expect(raw.calls[0]).toEqual(['a', 'b'])
+	})
+
+	it('wraps one client to one stable proxy', () => {
+		const raw = fakeClient()
+		expect(wrapBridgeClient(raw as never)).toBe(wrapBridgeClient(raw as never))
+	})
+})

--- a/src/__tests__/bridge-rejection-caller-stack.test.ts
+++ b/src/__tests__/bridge-rejection-caller-stack.test.ts
@@ -1,0 +1,82 @@
+/**
+ * A bridge rejection has to point at the code that made the call.
+ *
+ * The engine builds its rejection inside wasm, in a microtask continuation
+ * that runs after the response arrives: V8 captures the stack there, so the
+ * error reaches the consumer with glue and `wasm://` frames only and not one
+ * frame of the caller. A bot cannot tell which command triggered a
+ * `server error 429` from that.
+ *
+ * The socket therefore recreates the error at the JS boundary the caller
+ * awaited (`Socket/bridge-error-boundary.ts`): V8's async stack walk then
+ * names the awaiting caller, the enumerable payload crosses untouched, and
+ * the original error rides along as `cause` with its wasm stack intact.
+ *
+ * This file drives the real bridge through the real public surface, offline
+ * against a dead loopback port, because the symptom lives in where the stack
+ * is captured and only the real wasm boundary reproduces that.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, describe, it } from 'node:test'
+import P from 'pino'
+
+import { makeWASocket, type WASocket } from '../index.ts'
+import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
+import { expect } from './expect.ts'
+
+describe('bridge rejections carry a caller stack', { timeout: 60_000 }, () => {
+	let folder: string
+	let sock: WASocket
+
+	before(async () => {
+		folder = await mkdtemp(join(tmpdir(), 'baileyrs-callerstack-'))
+		const { state } = await useMultiFileAuthState(folder)
+		sock = makeWASocket({
+			auth: state,
+			logger: P({ level: 'silent' }) as never,
+			waWebSocketUrl: 'ws://127.0.0.1:1',
+			shouldSyncHistoryMessage: () => false
+		})
+	})
+
+	after(async () => {
+		await sock.end(undefined)
+		await rm(folder, { recursive: true, force: true })
+	})
+
+	const rejectionOf = async (call: () => Promise<unknown>): Promise<Error & Record<string, unknown>> => {
+		const outcome = await call().then(
+			() => null,
+			error => error as Error & Record<string, unknown>
+		)
+		if (!outcome) throw new Error('expected the call to reject offline')
+		return outcome
+	}
+
+	it('names the public API caller in the stack', async () => {
+		async function botCommandListaAluguel() {
+			return await sock.fetchBlocklist()
+		}
+
+		const error = await rejectionOf(botCommandListaAluguel)
+		expect(String(error.stack)).toContain('botCommandListaAluguel')
+	})
+
+	it('keeps the payload a consumer already inspects', async () => {
+		const error = await rejectionOf(() => sock.fetchBlocklist())
+		expect(error instanceof Error).toBe(true)
+		expect(error.name).toBe('WhatsAppError')
+		expect(error.message).toBe('not connected')
+		expect(error.kind).toBe('not-connected')
+	})
+
+	it('keeps the wasm stack reachable through cause', async () => {
+		const error = await rejectionOf(() => sock.fetchBlocklist())
+		const cause = error.cause as Error | undefined
+		expect(cause instanceof Error).toBe(true)
+		expect(String(cause?.stack)).toContain('wasm://')
+	})
+})


### PR DESCRIPTION
## Summary

Every rejection from the engine reached the consumer with a stack made of glue and `wasm://` frames and nothing else:

```
Error [WhatsAppError]: server error 429: rate-overlimit
    at __wbg_new_b667d279fd5aa943 (.../whatsapp-rust-bridge/dist/index.js:1:44811)
    at wasm://wasm/0151b48a:wasm-function[10666]:0x4b893c
    ...
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```

The error is constructed by `js_sys::Error::new` inside the glue's Error shim, in a microtask continuation that runs after the server response arrives. V8 captures the stack at construction, and by then the caller's frame is gone, so no stack captured there can ever name the code that made the call. Reproduced against the real wasm boundary offline: `sock.fetchBlocklist()` called from a named async function rejects with wasm frames only.

Now the error is recreated at the JS boundary the caller is awaiting, so the same rejection arrives as:

```
WhatsAppError: not connected
    at withCallerStack (src/Socket/bridge-error-boundary.ts)
    at rethrowWithCallerStack (src/Socket/bridge-error-boundary.ts)
    at async botCommandListaAluguel (...)
```

with the original error, wasm stack intact, attached as `cause`.

## Design

**Where the translation lives.** There is no per-call choke point (about 120 call sites of `(await ctx.getClient()).method(...)` across 17 files), but every one of them obtains the client through `getClient()`/`getClientSync()`, and consumers reach it through the `waClient` getter and the registered client behind `downloadMediaMessage`. Those four hand out a `Proxy` over the raw client (`src/Socket/bridge-error-boundary.ts`): method wrappers are created on first access and cached per method, sync returns pass through untouched, and promise returns are awaited inside a try/catch, which is what lets V8's async stack walk name the awaiting caller. The raw client keeps serving the teardown paths (`owner.peek()`), so the lifecycle ordering that `bridge-free-safety` pins is untouched.

**What is preserved, and how it survives the next field.** Probed against the real bridge: a rejection is a real `Error` whose payload (`kind`, `serverCode`, `serverText`, `errorType`, `backoffSeconds`, `field`, `reason`) and `name` (`WhatsAppError`) are own enumerable properties, while `message` and `stack` are own non-enumerable ones. The translation is `Object.assign(new Error(message, { cause: original }), original)`: it copies exactly the enumerable payload plus the name, never touches the fresh stack, and cannot invent a key the rejection did not carry (`'backoffSeconds' in e` stays `false` when the server sent none). A field the bridge adds tomorrow crosses without an edit here, and a test pins that with a field this repository has never heard of. `instanceof Error` stays true and `name` stays `WhatsAppError`.

**Boom.** Not introduced. The upstream-shaped `Boom` carries a `statusCode`, and no honest one exists for `timeout`, `crypto` or `not-connected`; an invented statusCode would be worse than an absent one. The one place a bridge rejection maps to something upstream actually throws, `no-recipient-device` to `Boom('All encryptions failed', 500)`, is a semantic translation and stays in `all-encryptions-failed.ts`; it now receives the boundary-translated error, reads the same `kind`, and its pinned test passes unmodified. The two mechanisms compose rather than converge: the boundary fixes where every stack points, the compatibility layer fixes what one condition means.

**The chain.** The original error becomes `cause`, non-enumerable, so `console.error(err)` prints the caller-side stack first and the wasm frames below it under `[cause]`. That is the cost: error printouts grow by the cause block, and the wasm half of the story is exactly what it buys.

**Failure behavior.** The guard is the bridge's own shape, a real `Error` carrying a string `kind`. A string, `null`, a plain `Error`, or a bare object reaches the caller with the identity it arrived with, pinned by tests.

## Cost

Happy path, measured (3 interleaved runs, 200k-500k iterations after warmup, Node 22):

| call | raw | wrapped |
| --- | --- | --- |
| stub method resolving immediately (worst case) | 64-85 ns/op | 140-143 ns/op |
| real wasm call resolving offline (`getPushName`) | 953-1031 ns/op | 1017-1197 ns/op |

The wrapper adds about 70 ns per call: one proxy trap plus cached-map hit, one `instanceof Promise` check, and the one extra promise layer of the awaited rethrow, which is what buys the caller frames. No closure is created per call and nothing is allocated before an error exists. On the cheapest real bridge call (about 1 us) the delta sits inside run-to-run variance; on network-bound calls it is unmeasurable. `Example/benchmark.ts` needs a live login and could not run here; numbers above are from the same offline harness the boundary tests use.

## Validation

`npm run lint`, `npm test` (1327 pass, 0 fail, 14 new), `npm run build`, `npm run format:check`, all green; no existing test changed. Red first: the caller-stack test was written before the fix and failed with wasm-only frames through the real public surface (`makeWASocket` offline). Revert checks, both directions: reverting the central line (`withCallerStack` to identity) turns the two caller-stack tests and the `cause` test red; replacing the generic copy with a fixed field list that fills absences with `undefined` turns the no-invented-keys and unknown-field tests red. Restored, everything passes. `compat:layers` and e2e need the sibling checkouts / mock server and are left to CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkWEiUqk2QVmJJEiPiCaMt)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bridge rejections now surface with caller-named stacks instead of wasm-only frames. Previously errors constructed in wasm only showed glue/wasm frames; we now rebuild the error at the awaited JS boundary so V8 names the caller, preserving the original as cause and leaving the payload intact.

**Review Notes**
- Introduces `wrapBridgeClient`: a `Proxy` that binds methods, passes sync returns through, and rethrows promise rejections via `withCallerStack`. Applied to `getClient()`, `getClientSync()`, the `waClient` getter, and the client registered for standalone helpers; memoization preserves identity for unregister.
- Adds `withCallerStack`: rebuilds only errors named `WhatsAppError` with a string `kind`; copies the rejection’s own enumerable fields (`kind`, `serverCode`, `serverText`, `errorType`, `backoffSeconds`, and future ones), keeps `name`/`message`, and sets the original as `cause`. Non-bridge errors (including consumer subclasses) pass through unchanged.
- Behavior unchanged; no `Boom` added. Side effects: error printouts include a `[cause]` block with wasm frames; happy-path overhead ~70 ns on a stub, negligible on real calls. Tests pin caller stacks, payload preservation, unknown-field passthrough, identity passthrough, and one-to-one client/proxy memoization. No migration required.
- Style-only: condensed the boundary guard onto one line; no behavior change.

<sup>Written for commit 03e9ea98e735389c52c6b290de23257baac2cb95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

