### PR TITLE
fix(messages): honour the caller's messageId on sendMessage

### DIFF
--- a/src/Compatibility/message-relay.ts
+++ b/src/Compatibility/message-relay.ts
@@ -4,9 +4,17 @@ import { Boom } from '../Utils/boom.ts'
 import { generateMessageIDV2 } from '../Utils/generics.ts'
 import { areJidsSameUser, isJidBroadcast, isJidGroup, isJidNewsletter } from '../WABinary/index.ts'
 
-const EMPTY_RELAY_NODES: BinaryNode[] = []
+export const EMPTY_RELAY_NODES: BinaryNode[] = []
 
-type OwnRelayIdentity = { id?: string; lid?: string } | undefined
+export type OwnRelayIdentity = { id?: string; lid?: string } | undefined
+
+/**
+ * The one place that decides between the caller's id and a generated one.
+ * Every send path resolves through here, so `messageId` means the same thing
+ * on `sendMessage` and on `relayMessage`.
+ */
+export const resolveMessageId = (own: OwnRelayIdentity, messageId?: string): string =>
+	messageId || generateMessageIDV2(own?.id)
 
 export type MessageRelayPlan =
 	| {
@@ -68,7 +76,7 @@ export const planMessageRelay = (
 		})
 	}
 
-	const id = messageId || generateMessageIDV2(own?.id)
+	const id = resolveMessageId(own, messageId)
 	const refreshGroupMetadata = useCachedGroupMetadata === false
 	if (participant) {
 		const requesterIsOwnDevice = isDirectConversation(jid) && isOwnDevice(participant.jid, own)

--- a/src/Socket/messages.ts
+++ b/src/Socket/messages.ts
@@ -1,7 +1,7 @@
 import { sendReportingUpstreamFailure } from '../Compatibility/all-encryptions-failed.ts'
 import { sendDroppingDerivedNodes } from '../Compatibility/derived-stanza-nodes.ts'
 import { encodeProtoCompat } from '../Compatibility/encode-proto.ts'
-import { planMessageRelay } from '../Compatibility/message-relay.ts'
+import { EMPTY_RELAY_NODES, planMessageRelay, resolveMessageId } from '../Compatibility/message-relay.ts'
 import { receiptMessageKeys } from '../Compatibility/message-keys.ts'
 import type {
 	AnyMessageContent,
@@ -77,6 +77,16 @@ export const makeMessageMethods = (ctx: SocketContext) => ({
 		if (contentType === 'protocolMessage') {
 			const protoMsg = msg.protocolMessage
 			if (protoMsg?.type === WAProto.Message.ProtocolMessage.Type.REVOKE && protoMsg?.key?.id) {
+				if (options?.messageId) {
+					// The core has no revoke variant that takes a stanza id, so
+					// the option cannot be honoured here. Saying so beats the
+					// silent drop this option used to get on every path.
+					ctx.logger.warn(
+						{ jid, messageId: options.messageId },
+						'messageId option cannot be honoured for a revoke: the core assigns the stanza id itself'
+					)
+				}
+
 				// Group revokes need the original sender's participant JID —
 				// without it the server rejects the revoke. The bridge
 				// signature is `revokeMessage(jid, message_id, participant?)`.
@@ -92,6 +102,15 @@ export const makeMessageMethods = (ctx: SocketContext) => ({
 				protoMsg?.key?.id &&
 				protoMsg?.editedMessage
 			) {
+				if (options?.messageId) {
+					// `editMessageBytes` returns the stanza id but does not yet
+					// accept one; honouring the option here waits on the bridge.
+					ctx.logger.warn(
+						{ jid, messageId: options.messageId },
+						'messageId option cannot be honoured for an edit: the installed bridge assigns the stanza id itself'
+					)
+				}
+
 				const editBytes = WAProto.Message.encode(protoMsg.editedMessage).finish()
 				const newMsgId = await client.editMessageBytes(jid, protoMsg.key.id, editBytes)
 				fullMsg.key.id = newMsgId || fullMsg.key.id
@@ -100,10 +119,14 @@ export const makeMessageMethods = (ctx: SocketContext) => ({
 		}
 
 		const msgBytes = encodeProtoCompat('Message', msg as Record<string, unknown>)
+		// The with-options sends are the same core send as the plain ones, with
+		// the stanza id supplied by the caller instead of drawn by the engine.
+		// The id resolves through the same place `relayMessage` resolves it.
+		const messageId = resolveMessageId(ctx.getUser(), options?.messageId)
 		const msgId = await sendReportingUpstreamFailure(() =>
 			jid === 'status@broadcast' && options?.statusJidList?.length
-				? client.sendStatusMessageBytes(msgBytes, options.statusJidList)
-				: client.sendMessageBytes(jid, msgBytes)
+				? client.sendStatusMessageBytesWithOptions(msgBytes, options.statusJidList, messageId, EMPTY_RELAY_NODES, false)
+				: client.relayMessageBytesWithOptions(jid, msgBytes, messageId, EMPTY_RELAY_NODES, false, false)
 		)
 
 		fullMsg.key.id = msgId || fullMsg.key.id

--- a/src/__tests__/relay-message-context-info.test.ts
+++ b/src/__tests__/relay-message-context-info.test.ts
@@ -52,16 +52,13 @@ interface DecodedMessage {
 }
 
 const makeCapturingContext = () => {
+	// `sendMessage` and `relayMessage` both hand their bytes to the same
+	// with-options send, so one capture covers the two describes below.
 	const relayed: Uint8Array[] = []
-	const sent: Uint8Array[] = []
 	const client = {
 		relayMessageBytesWithOptions: async (_jid: string, bytes: Uint8Array, messageId: string) => {
 			relayed.push(bytes)
 			return messageId
-		},
-		sendMessageBytes: async (_jid: string, bytes: Uint8Array) => {
-			sent.push(bytes)
-			return '3EB0AAAAAAAAAAAAAAAA'
 		}
 	} as unknown as WasmWhatsAppClient
 	const ctx = {
@@ -74,7 +71,7 @@ const makeCapturingContext = () => {
 		getMe: () => ({ id: '15550000000@s.whatsapp.net', lid: '100000000000000@lid' }),
 		getClient: async () => client
 	} as unknown as SocketContext
-	return { ctx, relayed, sent }
+	return { ctx, relayed }
 }
 
 const groupJid = '120363000000000000@g.us'
@@ -202,14 +199,14 @@ describe('relayMessage: album parent', () => {
 
 describe('sendMessage: messageContextInfo in the bytes handed to the bridge', () => {
 	it('keeps the pin duration generated for a pin', async () => {
-		const { ctx, sent } = makeCapturingContext()
+		const { ctx, relayed } = makeCapturingContext()
 		await makeMessageMethods(ctx).sendMessage(groupJid, {
 			pin: { remoteJid: groupJid, fromMe: false, id: 'AABBCCDD11223344' },
 			type: proto.PinInChat.Type.PIN_FOR_ALL,
 			time: 604800
 		})
-		expect(sent).toHaveLength(1)
-		const decoded = decodeProto('Message', sent[0]!) as DecodedMessage
+		expect(relayed).toHaveLength(1)
+		const decoded = decodeProto('Message', relayed[0]!) as DecodedMessage
 		expect(decoded.messageContextInfo?.messageAddOnDurationInSecs).toBe(604800)
 		expect(decoded.pinInChatMessage?.key?.id).toBe('AABBCCDD11223344')
 	})

--- a/src/__tests__/send-message-caller-id.test.ts
+++ b/src/__tests__/send-message-caller-id.test.ts
@@ -1,0 +1,203 @@
+/**
+ * `messageId` is a documented upstream option: "override the message ID with a
+ * custom provided string". Upstream honours it on every send. Here it was
+ * accepted, typed, and thrown away: `sendMessage` never handed it to the
+ * bridge, so a caller using it for idempotency got a different id back with no
+ * error and no warning.
+ *
+ * What is tested here is that the id a caller passes is the id on the wire and
+ * the id returned, that both `sendMessage` and `relayMessage` resolve it
+ * through the same place, and that the two paths that cannot carry a caller id
+ * today (edit and revoke) say so instead of staying silent.
+ */
+
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { describe, it } from 'node:test'
+import { makeMessageMethods } from '../Socket/messages.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import type { BinaryNode, WAProto } from '../Types/index.ts'
+
+const CALLER_ID = '3EB0CALLERPROVIDED'
+const ENGINE_ID = '3EB0ENGINEASSIGNED'
+
+type RecordedCall = {
+	method: string
+	jid?: string
+	messageId?: string | null
+	targetId?: string
+	recipients?: string[]
+	nodes?: BinaryNode[]
+}
+
+/**
+ * A bridge double that echoes the id it was given, the way the engine does,
+ * and answers with its own id on every call that carries none. Under the old
+ * code the id-less calls are the ones `sendMessage` makes, so every assertion
+ * on the caller's id fails against ENGINE_ID.
+ */
+const sendRecording = () => {
+	const calls: RecordedCall[] = []
+	const warns: string[] = []
+	const logger = {
+		level: 'silent',
+		child: () => logger,
+		trace: () => undefined,
+		debug: () => undefined,
+		info: () => undefined,
+		warn: (_obj: unknown, msg?: string) => {
+			warns.push(msg ?? String(_obj))
+		},
+		error: () => undefined
+	}
+	const client = {
+		relayMessageBytesWithOptions: async (
+			jid: string,
+			_bytes: Uint8Array,
+			messageId: string | null | undefined,
+			nodes: BinaryNode[]
+		) => {
+			calls.push({ method: 'relayMessageBytesWithOptions', jid, messageId, nodes })
+			return messageId || ENGINE_ID
+		},
+		sendStatusMessageBytesWithOptions: async (
+			_bytes: Uint8Array,
+			recipients: string[],
+			messageId: string | null | undefined,
+			nodes: BinaryNode[]
+		) => {
+			calls.push({ method: 'sendStatusMessageBytesWithOptions', messageId, recipients, nodes })
+			return messageId || ENGINE_ID
+		},
+		sendMessageBytes: async (jid: string) => {
+			calls.push({ method: 'sendMessageBytes', jid, messageId: undefined })
+			return ENGINE_ID
+		},
+		sendStatusMessageBytes: async (_bytes: Uint8Array, recipients: string[]) => {
+			calls.push({ method: 'sendStatusMessageBytes', messageId: undefined, recipients })
+			return ENGINE_ID
+		},
+		revokeMessage: async (jid: string, targetId: string) => {
+			calls.push({ method: 'revokeMessage', jid, targetId })
+		},
+		editMessageBytes: async (jid: string, targetId: string) => {
+			calls.push({ method: 'editMessageBytes', jid, targetId })
+			return ENGINE_ID
+		}
+	}
+	const ctx = {
+		ev: Object.assign(new EventEmitter(), {
+			createBufferedFunction: <A extends unknown[], R>(work: (...a: A) => Promise<R>) => work
+		}),
+		logger,
+		fullConfig: { options: {}, emitOwnEvents: false },
+		getUser: () => ({ id: '15550000000@s.whatsapp.net' }),
+		getMe: () => ({ id: '15550000000@s.whatsapp.net' }),
+		getClient: async () => client
+	} as unknown as SocketContext
+	const methods = makeMessageMethods(ctx)
+	return { calls, warns, send: methods.sendMessage, relay: methods.relayMessage }
+}
+
+const DM = '15550000001@s.whatsapp.net'
+
+describe('sendMessage with a caller-provided messageId', () => {
+	it('puts the caller id on the stanza and returns it', async () => {
+		const { calls, send } = sendRecording()
+		const sent = await send(DM, { text: 'oi' }, { messageId: CALLER_ID })
+
+		assert.equal(calls.length, 1)
+		assert.equal(calls[0]?.messageId, CALLER_ID, 'the bridge must receive the id the caller asked for')
+		assert.equal(sent.key.id, CALLER_ID, 'the returned key must be the id actually used')
+	})
+
+	it('sends the same caller id twice when asked twice, which is what idempotent resend means', async () => {
+		const { calls, send } = sendRecording()
+		await send(DM, { text: 'oi' }, { messageId: CALLER_ID })
+		await send(DM, { text: 'oi' }, { messageId: CALLER_ID })
+		assert.equal(calls[0]?.messageId, CALLER_ID)
+		assert.equal(calls[1]?.messageId, CALLER_ID)
+	})
+
+	it('carries the caller id to a status send as well', async () => {
+		const { calls, send } = sendRecording()
+		const sent = await send(
+			'status@broadcast',
+			{ text: 'oi' },
+			{ messageId: CALLER_ID, statusJidList: ['15550000002@s.whatsapp.net'] }
+		)
+		assert.equal(calls[0]?.method, 'sendStatusMessageBytesWithOptions')
+		assert.equal(calls[0]?.messageId, CALLER_ID)
+		assert.deepEqual(calls[0]?.recipients, ['15550000002@s.whatsapp.net'])
+		assert.equal(sent.key.id, CALLER_ID)
+	})
+})
+
+describe('sendMessage without the option', () => {
+	it('still generates an id, and two sends do not collide', async () => {
+		const { calls, send } = sendRecording()
+		const first = await send(DM, { text: 'oi' })
+		const second = await send(DM, { text: 'oi' })
+
+		assert.match(first.key.id!, /^3EB0[0-9A-F]{18}$/)
+		assert.match(second.key.id!, /^3EB0[0-9A-F]{18}$/)
+		assert.notEqual(first.key.id, second.key.id)
+		// The generated id is decided before the bridge call, not by the double's
+		// fallback: the id on the wire and the id returned are the same string.
+		assert.equal(calls[0]?.messageId, first.key.id)
+		assert.equal(calls[1]?.messageId, second.key.id)
+	})
+})
+
+describe('one resolution for both send paths', () => {
+	it('hands the bridge the same id whether the caller went through sendMessage or relayMessage', async () => {
+		// The proof that the resolution is a single place: the same option on
+		// either path reaches the bridge as the same string. A reintroduced
+		// second generator in either path overrides the caller and fails here.
+		const { calls, send, relay } = sendRecording()
+		await send(DM, { text: 'oi' }, { messageId: CALLER_ID })
+		await relay(DM, { conversation: 'oi' } as WAProto.IMessage, { messageId: CALLER_ID })
+
+		assert.equal(calls.length, 2)
+		assert.equal(calls[0]?.messageId, CALLER_ID)
+		assert.equal(calls[1]?.messageId, CALLER_ID)
+		assert.equal(calls[0]?.messageId, calls[1]?.messageId)
+	})
+})
+
+describe('the paths that cannot carry a caller id today', () => {
+	const targetKey = { remoteJid: DM, fromMe: true, id: '3EB0TARGETMESSAGE0' }
+
+	it('revoke: warns instead of silently dropping the option, and still revokes the target', async () => {
+		const { calls, warns, send } = sendRecording()
+		await send(DM, { delete: targetKey }, { messageId: CALLER_ID })
+
+		assert.equal(calls[0]?.method, 'revokeMessage')
+		assert.equal(calls[0]?.targetId, targetKey.id, 'the target of the revoke is untouched')
+		assert.equal(warns.length, 1)
+		assert.match(warns[0]!, /messageId/, 'the warning must name the option it cannot honour')
+	})
+
+	it('revoke: stays quiet when the option was not passed', async () => {
+		const { warns, send } = sendRecording()
+		await send(DM, { delete: targetKey })
+		assert.equal(warns.length, 0)
+	})
+
+	it('edit: warns instead of silently dropping the option, and keeps the engine-assigned id', async () => {
+		const { calls, warns, send } = sendRecording()
+		const sent = await send(DM, { text: 'edited', edit: targetKey }, { messageId: CALLER_ID })
+
+		assert.equal(calls[0]?.method, 'editMessageBytes')
+		assert.equal(calls[0]?.targetId, targetKey.id, 'the target of the edit is untouched')
+		assert.equal(sent.key.id, ENGINE_ID, 'the returned key is still the id the engine used')
+		assert.equal(warns.length, 1)
+		assert.match(warns[0]!, /messageId/)
+	})
+
+	it('edit: stays quiet when the option was not passed', async () => {
+		const { warns, send } = sendRecording()
+		await send(DM, { text: 'edited', edit: targetKey })
+		assert.equal(warns.length, 0)
+	})
+})


### PR DESCRIPTION
## Summary

`messageId` is a documented upstream option (`MinimalRelayOptions`: "override the message ID with a custom provided string") and upstream honours it on every send. Here it was accepted, typed, and thrown away: `sendMessage` never handed it to the bridge, and `fullMsg.key.id = msgId || fullMsg.key.id` then replaced the caller's id with the engine's, silently. A caller using the option for idempotent resend got no idempotency and no warning.

Now `sendMessage` puts the caller's id on the stanza for normal and status sends, and returns it. The two paths that cannot carry a caller id with the installed bridge and core (edit and revoke) log a warning instead of staying silent.

This closes the API incompatibility only. The request that surfaced it wanted a custom id to delete a payment message for everyone; the official client gates "delete for everyone" on an allow-list of message types, `payment` is not in it, and no id changes that.

## Design

The resolution already existed in one place, `planMessageRelay` in `src/Compatibility/message-relay.ts`. This PR extracts that line into `resolveMessageId(own, messageId)` in the same file; `planMessageRelay` now calls it, and `sendMessage` resolves through it before the bridge call. After the change there is exactly one `generateMessageIDV2` call site deciding a send id, and the test `one resolution for both send paths` in `send-message-caller-id.test.ts` proves the same option reaches the bridge as the same string through either entry point. It fails if either path grows its own generator back.

The normal send moves from `sendMessageBytes(jid, bytes)` to `relayMessageBytesWithOptions(jid, bytes, messageId, EMPTY_RELAY_NODES, false, false)`, and the status send from `sendStatusMessageBytes` to `sendStatusMessageBytesWithOptions`, because only the with-options spellings accept a stanza id. What I compared before making the swap:

- The bridge documents both spellings as the same core E2E send; the with-options variant adds "neutral core-owned controls" with routing, cache policy, encryption and reserved-node validation still owned by the core, and its `message_id` parameter is `Option<String>` passed straight into the core send.
- Extra nodes: `EMPTY_RELAY_NODES` is the same shared constant `relayMessage` passes when the caller supplied none, so nothing new rides on the stanza and the derived-node refusal retry can never trigger (it only fires on caller-supplied nodes).
- Freshness: `false, false` preserves the previous defaults of the plain calls (cached group metadata, cached devices).
- Failure translation: the call still runs inside `sendReportingUpstreamFailure`, so `no-recipient-device` still surfaces as upstream's `All encryptions failed`.
- Return value: `fullMsg.key.id` is still assigned from the id the bridge echoes back, so it remains the id actually used on the wire, now equal to the caller's when one was passed.

For the paths that cannot honour the option I chose a warn-level log over silence or refusal. Silence is exactly the bug this fixes; refusal would turn a call that works today (callers who pass `messageId` on a delete and never noticed it did nothing) into a thrown error, which is a breaking change this fix does not need.

## Not covered

- **Revoke**: the core has no revoke variant that takes options, so a `messageId` passed with `{ delete: key }` cannot reach the stanza. `sendMessage` warns and revokes normally. Nothing to build against in this batch; needs core support first.
- **Edit**: `editMessageBytes(jid, target_id, bytes)` returns the stanza id the engine chose but does not accept one, so a `messageId` passed with an edit cannot be honoured either. `sendMessage` warns and edits normally. This half unblocks whenever the bridge batch that accepts a caller id on edit lands; the warn branch is the single place to delete then.

## Cost

`Example/benchmark.ts` needs the bartender mock server, which is a private image this environment cannot pull (no docker daemon), so the number below comes from the same hot path measured directly: `sendMessage` of a text message against a no-op bridge double, 50k sends per run, 3 runs, `node --expose-gc`, covering message generation, proto encode, id resolution and call marshaling. The CI e2e suite exercises the changed path against the live mock.

| | before | after |
|---|---|---|
| JS time per send | 3.95 to 3.98 us | 8.79 to 8.99 us |
| JS sends per second | ~252k | ~113k |
| heap growth per send | 56 to 63 B | 125 to 130 B |

The delta is ~4.9 us per send. Of that, 3.7 us is `generateMessageIDV2` itself (measured in isolation: 3725 ns per call), which now runs in JS instead of the engine drawing the id in Rust; the remaining ~1.2 us is the with-options marshaling. This is not new work invented by the fix: it is the id draw upstream Baileys performs on every `sendMessage`, and the one `relayMessage` in this repository already performs per send, moved to where the caller's id can take its place. On a real send the engine's encryption and the network dominate at millisecond scale, so the ceiling of ~113k sends per second of pure JS overhead is far above what a live socket sustains.

## Validation

Ran locally: `npm run lint` (tsc + oxlint, clean), `npm test` (1337 pass, 1 pre-existing skip, 0 fail), `npm run build` (clean), `npm run format:check` (clean). `npm run compat:layers` was not run; it requires the `whatsapp-rust` and `whatsapp-rust-bridge` checkouts as siblings and fails with ENOENT without them.

Revert check, as required: with the whole fix stashed, `send-message-caller-id.test.ts` fails 7 of 9 (the red state this started from); with only the central line neutered (`resolveMessageId(ctx.getUser(), undefined)` in `sendMessage`), it fails 4 of 9, including the cross-path resolution test; restored, 9 of 9 pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_015xJfEtN8QoMvyPe1FVJ45R)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the caller’s messageId in sendMessage to restore idempotent resend. Previously we accepted messageId but ignored it, replacing it with an engine-generated id and returning that value.

- sendMessage now resolves the stanza id via a shared resolveMessageId (extracted from message-relay) and passes it to the bridge for both normal and status sends; the returned key.id matches the on-wire id.
- Edit and revoke still cannot accept a caller id with the installed bridge/core; if messageId is provided, we log a warn and proceed unchanged.
- sendMessage switches to with-options bridge calls to carry the stanza id, using EMPTY_RELAY_NODES and previous caching defaults; routing/encryption semantics and error translation are unchanged.

**Reviewer notes**
- Check resolveMessageId is the single decision point for ids across sendMessage and relayMessage (one generateMessageIDV2 call site).
- Verify with-options calls preserve prior behavior aside from honoring messageId.
- New tests cover id propagation, idempotent resend, and warnings on edit/revoke; small test harness tweaks reflect the with-options path.

<sup>Written for commit 160fa3c828834609cb1667c72cb7935914ba3862. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for caller-provided message IDs when sending or relaying messages.
  - Message IDs are now preserved consistently across retries, regular messages, and status messages.
  - Automatically generated IDs remain available when none is provided.

- **Bug Fixes**
  - Edit and revoke operations now warn when a supplied message ID cannot be supported by the installed bridge, while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->