### PR TITLE
deps: move to bridge 0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.14.0",
+        "@oxidezap/whatsapp-rust-bridge": "0.15.0",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.14.0.tgz",
-      "integrity": "sha512-dmabe/GKJroLtgZOMFiUlnSuUu0odoWS5htDStCNcdlBD/Y+TuJfe+w45ekVIawS2LX3kpeUylhH0t56trkwxA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.15.0.tgz",
+      "integrity": "sha512-4XFUjfjQ2x4FMqk4Pvn3xCGxXeG++i//0PipLtM/XMk0k7zvBDuAH95O6wpYc89lGIFLZghA4OA2dYCnpYHXfQ==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@oxidezap/whatsapp-rust-bridge": "0.14.0",
+    "@oxidezap/whatsapp-rust-bridge": "0.15.0",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"


### PR DESCRIPTION
## Summary

Bridge 0.15.0 carries one change: `editMessageBytes` gains an optional fourth argument for the outer stanza id ([whatsapp-rust-bridge#70](https://github.com/oxidezap/whatsapp-rust-bridge/pull/70)). The shipped declaration is now

```ts
editMessageBytes(jid: string, message_id: string, bytes: Uint8Array, stanza_id?: string | null): Promise<string>
```

The third argument keeps its meaning — `message_id` is still the message being edited, and the new one is the id the edit stanza itself goes out under. Optional and additive: omitting it is exactly today's behaviour, an id minted by the engine.

## What this bump does not do

Nothing here uses the new argument. `sendMessage` still logs

> `messageId option cannot be honoured for an edit: the installed bridge assigns the stanza id itself`

and after this bump that sentence is wrong about the reason — the installed bridge does take it now. Wiring it up is [#71](https://github.com/oxidezap/baileyrs/pull/71), which was blocked on exactly this release; leaving the edit path alone here keeps that work with its author instead of landing it twice.

The revoke warning stays correct and untouched: the core still has no options variant for a revoke, so there is nothing for the bridge to expose yet.

## Worth knowing for #71

The argument is a real typed parameter in the emitted `.d.ts`, so it needs no cast to call. A cast would be worse than the current warning rather than better: against an older bridge the wasm binding still takes three arguments and a fourth is dropped silently, which turns a visible "cannot honour this" into an edit that quietly goes out under the wrong id.

## Validation

```
npm run lint     # tsc + oxlint
npm test         # 1337 pass, 1 skip, 0 fail
npm run build
```

No source change, so nothing new to test here; the suite is the check that the new declaration does not break the existing calls, and the two edit call sites still typecheck unchanged against the four-argument signature.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `@oxidezap/whatsapp-rust-bridge` to 0.15.0 to support an optional `stanza_id` in `editMessageBytes`. Previously the engine always minted the stanza id; now callers may provide it. Omitting it preserves current behavior.

- No runtime behavior change in this repo: edit paths ignore caller ids and keep the existing warning (its reason is now outdated). Wiring this up will follow.
- Backward compatible; no migration required.
- Diff is limited to `package.json` and `package-lock.json`.

<sup>Written for commit 6345bf87274730a2f9fbdd78c74984720e3f65bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

