### PR TITLE
deps: move to bridge 0.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.15.0",
+        "@oxidezap/whatsapp-rust-bridge": "0.16.0",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.15.0.tgz",
-      "integrity": "sha512-4XFUjfjQ2x4FMqk4Pvn3xCGxXeG++i//0PipLtM/XMk0k7zvBDuAH95O6wpYc89lGIFLZghA4OA2dYCnpYHXfQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.16.0.tgz",
+      "integrity": "sha512-a5k+fN/D/huK+H732li04Bfs1OlD6zpi/wLyzBG8bYPRk7S/q8zhPS0w4oD/aeMASYEfUB3rNy5kQtJIB0tcmg==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@oxidezap/whatsapp-rust-bridge": "0.15.0",
+    "@oxidezap/whatsapp-rust-bridge": "0.16.0",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"


### PR DESCRIPTION
## Summary

Bridge 0.16.0 carries [whatsapp-rust#1328](https://github.com/oxidezap/whatsapp-rust/pull/1328), the fix for the "Aguardando mensagem" reports, plus three rounds of allocation work in the engine.

An operator described the bug precisely: in a **closed** group one participant sees every message from the bot stuck on "waiting for this message" while everyone else reads normally, and the moment that person sends anything, even just a reaction, the next ones decrypt for her. The bot was sending. That member never had the sender key: the engine could not key them, dropped them from the distribution, then recorded them as already holding it, so every later send skipped them.

## What landed

**The fix.** Three engine changes:

- a usync answer carrying companions it cannot validate keeps the user's primary instead of discarding the whole identity;
- a primary that received no distribution is no longer recorded as keyed, so it is targeted again on the next send. This is what breaks the permanence: a transient failure stops becoming a permanent one;
- the phash the server echoes on a group `<ack>` is compared instead of discarded, so a disagreement about the participant set re-queries the group.

**Performance.** Allocation churn removed from phash computation, ack attribute parsing, message classification, addon crypto, ADV validation, prekeys, sender keys, lthash and the send fan-out. Same behaviour, fewer allocations on paths that run per message.

**Not carried.** The MLow encoder work in the same range does not reach this package: the bridge compiles no VoIP surface.

## What this does not fix

The phash comparison detects any divergence between our participant device set and the server's, whatever caused it, and logs it. The repair it triggers is narrower: it re-queries the group, which resolves a member missing from our participant list. A device-level or session-level divergence, where the participant is known but the device row we hold is stale, is still left to the server's `<notification type="devices">`, exactly as the official client leaves it.

So this closes one shape of the bug and gives a signal for the rest. If affected bots stop reporting and a phash mismatch shows up in their logs, the diagnosis held. If reports continue with no mismatch logged, the divergence is not in the participant set and the next batch belongs elsewhere.

Nothing here was verified against a live affected account; the engine fix is covered by tests and by the WhatsApp Web capture.

## Compatibility

Behaviour only. A primary that fails to encrypt is re-targeted on the following send instead of being skipped, so a group with a member the engine cannot key will see more sender key distributions than before. Nothing changes about what a caller passes or receives, and no send that returned `Ok` starts failing.

## Validation

```
npm run format:check
npm run lint          # tsc + oxlint
npm test              # 1339 pass, 1 skip, 0 fail
npm run build
```

No source change, so the suite is here to confirm the new bridge declaration does not move anything the adapters read.