### PR TITLE
fix(events): a 429 stream error is a rejected session, not a preserved connection

### DIFF
--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -463,13 +463,21 @@ const DISPATCHERS: DispatcherMap = {
 	// the moment the engine already knows, instead of the round trip that
 	// confirms it. The coded errors that *are* terminal (401/409/515/516) never
 	// reach this dispatcher; they emit `loggedOut` / `streamReplaced` instead.
-	streamError: (evt, { ctx }) => {
+	streamError: (evt, { ctx, callbacks }) => {
 		if (evt.code === RATE_LIMITED_STREAM_ERROR) {
 			ctx.logger.warn(
 				{ code: evt.code },
 				'stream error: the server rate limited this session; the engine will retry with an extended backoff'
 			)
-			emitRetrying(ctx)
+			// `connecting` promises the engine is restoring this connection.
+			// Under `setAutoReconnect(false)` it will not — the run loop breaks
+			// on the pass after the disconnect that follows — so publishing it
+			// would leave a retrying state nobody resolves. Silence, not a
+			// close: the engine still dispatches `Disconnected` when the server
+			// ends the stream, and that dispatcher already turns it into a
+			// terminal close under this flag. Closing here too would publish two
+			// for one failure, the second after teardown had already run.
+			if (callbacks?.isAutoReconnectEnabled?.() !== false) emitRetrying(ctx)
 			return
 		}
 

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -277,6 +277,13 @@ const emitClose = (
  * state upstream itself uses while a connection is being (re)established, so
  * consumers read this as `open → connecting → open` and stay out of the way.
  */
+/**
+ * `<stream:error code="429">` — the server rate limiting this session. The one
+ * stream error the engine forwards that is not a preserved connection; see the
+ * `streamError` dispatcher.
+ */
+const RATE_LIMITED_STREAM_ERROR = '429'
+
 const emitRetrying = (ctx: SocketContext) =>
 	ctx.ev.emit('connection.update', {
 		connection: 'connecting',
@@ -430,15 +437,44 @@ const DISPATCHERS: DispatcherMap = {
 		const status = mapConnectFailureToDisconnect(evt.reason)
 		emitClose(dispatchCtx, evt.message ?? 'Connection failure', status)
 	},
-	// NOT a close. The engine dispatches `StreamError` only from its catch-all
-	// `<stream:error>` branch — an unknown code, an `<ack/>` it still owes the
-	// server, or `<xml-not-well-formed>` — and it keeps or deliberately recycles
-	// the connection in every one of those. This used to report
+	// NOT a close, in either branch below. This used to report
 	// `DisconnectReason.badSession`, the code bots use to wipe credentials and
-	// re-pair, so a routine stream recycle could destroy a working session. The
-	// coded stream errors (401/409/515/516) never arrive here; they dispatch
-	// `loggedOut` / `streamReplaced` of their own.
-	streamError: (evt, { ctx }) => ctx.logger.warn({ code: evt.code }, 'stream error; the connection is preserved'),
+	// re-pair, so a routine stream recycle could destroy a working session.
+	//
+	// Two kinds of event arrive here, and they are not interchangeable:
+	//
+	//  - the engine's catch-all `<stream:error>` branch — an unknown code, an
+	//    `<ack/>` it still owes the server, or `<xml-not-well-formed>` — where
+	//    it keeps or deliberately recycles the connection. Nothing to publish:
+	//    the recycle reaches the consumer as a `disconnected` of its own.
+	//
+	//  - `429`, which is a *rejected session*, not a preserved connection.
+	//    `client/node_io.rs` clears `is_logged_in`, adds five rungs to the
+	//    Fibonacci backoff and suppresses the reset that would undo them, then
+	//    dispatches this event so an embedder can act on it — the core's comment
+	//    says as much ("An embedder has none, so report the rate limit through
+	//    `StreamError`"). It falls through the handler's `should_disconnect`
+	//    block, so the transport is still up at this instant and the socket
+	//    would keep reporting `open` until the server ends the stream.
+	//
+	// `connecting` for 429 is not a new state: it is the one this library
+	// already defines for "the engine is restoring the connection", and the one
+	// the next server frame produces anyway. Publishing it here just moves it to
+	// the moment the engine already knows, instead of the round trip that
+	// confirms it. The coded errors that *are* terminal (401/409/515/516) never
+	// reach this dispatcher; they emit `loggedOut` / `streamReplaced` instead.
+	streamError: (evt, { ctx }) => {
+		if (evt.code === RATE_LIMITED_STREAM_ERROR) {
+			ctx.logger.warn(
+				{ code: evt.code },
+				'stream error: the server rate limited this session; the engine will retry with an extended backoff'
+			)
+			emitRetrying(ctx)
+			return
+		}
+
+		ctx.logger.warn({ code: evt.code }, 'stream error; the connection is preserved')
+	},
 	streamReplaced: (_, dispatchCtx) =>
 		emitClose(dispatchCtx, 'Connection replaced', DisconnectReason.connectionReplaced),
 	// Carries the wire code (405), not `DisconnectReason.badSession`. Upstream

--- a/src/__tests__/auto-reconnect-terminal-close.test.ts
+++ b/src/__tests__/auto-reconnect-terminal-close.test.ts
@@ -186,10 +186,14 @@ const RETRYING: Array<{ label: string; event: BridgeEvent }> = [
 /** Events that must not touch `connection.update` at all. */
 const SILENT: Array<{ label: string; event: BridgeEvent }> = [
 	{
-		// Reaches JS only from the engine's catch-all `<stream:error>` branch —
-		// unknown code, `<ack/>`, `<xml-not-well-formed>` — every one of which
-		// keeps or deliberately recycles the connection. This used to report
+		// The engine's catch-all `<stream:error>` branch — unknown code,
+		// `<ack/>`, `<xml-not-well-formed>` — every one of which keeps or
+		// deliberately recycles the connection. This used to report
 		// `badSession`, the code bots use to wipe credentials and re-pair.
+		//
+		// Not every stream error is silent: `429` is a rejected session, not a
+		// preserved connection, and reports `connecting`. See
+		// `rate-limited-stream-error.test.ts`.
 		label: 'stream error (connection preserved)',
 		event: { type: 'stream_error', data: { code: 'unknown' } }
 	}

--- a/src/__tests__/rate-limited-stream-error.test.ts
+++ b/src/__tests__/rate-limited-stream-error.test.ts
@@ -1,0 +1,147 @@
+/**
+ * A `<stream:error code="429">` leaves the session unusable, and the consumer
+ * has to be able to see that.
+ *
+ * The engine treats 429 differently from every other stream error it forwards.
+ * `client/node_io.rs`:
+ *
+ * ```rust
+ * "429" => {
+ *     warn!("Got 429 stream error (rate limited). Will auto-reconnect with extended backoff.");
+ *     self.is_logged_in.store(false, Ordering::Relaxed);
+ *     self.auto_reconnect_errors.fetch_add(5, Ordering::Relaxed);
+ *     self.backoff_reset_suppressed.store(true, Ordering::Relaxed);
+ *     self.core.event_bus.dispatch(Event::StreamError(…));
+ * }
+ * ```
+ *
+ * That is a rejected session — `is_logged_in` cleared, five rungs added to the
+ * Fibonacci ladder, and the reset that would undo them suppressed — dispatched
+ * on purpose so an embedder can act, as the core's own comment says: "An
+ * embedder has none [no human watching a UI], so report the rate limit through
+ * `StreamError`."
+ *
+ * It arrived here and was dropped. Two things were wrong with that:
+ *
+ *  1. The socket kept reporting `open`. The transport is still up at that
+ *     instant — 429 falls through the handler's `should_disconnect` block ("so
+ *     the socket layer notices a real teardown without us forcing one") — so
+ *     nothing else contradicted it until the server ended the stream, which is
+ *     the one signal whose timing we do not control.
+ *  2. The log said `the connection is preserved`, which is true for the
+ *     catch-all branch this dispatcher was written for and false here.
+ *
+ * `connecting` is not a new state invented for this: it is the state this
+ * library already defines for "the engine is restoring the connection", and it
+ * is the state the very next server frame produces anyway. This publishes it at
+ * the moment the engine already knows the session was rejected, instead of
+ * waiting for the round trip that confirms it.
+ */
+
+import { EventEmitter } from 'node:events'
+import { describe, it } from 'node:test'
+
+import { makeEventHandlers } from '../Socket/events.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import type { ConnectionState } from '../Types/index.ts'
+import { expect } from './expect.ts'
+
+type LogLine = { payload: Record<string, unknown>; message: string }
+
+const makeCtx = () => {
+	const ev = new EventEmitter()
+	const ws = new EventEmitter()
+	const warnings: LogLine[] = []
+	const logger = {
+		trace() {},
+		debug() {},
+		info() {},
+		warn(payload: Record<string, unknown>, message: string) {
+			warnings.push({ payload, message })
+		},
+		error() {},
+		child() {
+			return logger
+		}
+	}
+	const ctx: SocketContext = {
+		ev: ev as unknown as SocketContext['ev'],
+		logger: logger as never,
+		fullConfig: {} as never,
+		ws,
+		getUser: () => undefined,
+		getMe: () => undefined,
+		setUser: () => {},
+		reportUnexpectedError: () => {},
+		getClient: () => Promise.reject(new Error('not used')),
+		getClientSync: () => {
+			throw new Error('not used')
+		}
+	}
+	return { ctx, ev, warnings }
+}
+
+const dispatchStreamError = (code: string) => {
+	const { ctx, ev, warnings } = makeCtx()
+	const updates: Partial<ConnectionState>[] = []
+	const terminalCloses: Error[] = []
+
+	ev.on('connection.update', (update: Partial<ConnectionState>) => updates.push(update))
+
+	makeEventHandlers(ctx, {
+		onTerminalClose: (error, publish) => {
+			terminalCloses.push(error)
+			publish()
+		}
+	}).onEvent?.({ type: 'stream_error', data: { code } } as never)
+
+	return { updates, warnings, terminalCloses }
+}
+
+describe('stream error 429: a rate-limited session', () => {
+	it('reports the session as no longer usable', () => {
+		const { updates } = dispatchStreamError('429')
+
+		expect(updates.length).toBe(1)
+		expect(updates[0]?.connection).toBe('connecting')
+	})
+
+	it('is not a close: the engine keeps the socket and retries on its own', () => {
+		const { updates, terminalCloses } = dispatchStreamError('429')
+
+		expect(terminalCloses.length).toBe(0)
+		expect(updates.some(update => update.connection === 'close')).toBe(false)
+	})
+
+	it('clears a QR the drop invalidated, like every other retry path', () => {
+		const { updates } = dispatchStreamError('429')
+
+		expect(updates[0]?.qr).toBe(undefined)
+		expect(updates[0]?.receivedPendingNotifications).toBe(false)
+	})
+
+	it('does not tell the operator the connection was preserved', () => {
+		const { warnings } = dispatchStreamError('429')
+
+		expect(warnings.length).toBe(1)
+		expect(warnings[0]?.message.includes('preserved')).toBe(false)
+		expect(warnings[0]?.message.includes('rate limited')).toBe(true)
+		expect(warnings[0]?.payload.code).toBe('429')
+	})
+})
+
+describe('stream error: every other code is still silent', () => {
+	// The catch-all branch the dispatcher was written for. The connection really
+	// is preserved (an `<ack/>` the server is still owed) or recycled by the
+	// engine itself (`<xml-not-well-formed>`, which sets `should_disconnect` and
+	// therefore reaches the consumer as a `disconnected` event of its own).
+	for (const code of ['', 'unknown', 'ack']) {
+		it(`code ${code === '' ? '(none)' : code} touches no connection.update`, () => {
+			const { updates, warnings } = dispatchStreamError(code)
+
+			expect(updates.length).toBe(0)
+			expect(warnings.length).toBe(1)
+			expect(warnings[0]?.message.includes('preserved')).toBe(true)
+		})
+	}
+})

--- a/src/__tests__/rate-limited-stream-error.test.ts
+++ b/src/__tests__/rate-limited-stream-error.test.ts
@@ -81,7 +81,7 @@ const makeCtx = () => {
 	return { ctx, ev, warnings }
 }
 
-const dispatchStreamError = (code: string) => {
+const dispatchStreamError = (code: string, opts: { autoReconnect?: boolean } = {}) => {
 	const { ctx, ev, warnings } = makeCtx()
 	const updates: Partial<ConnectionState>[] = []
 	const terminalCloses: Error[] = []
@@ -92,7 +92,8 @@ const dispatchStreamError = (code: string) => {
 		onTerminalClose: (error, publish) => {
 			terminalCloses.push(error)
 			publish()
-		}
+		},
+		isAutoReconnectEnabled: () => opts.autoReconnect ?? true
 	}).onEvent?.({ type: 'stream_error', data: { code } } as never)
 
 	return { updates, warnings, terminalCloses }
@@ -144,4 +145,41 @@ describe('stream error: every other code is still silent', () => {
 			expect(warnings[0]?.message.includes('preserved')).toBe(true)
 		})
 	}
+})
+
+/**
+ * `setAutoReconnect(false)` and a 429 together.
+ *
+ * The promise `connecting` carries here is "the engine is restoring this
+ * connection". With auto-reconnect off it will not: the run loop breaks on the
+ * pass after the ensuing disconnect. Publishing `connecting` anyway would leave
+ * the consumer holding a retrying state nobody is going to resolve — the same
+ * trap `disconnected` and the retryable `connectFailure` codes already avoid by
+ * asking `isAutoReconnectEnabled` first.
+ *
+ * Staying silent, rather than closing here: the engine still dispatches
+ * `Disconnected` when the server ends the stream, and that dispatcher already
+ * turns it into a terminal close under this flag. Emitting one here too would
+ * publish two closes for one failure, and the second would arrive after
+ * teardown had already run.
+ */
+describe('stream error 429 with auto-reconnect disabled', () => {
+	it('does not claim the engine is retrying', () => {
+		const { updates } = dispatchStreamError('429', { autoReconnect: false })
+
+		expect(updates.length).toBe(0)
+	})
+
+	it('still tells the operator it was rate limited', () => {
+		const { warnings } = dispatchStreamError('429', { autoReconnect: false })
+
+		expect(warnings.length).toBe(1)
+		expect(warnings[0]?.message.includes('rate limited')).toBe(true)
+	})
+
+	it('leaves the terminal close to the disconnect that follows', () => {
+		const { terminalCloses } = dispatchStreamError('429', { autoReconnect: false })
+
+		expect(terminalCloses.length).toBe(0)
+	})
 })


### PR DESCRIPTION
## Summary

`<stream:error code="429">` reached the `streamError` dispatcher and was handled like the engine's catch-all branch: a `logger.warn` saying *the connection is preserved*, and nothing on the bus. For that code both halves are wrong.

`client/node_io.rs` treats 429 unlike anything else it forwards:

```rust
"429" => {
    warn!("Got 429 stream error (rate limited). Will auto-reconnect with extended backoff.");
    self.is_logged_in.store(false, Ordering::Relaxed);
    self.auto_reconnect_errors.fetch_add(5, Ordering::Relaxed);
    self.backoff_reset_suppressed.store(true, Ordering::Relaxed);
    self.core.event_bus.dispatch(Event::StreamError(…));
}
```

That is a rejected session — `is_logged_in` cleared, five rungs added to the Fibonacci ladder, and the reset that would undo them suppressed — dispatched deliberately so an embedder can act on it. The core's own comment says why: *"An embedder has none [no human watching a UI], so report the rate limit through `StreamError`."*

It also falls through the handler's `should_disconnect` block ("so the socket layer notices a real teardown without us forcing one"), so the transport is still up at that instant and the socket kept reporting `open` until the server ended the stream — the one signal whose timing we do not control.

## What changes

429 now publishes `connecting`, through the existing `emitRetrying`.

That is not a new state invented for this case: it is the one this library already defines for *the engine is restoring the connection*, and the one the next server frame produces anyway once the stream ends. This moves it to the moment the engine already knows the session was rejected, instead of the round trip that confirms it.

The log line for 429 also stops saying the connection was preserved, and says it was rate limited.

Every other stream error is untouched and still silent. No path gained a `close`.

## Why the comment mattered

The dispatcher's comment claimed `StreamError` only ever arrives from the catch-all branch, and that the connection is kept or recycled in every case that reaches it. The engine dispatches it from two places — the catch-all *and* the 429 arm — so that premise is what made this easy to miss. `auto-reconnect-terminal-close.test.ts` encoded the same premise in its `SILENT` list; both now describe the split.

## How this surfaces for a consumer

A bot that treats `open` as "usable" had no way to learn the session had been rejected. The visible symptom is every call failing with `not connected` while `connection` still reads `open`, for as long as the extended backoff lasts — and per the README's own table, four consecutive 429s is about 31 minutes.

## Tests

`src/__tests__/rate-limited-stream-error.test.ts`, driven through `makeEventHandlers` like the existing dispatcher tests:

- 429 reports the session as no longer usable (`connecting`)
- 429 is not a close, and does not run `onTerminalClose`
- 429 clears the spent QR, like every other retry path
- the operator is not told the connection was preserved
- `''`, `unknown` and `ack` still touch no `connection.update` at all

## Validation

```
node --test src/__tests__/*.test.ts     840 pass, 0 fail
npm run lint                            clean (tsc + oxlint)
npm run format:check                    clean
npm run compat:audit:lifecycle          holds 28 · violated 0
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats `<stream:error code="429">` as a rejected session so consumers see the drop immediately. Before: we logged "connection preserved" and published nothing; after: we warn about rate limiting and publish `connection.update { connection: 'connecting' }` via `emitRetrying` when auto‑reconnect is enabled.

- Updates `streamError` dispatcher to branch on `429`: log rate limiting and emit `connecting` only if `isAutoReconnectEnabled()` is not false. When auto‑reconnect is disabled, stay silent here and let the subsequent `Disconnected` produce the terminal close.
- Leaves other stream errors unchanged: the catch‑all branch stays silent; terminal coded errors (401/409/515/516) continue on their own paths; no code path here emits `close`.
- Tests: adds `src/__tests__/rate-limited-stream-error.test.ts` (including the auto‑reconnect‑off case) and adjusts `auto-reconnect-terminal-close.test.ts` comments/expectations.
- No migration required. Consumers who treat `open` as usable will now get an immediate `connecting` during rate limiting when auto‑reconnect is on, instead of waiting for the stream to end.

<sup>Written for commit 6733d982955ce48a0f4215c1e1703120758bb38d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rate-limited stream connections by reporting a reconnecting status and retrying instead of treating them as terminal failures.
  * Preserved existing connection behavior for other stream errors, with clearer warnings.

* **Tests**
  * Added coverage for rate-limited errors, reconnect state cleanup, and non-terminal connection handling.
  * Clarified stream-error behavior in existing test documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->