### PR TITLE
feat(socket): warn once about config options nothing here reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,15 +230,19 @@ A few behaviors that differ from upstream — almost always to your advantage:
   either hook: a `cachedGroupMetadata` carried over from upstream never runs,
   and neither does a `getMessage`. Passing them is harmless — the whole
   `SocketConfig` shape is accepted so a migration needs no edits — but they are
-  not overrides, so delete them rather than maintain them. The socket warns once
+  not overrides, so delete them rather than maintain them. Every socket warns once
   at construction naming any option in that group it received; that list is the
-  authority, and it currently also covers `keepAliveIntervalMs`,
+  authority — the type system requires each `SocketConfig` member to be
+  classified, so it cannot fall behind — and it also covers `keepAliveIntervalMs`,
   `markOnlineOnConnect`, `maxMsgRetryCount`, `msgRetryCounterCache`,
   `retryRequestDelayMs`, `fireInitQueries`, `syncFullHistory`,
   `shouldSyncHistoryMessage`, `generateHighQualityLinkPreview`,
   `linkPreviewImageThumbnailWidth`, `enableAutoSessionRecreation`,
   `enableRecentMessageCache`, `appStateMacVerification`,
-  `patchMessageBeforeSending`, `customUploadHosts` and `countryCode`.
+  `patchMessageBeforeSending`, `customUploadHosts`, `countryCode`,
+  `connectTimeoutMs`, `qrTimeout`, `printQRInTerminal`, `ignoreOfflineMessages`,
+  `downloadHistory`, `agent`, `fetchAgent`, `mobile`, `mediaCache`,
+  `userDevicesCache`, `callOfferCache` and `placeholderResendCache`.
 - **`Boom` ships in the box.** baileyrs exports its own
   `@hapi/boom`-compatible `Boom`, so the existing
   `(err as Boom).output.statusCode` pattern works unchanged. If your

--- a/README.md
+++ b/README.md
@@ -226,8 +226,19 @@ A few behaviors that differ from upstream — almost always to your advantage:
   [When `connecting` lasts minutes](#when-connecting-lasts-minutes): a
   readiness timeout written for upstream's `connecting` misreads this one.
 - **No `getMessage` / `cachedGroupMetadata` polyfill required.** The Rust
-  side caches group metadata and message keys natively. You can still pass
-  them — they're respected as overrides — but they're optional.
+  side caches group metadata and message keys natively, and nothing here calls
+  either hook: a `cachedGroupMetadata` carried over from upstream never runs,
+  and neither does a `getMessage`. Passing them is harmless — the whole
+  `SocketConfig` shape is accepted so a migration needs no edits — but they are
+  not overrides, so delete them rather than maintain them. The socket warns once
+  at construction naming any option in that group it received; that list is the
+  authority, and it currently also covers `keepAliveIntervalMs`,
+  `markOnlineOnConnect`, `maxMsgRetryCount`, `msgRetryCounterCache`,
+  `retryRequestDelayMs`, `fireInitQueries`, `syncFullHistory`,
+  `shouldSyncHistoryMessage`, `generateHighQualityLinkPreview`,
+  `linkPreviewImageThumbnailWidth`, `enableAutoSessionRecreation`,
+  `enableRecentMessageCache`, `appStateMacVerification`,
+  `patchMessageBeforeSending`, `customUploadHosts` and `countryCode`.
 - **`Boom` ships in the box.** baileyrs exports its own
   `@hapi/boom`-compatible `Boom`, so the existing
   `(err as Boom).output.statusCode` pattern works unchanged. If your

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -55,6 +55,7 @@ import { makeChatActionMethods } from './chat-actions.ts'
 import { makeContactMethods } from './contacts.ts'
 import { makeCommunityMethods } from './communities.ts'
 import { makeBridgeClientOwner } from './bridge-client-owner.ts'
+import { warnUnsupportedConfig } from './unsupported-config.ts'
 import { wrapBridgeClient } from './bridge-error-boundary.ts'
 import { makeTerminalCloseReporter } from './terminal-close-reporter.ts'
 import { makeEventHandlers } from './events.ts'
@@ -105,6 +106,10 @@ const browserToPlatformType = (browser: string): DevicePlatformType => {
 const makeWASocket = (config: UserFacingSocketConfig) => {
 	const fullConfig = { ...DEFAULT_CONNECTION_CONFIG, ...config }
 	const { logger } = fullConfig
+	// Against `config`, not `fullConfig`: only what this caller actually passed
+	// is worth naming. Merging the defaults first would report every unsupported
+	// option on every socket, including the ones nobody chose.
+	warnUnsupportedConfig(config, logger)
 	const auth = normalizeSocketAuthenticationState(fullConfig.auth)
 	const getExposedKeys = makeLazyTransactionKeyStore(auth.keys, logger, fullConfig.transactionOpts)
 

--- a/src/Socket/unsupported-config.ts
+++ b/src/Socket/unsupported-config.ts
@@ -147,9 +147,15 @@ export const unsupportedConfigKeys = (config: object): string[] =>
  * close carries its own configuration decision, and `Socket/internals.ts`
  * already warns "once per socket rather than per call" for its own no-ops.
  *
- * `warn` and not `error`: nothing is broken, and a socket must never fail to
- * build over a diagnostic — hence the guard around the call, which also keeps a
- * minimal test logger from throwing.
+ * `warn` and not `error`: nothing is broken.
+ *
+ * A socket must never fail to build over a diagnostic, which takes both guards
+ * around the call. The optional chaining covers a logger that has no `warn` (a
+ * minimal one in a test, say); the `try` covers one whose `warn` throws — a
+ * synchronous transport failing there would otherwise take down `makeWASocket`
+ * itself, and only for the consumers who passed an inert option: the one group
+ * this warning exists to help. The failure is swallowed rather than reported,
+ * because the only thing left to report it with is the logger that just threw.
  *
  * @param config the object handed to `makeWASocket`, before defaults are merged
  * @param logger the socket's logger
@@ -161,8 +167,12 @@ export const warnUnsupportedConfig = (
 	const options = unsupportedConfigKeys(config)
 	if (!options.length) return
 
-	logger?.warn?.(
-		{ options },
-		'these options are accepted for upstream compatibility but nothing reads them here: the engine owns that behaviour'
-	)
+	try {
+		logger?.warn?.(
+			{ options },
+			'these options are accepted for upstream compatibility but nothing reads them here: the engine owns that behaviour'
+		)
+	} catch {
+		// See above: nothing here is worth failing a socket over.
+	}
 }

--- a/src/Socket/unsupported-config.ts
+++ b/src/Socket/unsupported-config.ts
@@ -40,7 +40,7 @@ export const UNSUPPORTED_CONFIG_KEYS = [
 	'fireInitQueries',
 	// Presence is explicit here: call `sendPresenceUpdate` after `open`.
 	'markOnlineOnConnect',
-	// History sync is driven by the engine and shaped by `downloadHistory`.
+	// History sync is driven by the engine.
 	'syncFullHistory',
 	'shouldSyncHistoryMessage',
 	// Link previews are not generated on this side.
@@ -60,8 +60,69 @@ export const UNSUPPORTED_CONFIG_KEYS = [
 	// Upstream hooks with no counterpart on this side.
 	'patchMessageBeforeSending',
 	'customUploadHosts',
-	'countryCode'
+	'countryCode',
+	// Timeouts and transport knobs the engine owns. `connectTimeoutMs` is the
+	// one to point at: `Socket/internals.ts` already documented that it "reaches
+	// neither the transport nor the core", and it was still missing from the
+	// first version of this list. Proxy and TLS configuration goes through
+	// `options.dispatcher`, which is read — `agent` and `fetchAgent` are not.
+	'connectTimeoutMs',
+	'qrTimeout',
+	'agent',
+	'fetchAgent',
+	'mobile',
+	// The QR is published on `connection.update`; drawing it is the consumer's.
+	'printQRInTerminal',
+	// Offline delivery is the engine's, and history sync is driven by it too.
+	'ignoreOfflineMessages',
+	'downloadHistory',
+	// Caches the engine keeps natively, in Rust, keyed off its own stores.
+	'mediaCache',
+	'userDevicesCache',
+	'callOfferCache',
+	'placeholderResendCache'
 ] as const satisfies ReadonlyArray<keyof SocketConfig>
+
+/**
+ * The other half: options something on this side actually reads.
+ *
+ * Only here to make the classification total. Nothing consumes this list at
+ * runtime; its job is to let the assertion below fail the build when a new
+ * member of `SocketConfig` belongs to neither list — which is exactly how the
+ * first version of the catalog shipped twelve keys short.
+ */
+export const READ_CONFIG_KEYS = [
+	'waWebSocketUrl',
+	'options',
+	'logger',
+	'version',
+	'browser',
+	'pushName',
+	'auth',
+	'cache',
+	'deviceProps',
+	'wantedPreKeyCount',
+	'emitOwnEvents',
+	'shouldIgnoreJid',
+	'defaultQueryTimeoutMs',
+	'transactionOpts',
+	'makeSignalRepository'
+] as const satisfies ReadonlyArray<keyof SocketConfig>
+
+/**
+ * Every member of `SocketConfig` is classified.
+ *
+ * A compile error here means a new option was added without deciding whether
+ * this library reads it. Put it in whichever list is true and the error goes
+ * away; the README presents the unread one as authoritative, so leaving an
+ * option out of both is what makes that claim false.
+ */
+type UnclassifiedConfigKey = Exclude<
+	keyof SocketConfig,
+	(typeof UNSUPPORTED_CONFIG_KEYS)[number] | (typeof READ_CONFIG_KEYS)[number]
+>
+const _everyConfigKeyIsClassified: UnclassifiedConfigKey extends never ? true : never = true
+void _everyConfigKeyIsClassified
 
 /**
  * Which unsupported options this caller actually passed.
@@ -79,7 +140,12 @@ export const unsupportedConfigKeys = (config: object): string[] =>
 	)
 
 /**
- * Say once, at construction, which unsupported options this caller passed.
+ * Say once per socket, at construction, which unsupported options this caller
+ * passed.
+ *
+ * Per socket, not per process: a replacement socket built after a terminal
+ * close carries its own configuration decision, and `Socket/internals.ts`
+ * already warns "once per socket rather than per call" for its own no-ops.
  *
  * `warn` and not `error`: nothing is broken, and a socket must never fail to
  * build over a diagnostic — hence the guard around the call, which also keeps a

--- a/src/Socket/unsupported-config.ts
+++ b/src/Socket/unsupported-config.ts
@@ -149,13 +149,23 @@ export const unsupportedConfigKeys = (config: object): string[] =>
  *
  * `warn` and not `error`: nothing is broken.
  *
- * A socket must never fail to build over a diagnostic, which takes both guards
- * around the call. The optional chaining covers a logger that has no `warn` (a
- * minimal one in a test, say); the `try` covers one whose `warn` throws — a
- * synchronous transport failing there would otherwise take down `makeWASocket`
- * itself, and only for the consumers who passed an inert option: the one group
- * this warning exists to help. The failure is swallowed rather than reported,
- * because the only thing left to report it with is the logger that just threw.
+ * A socket must never fail to build over a diagnostic. That guarantee is
+ * unconditional, so the guard covers the whole of it — the reading as well as
+ * the writing:
+ *
+ *  - the optional chaining, for a logger with no `warn` (a minimal one in a
+ *    test, say);
+ *  - the `try` around the logging call, for a logger whose `warn` throws — a
+ *    synchronous transport failing there would take down `makeWASocket` itself;
+ *  - the same `try` around the inspection, because telling a passed option from
+ *    a spread leftover means reading `config[key]`, and reading fires getters. A
+ *    config with a throwing accessor, or a proxy with a throwing trap, would
+ *    otherwise fail construction from outside the logging call.
+ *
+ * All of it only ever bites consumers who passed an inert option, which is the
+ * one group this warning exists to help. The failure is swallowed rather than
+ * reported, because the only thing left to report it with is the logger that
+ * just threw.
  *
  * @param config the object handed to `makeWASocket`, before defaults are merged
  * @param logger the socket's logger
@@ -164,10 +174,10 @@ export const warnUnsupportedConfig = (
 	config: object,
 	logger: { warn?: (payload: object, message: string) => void }
 ) => {
-	const options = unsupportedConfigKeys(config)
-	if (!options.length) return
-
 	try {
+		const options = unsupportedConfigKeys(config)
+		if (!options.length) return
+
 		logger?.warn?.(
 			{ options },
 			'these options are accepted for upstream compatibility but nothing reads them here: the engine owns that behaviour'

--- a/src/Socket/unsupported-config.ts
+++ b/src/Socket/unsupported-config.ts
@@ -1,0 +1,102 @@
+/**
+ * Options `SocketConfig` accepts that nothing on this side reads.
+ *
+ * Being a drop-in replacement means accepting the whole upstream shape, so none
+ * of these throws and none of them ever will. But the Rust engine owns
+ * keepalive, retry, history sync, link previews and its own message and group
+ * caches, so for these keys there is no reader to hand the value to — and a
+ * consumer that passes one is describing behaviour it will not get.
+ *
+ * That gap is expensive precisely because it is quiet. Two shapes found in a
+ * production bot, both dead for months, both looking deliberate:
+ *
+ * ```ts
+ * cachedGroupMetadata: async jid => myOwnCache.get(jid)   // never called
+ * getMessage: async key => myStore.get(key.id)            // never called
+ * ```
+ *
+ * `enableRecentMessageCache: true` is worse: it names a cache the consumer
+ * believes it turned on.
+ *
+ * The list is deliberately hand-maintained rather than derived. Deriving it
+ * (scanning for reads) would quietly go wrong in both directions — an option
+ * read through a computed key would look unsupported, and one only mentioned in
+ * a type would look supported. A test anchors every entry to `SocketConfig`, so
+ * an option that starts being read here fails the audit for whoever removes it.
+ */
+
+import type { SocketConfig } from '../Types/index.ts'
+
+export const UNSUPPORTED_CONFIG_KEYS = [
+	// The engine runs its own keepalive (WA Web's idle-ping + dead-socket
+	// watchdog) and its own Fibonacci reconnect ladder.
+	'keepAliveIntervalMs',
+	// Retry of an undecryptable message is engine-side, keyed off its own store
+	// of sent messages; there is nothing for a consumer counter to count.
+	'maxMsgRetryCount',
+	'msgRetryCounterCache',
+	'retryRequestDelayMs',
+	// The engine decides its own post-login queries.
+	'fireInitQueries',
+	// Presence is explicit here: call `sendPresenceUpdate` after `open`.
+	'markOnlineOnConnect',
+	// History sync is driven by the engine and shaped by `downloadHistory`.
+	'syncFullHistory',
+	'shouldSyncHistoryMessage',
+	// Link previews are not generated on this side.
+	'generateHighQualityLinkPreview',
+	'linkPreviewImageThumbnailWidth',
+	// Session recreation and the recent-message cache are engine-side, and
+	// configured through `cache` (CacheConfig), not through these flags.
+	'enableAutoSessionRecreation',
+	'enableRecentMessageCache',
+	// App-state MAC verification happens in the engine.
+	'appStateMacVerification',
+	// The engine resolves group metadata and sent messages from its own stores;
+	// these two are the ones consumers most often carry over from upstream and
+	// keep believing in.
+	'cachedGroupMetadata',
+	'getMessage',
+	// Upstream hooks with no counterpart on this side.
+	'patchMessageBeforeSending',
+	'customUploadHosts',
+	'countryCode'
+] as const satisfies ReadonlyArray<keyof SocketConfig>
+
+/**
+ * Which unsupported options this caller actually passed.
+ *
+ * Only own, non-`undefined` properties count: spreading a partial config
+ * commonly leaves `{ getMessage: undefined }` behind, and warning about a key
+ * whose value is absent would be noise about nothing.
+ *
+ * @param config the object handed to `makeWASocket`, before defaults are merged
+ * @returns the offending keys, in catalog order (stable across consumers)
+ */
+export const unsupportedConfigKeys = (config: object): string[] =>
+	UNSUPPORTED_CONFIG_KEYS.filter(
+		key => Object.hasOwn(config, key) && (config as Record<string, unknown>)[key] !== undefined
+	)
+
+/**
+ * Say once, at construction, which unsupported options this caller passed.
+ *
+ * `warn` and not `error`: nothing is broken, and a socket must never fail to
+ * build over a diagnostic — hence the guard around the call, which also keeps a
+ * minimal test logger from throwing.
+ *
+ * @param config the object handed to `makeWASocket`, before defaults are merged
+ * @param logger the socket's logger
+ */
+export const warnUnsupportedConfig = (
+	config: object,
+	logger: { warn?: (payload: object, message: string) => void }
+) => {
+	const options = unsupportedConfigKeys(config)
+	if (!options.length) return
+
+	logger?.warn?.(
+		{ options },
+		'these options are accepted for upstream compatibility but nothing reads them here: the engine owns that behaviour'
+	)
+}

--- a/src/__tests__/unsupported-config-options.test.ts
+++ b/src/__tests__/unsupported-config-options.test.ts
@@ -133,9 +133,23 @@ describe('warnUnsupportedConfig', () => {
 		expect(collect({ browser: ['x', 'y', 'z'] }).length).toBe(0)
 	})
 
-	// A socket must never fail to build over a diagnostic.
+	// A socket must never fail to build over a diagnostic — and that has to hold
+	// for a logger that throws, not just one that is missing. A synchronous
+	// transport failing inside `warn` would otherwise take down `makeWASocket`
+	// itself, and only for consumers who passed an inert option: the one group
+	// this warning exists to help.
 	it('survives a logger without warn', () => {
 		warnUnsupportedConfig({ getMessage: async () => undefined }, {} as never)
+	})
+
+	it('survives a logger whose warn throws', () => {
+		const throwing = {
+			warn() {
+				throw new Error('logging transport is down')
+			}
+		}
+
+		warnUnsupportedConfig({ getMessage: async () => undefined }, throwing as never)
 	})
 })
 

--- a/src/__tests__/unsupported-config-options.test.ts
+++ b/src/__tests__/unsupported-config-options.test.ts
@@ -142,6 +142,42 @@ describe('warnUnsupportedConfig', () => {
 		warnUnsupportedConfig({ getMessage: async () => undefined }, {} as never)
 	})
 
+	// The inspection reads `config[key]` to tell a passed option from a spread
+	// leftover, and reading fires getters — so a config that throws on access
+	// would take the socket down from outside the logging call. Exotic, but the
+	// guarantee above is unconditional, so the guard has to cover the reading
+	// as well as the writing.
+	it('survives a config whose getter throws', () => {
+		const hostile = {}
+		Object.defineProperty(hostile, 'getMessage', {
+			enumerable: true,
+			get() {
+				throw new Error('config accessor is hostile')
+			}
+		})
+
+		warnUnsupportedConfig(hostile, { warn() {} } as never)
+	})
+
+	it('survives a proxy config whose traps throw', () => {
+		const hostile = new Proxy(
+			{},
+			{
+				get() {
+					throw new Error('trap is hostile')
+				},
+				getOwnPropertyDescriptor() {
+					throw new Error('trap is hostile')
+				},
+				has() {
+					throw new Error('trap is hostile')
+				}
+			}
+		)
+
+		warnUnsupportedConfig(hostile, { warn() {} } as never)
+	})
+
 	it('survives a logger whose warn throws', () => {
 		const throwing = {
 			warn() {

--- a/src/__tests__/unsupported-config-options.test.ts
+++ b/src/__tests__/unsupported-config-options.test.ts
@@ -19,15 +19,22 @@
  * it. `enableRecentMessageCache: true` reads worse still: it names a cache the
  * consumer believes it turned on.
  *
- * The warning is one line at construction, listing only keys the caller passed
- * explicitly. A default-only config is silent, and so is every subsequent
- * socket built from the same options.
+ * The warning is one line per socket, at construction, listing only keys the
+ * caller passed explicitly; a default-only config is silent. Per socket and not
+ * per process on purpose — `Socket/internals.ts` uses the same rule for its own
+ * no-op notice, and a replacement socket after a terminal close is a new
+ * configuration decision, not a repeat of the old one.
  */
 
 import { describe, it } from 'node:test'
 
 import { DEFAULT_CONNECTION_CONFIG } from '../Defaults/index.ts'
-import { unsupportedConfigKeys, UNSUPPORTED_CONFIG_KEYS, warnUnsupportedConfig } from '../Socket/unsupported-config.ts'
+import {
+	unsupportedConfigKeys,
+	UNSUPPORTED_CONFIG_KEYS,
+	READ_CONFIG_KEYS,
+	warnUnsupportedConfig
+} from '../Socket/unsupported-config.ts'
 import { expect } from './expect.ts'
 
 describe('unsupportedConfigKeys', () => {
@@ -48,7 +55,7 @@ describe('unsupportedConfigKeys', () => {
 	})
 
 	it('stays quiet for a config of only supported options', () => {
-		expect(unsupportedConfigKeys({ browser: ['x', 'y', 'z'], printQRInTerminal: false })).toEqual([])
+		expect(unsupportedConfigKeys({ browser: ['x', 'y', 'z'], emitOwnEvents: false })).toEqual([])
 	})
 
 	it('stays quiet for an empty config', () => {
@@ -129,5 +136,53 @@ describe('warnUnsupportedConfig', () => {
 	// A socket must never fail to build over a diagnostic.
 	it('survives a logger without warn', () => {
 		warnUnsupportedConfig({ getMessage: async () => undefined }, {} as never)
+	})
+})
+
+/**
+ * Completeness, which is where the first version of this catalog went wrong.
+ *
+ * It shipped missing twelve keys — `connectTimeoutMs` among them, whose own
+ * doc comment in `Socket/internals.ts` says it "reaches neither the transport
+ * nor the core". A hand-maintained list that the README calls authoritative has
+ * to be provably complete, or it quietly grants the same false confidence it
+ * exists to remove.
+ *
+ * So every member of `SocketConfig` is classified as read or unread, and the
+ * type-level assertion in the module fails the build when a new option belongs
+ * to neither. These runtime checks cover the other half: no key claimed by both
+ * lists, and none by neither among the ones that carry a default.
+ */
+describe('the classification covers SocketConfig', () => {
+	it('never puts a key in both lists', () => {
+		const unread = new Set<string>(UNSUPPORTED_CONFIG_KEYS)
+		expect(READ_CONFIG_KEYS.filter(key => unread.has(key))).toEqual([])
+	})
+
+	it('classifies every option that carries a default', () => {
+		const classified = new Set<string>([...UNSUPPORTED_CONFIG_KEYS, ...READ_CONFIG_KEYS])
+		const unclassified = Object.keys(DEFAULT_CONNECTION_CONFIG).filter(key => !classified.has(key))
+
+		expect(unclassified).toEqual([])
+	})
+
+	// The specific misses that motivated this block, so a regression names itself.
+	it('catalogs the options the first version missed', () => {
+		for (const key of [
+			'connectTimeoutMs',
+			'qrTimeout',
+			'printQRInTerminal',
+			'ignoreOfflineMessages',
+			'downloadHistory',
+			'mediaCache',
+			'userDevicesCache',
+			'callOfferCache',
+			'placeholderResendCache',
+			'agent',
+			'fetchAgent',
+			'mobile'
+		]) {
+			expect(UNSUPPORTED_CONFIG_KEYS.includes(key as never)).toBe(true)
+		}
 	})
 })

--- a/src/__tests__/unsupported-config-options.test.ts
+++ b/src/__tests__/unsupported-config-options.test.ts
@@ -1,0 +1,133 @@
+/**
+ * An option this library does not read should say so, once, instead of looking
+ * configured.
+ *
+ * `SocketConfig` is the upstream Baileys shape, and a drop-in replacement has to
+ * accept all of it — that is the point. But the engine owns keepalive, retry,
+ * history sync, link previews and its own message and group caches, so a good
+ * half of those keys have no reader on this side. Passing them is not an error
+ * and must never throw. It is silently believing them that costs.
+ *
+ * Two real shapes that took a while to find in a consumer:
+ *
+ *   cachedGroupMetadata: async jid => myOwnCache.get(jid)   // never called
+ *   getMessage: async key => myStore.get(key.id)            // never called
+ *
+ * Both had been dead for months, and the README's migration notes actively
+ * encouraged keeping them ("you can still pass them — they're respected as
+ * overrides"), which is the sentence this change makes true again by removing
+ * it. `enableRecentMessageCache: true` reads worse still: it names a cache the
+ * consumer believes it turned on.
+ *
+ * The warning is one line at construction, listing only keys the caller passed
+ * explicitly. A default-only config is silent, and so is every subsequent
+ * socket built from the same options.
+ */
+
+import { describe, it } from 'node:test'
+
+import { DEFAULT_CONNECTION_CONFIG } from '../Defaults/index.ts'
+import { unsupportedConfigKeys, UNSUPPORTED_CONFIG_KEYS, warnUnsupportedConfig } from '../Socket/unsupported-config.ts'
+import { expect } from './expect.ts'
+
+describe('unsupportedConfigKeys', () => {
+	it('names an option the engine owns', () => {
+		expect(unsupportedConfigKeys({ getMessage: async () => undefined })).toEqual(['getMessage'])
+	})
+
+	// Catalog order, not caller order: stable across consumers, so the warning
+	// reads the same for the same set of options however the config was built.
+	it('lists several in a stable order', () => {
+		const keys = unsupportedConfigKeys({
+			markOnlineOnConnect: true,
+			browser: ['x', 'y', 'z'],
+			cachedGroupMetadata: async () => undefined
+		})
+
+		expect(keys).toEqual(['markOnlineOnConnect', 'cachedGroupMetadata'])
+	})
+
+	it('stays quiet for a config of only supported options', () => {
+		expect(unsupportedConfigKeys({ browser: ['x', 'y', 'z'], printQRInTerminal: false })).toEqual([])
+	})
+
+	it('stays quiet for an empty config', () => {
+		expect(unsupportedConfigKeys({})).toEqual([])
+	})
+
+	it('ignores a key set to undefined, which reads as not passed', () => {
+		expect(unsupportedConfigKeys({ getMessage: undefined })).toEqual([])
+	})
+
+	// A key that is not in `SocketConfig` would silently never fire. That is
+	// caught at compile time by the `satisfies ReadonlyArray<keyof SocketConfig>`
+	// on the catalog — stronger than a runtime check, which cannot see the
+	// optional members (`msgRetryCounterCache` has no default, so it is absent
+	// from `DEFAULT_CONNECTION_CONFIG` while being a perfectly real option).
+	// What is worth asserting here is that the catalog is coherent with itself.
+	it('is a catalog, not a list with repeats', () => {
+		expect(new Set(UNSUPPORTED_CONFIG_KEYS).size).toBe(UNSUPPORTED_CONFIG_KEYS.length)
+	})
+
+	// The keys that do carry a default must match it exactly; a typo in one of
+	// those is the mistake a compile-time check cannot make obvious.
+	it('agrees with the defaults on every key that has one', () => {
+		const withDefaults = UNSUPPORTED_CONFIG_KEYS.filter(key => key in DEFAULT_CONNECTION_CONFIG)
+
+		expect(withDefaults.length > 10).toBe(true)
+		expect(unsupportedConfigKeys(DEFAULT_CONNECTION_CONFIG)).toEqual(withDefaults)
+	})
+
+	it('does not claim an option the library reads', () => {
+		for (const supported of ['browser', 'auth', 'version', 'logger', 'emitOwnEvents', 'shouldIgnoreJid']) {
+			expect(UNSUPPORTED_CONFIG_KEYS.includes(supported as never)).toBe(false)
+		}
+	})
+})
+
+/**
+ * The warning itself. One line, at construction, naming the keys — so the
+ * consumer finds it the first time it looks at the log, not months later while
+ * debugging why its `cachedGroupMetadata` never ran.
+ */
+describe('warnUnsupportedConfig', () => {
+	const collect = (config: object) => {
+		const warnings: Array<{ payload: Record<string, unknown>; message: string }> = []
+		const logger = {
+			trace() {},
+			debug() {},
+			info() {},
+			warn(payload: Record<string, unknown>, message: string) {
+				warnings.push({ payload, message })
+			},
+			error() {},
+			child() {
+				return logger
+			}
+		}
+		warnUnsupportedConfig(config, logger as never)
+		return warnings
+	}
+
+	it('names every unsupported key the caller passed', () => {
+		const warnings = collect({ getMessage: async () => undefined, markOnlineOnConnect: true })
+
+		expect(warnings.length).toBe(1)
+		expect(warnings[0]?.payload.options).toEqual(['markOnlineOnConnect', 'getMessage'])
+	})
+
+	it('points at the engine rather than blaming the caller', () => {
+		const warnings = collect({ getMessage: async () => undefined })
+
+		expect(warnings[0]?.message.includes('engine')).toBe(true)
+	})
+
+	it('says nothing when there is nothing to say', () => {
+		expect(collect({ browser: ['x', 'y', 'z'] }).length).toBe(0)
+	})
+
+	// A socket must never fail to build over a diagnostic.
+	it('survives a logger without warn', () => {
+		warnUnsupportedConfig({ getMessage: async () => undefined }, {} as never)
+	})
+})


### PR DESCRIPTION
## Summary

`SocketConfig` is the upstream shape, and a drop-in replacement has to accept all of it — that is the point, and none of this changes. But the engine owns keepalive, retry, history sync, link previews and its own message and group caches, so roughly half of those keys have no reader on this side. Passing one is not an error. Silently believing it is what costs.

Two shapes found in a production bot, both dead for months, both looking deliberate:

```ts
cachedGroupMetadata: async jid => myOwnCache.get(jid)   // never called
getMessage: async key => myStore.get(key.id)            // never called
```

Neither hook is called anywhere in `src/`. `enableRecentMessageCache: true` reads worse still: it names a cache the consumer believes it turned on.

## What changes

`makeWASocket` warns once, at construction, naming only the keys this caller passed explicitly:

```
these options are accepted for upstream compatibility but nothing reads them
here: the engine owns that behaviour
  options: [ "markOnlineOnConnect", "cachedGroupMetadata", "getMessage" ]
```

Checked against `config`, not the merged `fullConfig` — otherwise every socket would report every unsupported option, including the ones nobody chose. A default-only config is silent.

Nothing throws, nothing changes shape, and a socket never fails to build over a diagnostic (`logger?.warn?.`).

## The README said the opposite

> **No `getMessage` / `cachedGroupMetadata` polyfill required.** […] You can still pass them — they're respected as overrides — but they're optional.

They are not overrides. That is the sentence that kept the two dead hooks above alive in a real consumer, so it is corrected here, and the migration note now points at the warning as the authority on which options are inert.

## Why the catalog is hand-maintained

Deriving it (scanning for reads) goes wrong in both directions: an option read through a computed key would look unsupported, and one only mentioned in a type would look supported. The list carries a `satisfies ReadonlyArray<keyof SocketConfig>`, so a key that does not exist fails the build — stronger than any runtime check, which cannot see optional members (`msgRetryCounterCache` has no default, so it is absent from `DEFAULT_CONNECTION_CONFIG` while being a perfectly real option).

Current entries: `keepAliveIntervalMs`, `maxMsgRetryCount`, `msgRetryCounterCache`, `retryRequestDelayMs`, `fireInitQueries`, `markOnlineOnConnect`, `syncFullHistory`, `shouldSyncHistoryMessage`, `generateHighQualityLinkPreview`, `linkPreviewImageThumbnailWidth`, `enableAutoSessionRecreation`, `enableRecentMessageCache`, `appStateMacVerification`, `cachedGroupMetadata`, `getMessage`, `patchMessageBeforeSending`, `customUploadHosts`, `countryCode`.

Happy to trim or extend that list — it is the part most likely to want a maintainer's eye, and an option that starts being read here should lose its entry in the same commit.

## Tests

`src/__tests__/unsupported-config-options.test.ts`:

- names a passed option; lists several in a stable (catalog) order
- silent for a supported-only config, and for an empty one
- ignores a key explicitly set to `undefined` (a spread leftover is not a choice)
- the catalog has no repeats, and agrees with the defaults on every key that has one
- never claims an option the library does read
- the warning names the engine rather than blaming the caller, and survives a logger without `warn`

## Validation

```
node --test src/__tests__/*.test.ts     845 pass, 0 fail
npm run lint                            clean (tsc + oxlint)
npm run format:check                    clean
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns once per socket at construction when config includes upstream `SocketConfig` options this library does not read. Previously, unsupported keys were silently accepted; now `makeWASocket` logs a one-time warning per socket naming only the inert keys, and guards both inspection and logging so diagnostics never break construction.

- Adds `warnUnsupportedConfig()` (`src/Socket/unsupported-config.ts`) and calls it from `makeWASocket` with the raw `config` before defaults; only own, defined props trigger the warning, in stable (catalog) order; warning is per socket.
- Classifies every `SocketConfig` key as read or unread with a type-level assertion for completeness. Catalog now lists 30 inert options (e.g., `cachedGroupMetadata`, `getMessage`, `enableRecentMessageCache`, `connectTimeoutMs`, `qrTimeout`, `printQRInTerminal`, `agent`, `fetchAgent`, `mobile`, caches), see README for the full list.
- Hardens diagnostics: wraps both option inspection and `logger.warn` in a try/catch and uses optional chaining, so missing/throwing loggers and throwing getters/proxies cannot crash socket creation.
- README clarifies `getMessage`/`cachedGroupMetadata` are not overrides and documents the inert list. Tests cover catalog coherence/completeness and warning behavior; supported example now uses `emitOwnEvents`.

- Migration: Remove any warned hooks/flags from your config; no other changes required.

<sup>Written for commit 69294c88cb842b2bca42a9c6288b1ed89a64eaa6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

