### PR TITLE
deps: move to bridge 0.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,14 @@ What to do instead:
   tens of minutes rather than seconds, and have it alert a human instead of
   killing the process. A shorter one fires on a backoff that was about to
   succeed.
+- Know what your own calls do meanwhile. A call issued while the engine is
+  reconnecting no longer fails fast: it parks and goes out when the connection
+  lands, which on the ladder above can be tens of minutes. That is the point,
+  since the alternative was an error indistinguishable from a finished session,
+  but it means a call you issue during `connecting` is a call you are committing
+  to. Racing it against your own deadline bounds your waiting and not the work:
+  the call still goes out when the reconnect lands, so a retry after the
+  deadline sends it twice unless you pinned `messageId`.
 - Fix the cause on your side: send less. The engine restores the connection,
   but it does not pace your traffic, and the traffic is what earned the `429`.
   Queueing, throttling and deferral are yours to decide, the same as upstream.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.16.0",
+        "@oxidezap/whatsapp-rust-bridge": "0.17.0",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.16.0.tgz",
-      "integrity": "sha512-a5k+fN/D/huK+H732li04Bfs1OlD6zpi/wLyzBG8bYPRk7S/q8zhPS0w4oD/aeMASYEfUB3rNy5kQtJIB0tcmg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.17.0.tgz",
+      "integrity": "sha512-TxfCLJhF9uDlG2jdHmQDEham6vpmxOx8awG4DUEeRkL6CMtGvsWLcUPUnttLO3Rg8kGNcyYA+ywI4B0S6Tyxmw==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@oxidezap/whatsapp-rust-bridge": "0.16.0",
+    "@oxidezap/whatsapp-rust-bridge": "0.17.0",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"

--- a/src/__tests__/closed-domain-arguments.test.ts
+++ b/src/__tests__/closed-domain-arguments.test.ts
@@ -366,20 +366,33 @@ const statusCodeOf = (error: unknown): number | undefined =>
 	(error as { output?: { statusCode?: number } })?.output?.statusCode
 
 /** Settle a call, reporting a wait that never ends rather than hanging on it. */
+/**
+ * A domain rejection is synchronous by construction: `assertArgumentDomain`
+ * runs at the top of the method, before the first `await`, so it settles on the
+ * next microtask. Anything still pending after that is, by definition, not one
+ * — which makes "did it reject before yielding" the oracle this file wants.
+ *
+ * Waiting on the call itself is not an option and not needed. Since the engine
+ * holds a call through a reconnect, a valid argument on an offline socket parks
+ * with no bound; a timer would only pick a number, and the sentinel it resolved
+ * with used to satisfy `isDomainRejection(...) === false` on its own, so a
+ * parked call passed the assertion it was supposed to be exercising.
+ */
+const NEVER_REJECTED = Symbol('the call did not reject before yielding')
+
 const settle = async (run: () => Promise<unknown>): Promise<unknown> => {
-	let timer: NodeJS.Timeout | undefined
-	const pending = new Promise(resolve => {
-		timer = setTimeout(() => resolve(new Error('the call never settled')), 10_000)
-	})
-	const outcome = await Promise.race([
-		run().then(
-			() => undefined,
-			(error: unknown) => error
-		),
-		pending
+	const outcome = run().then(
+		() => undefined,
+		(error: unknown) => error
+	)
+	const tick = () => new Promise(resolve => setImmediate(resolve))
+	const raced = await Promise.race([
+		outcome,
+		tick()
+			.then(tick)
+			.then(() => NEVER_REJECTED)
 	])
-	clearTimeout(timer)
-	return outcome
+	return raced === NEVER_REJECTED ? undefined : raced
 }
 
 /** How the message renders a value it received, or one it accepts. */


### PR DESCRIPTION
## Summary

Bridge 0.17.0 carries three things. One changes what a caller experiences, one fixes silent data corruption, and one is an escape hatch this package does not yet surface.

## What landed

**A call that lands during a reconnect now parks instead of failing** ([bridge#76](https://github.com/oxidezap/whatsapp-rust-bridge/pull/76)). The engine reconnects on its own, so there is a window where the client is alive and momentarily unreachable. A call in that window used to come back with the same error a shut-down or logged-out client produces, so a caller could not tell "wait, this comes back" from "this is over". Now it waits and goes out on the other side. 114 of the bridge's calls do this; 19 still fail fast, each for a reason recorded at its own call site: the ones that would deadlock, the ones bound to the connection that just ended, and the ones the engine already re-drives itself.

**A receipt's id count outgrew the byte it was written in** ([bridge#75](https://github.com/oxidezap/whatsapp-rust-bridge/pull/75)). A read receipt aggregates every message it acknowledges, so an active group clears past 255 in one go. The count was a `u8`: past that the encoders disagreed, and since receipt records sit in one flat buffer with no delimiter, the reader walked into the next record and every receipt after it in the batch decoded shifted. Wrong chat, wrong sender, ids belonging to another record. The count is now 16-bit on both sides, and the length is validated before the first byte of the record is written, so a rejected receipt costs only itself.

**Hosts can withdraw parked calls** ([bridge#78](https://github.com/oxidezap/whatsapp-rust-bridge/pull/78)), through a `withdrawParkedCalls()` on the bridge client. This package does not expose it: the bridge client is internal here, and adding non-upstream surface is a decision of its own rather than something to fold into a dependency bump. See **Not carried** below.

## The README

The reconnect section is where a consumer decides what to do during a `connecting` that can last tens of minutes, and it described events only. It now also says what a consumer's own calls do meanwhile, because that is the half that changed:

> A call issued while the engine is reconnecting no longer fails fast: it parks and goes out when the connection lands. Racing it against your own deadline bounds your waiting and not the work: the call still goes out when the reconnect lands, so a retry after the deadline sends it twice unless you pinned `messageId`.

That last clause matters and is worth reading twice. `Promise.race([call, deadline])` is the reflex, and after this bump it duplicates the send. Pinning `messageId` is what makes the retry safe, which is exactly what that option was restored for.

## Not carried

`withdrawParkedCalls()` is unreachable from a socket built here. A consumer whose call parks has no way to abandon it short of the connection ending. Whether this package should expose it, and under what name, is worth deciding on its own: it has no upstream counterpart, and every non-upstream method is one more thing a migrating consumer has to learn it does not need. Flagging it rather than deciding it inside a bump.

## Compatibility

No API change here, no event change, no method renamed. The behavioural change is the parking, and it only affects a call that would have failed anyway.

## Validation

```
npm run format:check
npm run lint          # tsc + oxlint
npm test              # 1354 pass, 14 skip, 0 fail
npm run build
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move to `@oxidezap/whatsapp-rust-bridge` 0.17.0. Calls made during reconnect now park and send after the connection returns (previously failed like a shutdown), and a receipt wire bug that could corrupt batches is fixed.

- Behavior change: a call issued while reconnecting waits and sends after the connection returns. Required action: if you race calls against your own deadlines, pin messageId or you may duplicate sends when the parked call eventually goes out.
- Data integrity: receipt id count is now 16-bit with upfront length validation; only the offending receipt is rejected and the rest of the batch decodes correctly.
- Scope: we do not expose the upstream withdrawParkedCalls(); no API or event changes in this package. README reconnect guidance now documents parked calls and safe retries.
- Tests: the domain-argument suite now asserts synchronous rejections by racing microtasks instead of using 10s timers, avoiding false passes from parked calls and speeding the file up.

<sup>Written for commit ae5b1814e495d901475588244a01cd51b72c1dbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that calls made during reconnection are queued until connectivity returns.
  * Added guidance about deadlines, retries, and potential duplicate messages.

* **Chores**
  * Updated the WhatsApp bridge dependency to version 0.17.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->