### PR TITLE
perf(core): optimize jid normalization, content type detection and the CB attr walk

### DIFF
--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -25,7 +25,7 @@ import type {
 	WhatsAppEvent,
 	WhatsAppEventCallbacks
 } from '@oxidezap/whatsapp-rust-bridge'
-import type { CanonicalEvent, CanonicalMessage, CanonicalReceipt } from '../Bridge/index.ts'
+import type { CanonicalEvent, CanonicalMessage } from '../Bridge/index.ts'
 import { adaptBridgeEvent, adaptBridgeMessageWire } from '../Bridge/index.ts'
 import { decodeHistorySyncWireBatch } from '../Bridge/history-sync-wire.ts'
 import { bridgeGroupMetadataToBaileys } from '../Compatibility/group-metadata.ts'
@@ -34,7 +34,6 @@ import type {
 	BaileysEventMap,
 	BinaryNode,
 	ConnectionState,
-	MessageUserReceiptUpdate,
 	WACallEvent,
 	WACallUpdateType,
 	WAMessage,
@@ -375,48 +374,6 @@ const describeTempBan = (code: number | undefined): string => {
 const emitConnectionUpdate = (ctx: SocketContext, update: Partial<ConnectionState>) =>
 	ctx.ev.emit('connection.update', update as Partial<ConnectionState>)
 
-/**
- * Append one `MessageUserReceiptUpdate` per message id (upstream emits per-id),
- * picking the timestamp slot from the receipt type so consumers branching on
- * `receipt.readTimestamp` / `receipt.playedTimestamp` see the right field
- * populated. Takes the sink so a packed batch can fill one array for the whole
- * batch instead of one array (and one emission) per receipt.
- */
-const collectReceiptUpdates = (evt: CanonicalReceipt, into: MessageUserReceiptUpdate[]) => {
-	const participant = evt.isGroup ? evt.senderJid : undefined
-	const receipt: { receiptTimestamp?: number; readTimestamp?: number; playedTimestamp?: number } = {}
-	if (evt.receiptType === 'read' || evt.receiptType === 'read-self') {
-		receipt.readTimestamp = evt.timestamp
-	} else if (evt.receiptType === 'played' || evt.receiptType === 'played-self') {
-		receipt.playedTimestamp = evt.timestamp
-	} else {
-		receipt.receiptTimestamp = evt.timestamp
-	}
-
-	for (const id of evt.messageIds) {
-		into.push({
-			key: { remoteJid: evt.chatJid, id, fromMe: evt.isFromMe, participant },
-			receipt
-		})
-	}
-
-	return into
-}
-
-/**
- * Release a collected receipt batch on the event channel, under the same
- * containment `dispatchCanonicalEvent` gave the per-receipt emission it
- * replaces: a throwing consumer must not escape back into the bridge. Kept at
- * module scope so a batch does not allocate a closure to flush itself.
- */
-const emitReceiptUpdates = (ctx: SocketContext, updates: MessageUserReceiptUpdate[]) => {
-	try {
-		ctx.ev.emit('message-receipt.update', updates)
-	} catch (err) {
-		ctx.reportUnexpectedError(err, "dispatching a 'receipt' event")
-	}
-}
-
 const DISPATCHERS: DispatcherMap = {
 	// ── Connection lifecycle ──
 	connected: (_, { ctx }) => emitConnectionUpdate(ctx, { connection: 'open' }),
@@ -648,7 +605,26 @@ const DISPATCHERS: DispatcherMap = {
 	},
 
 	receipt: (evt, { ctx }) => {
-		ctx.ev.emit('message-receipt.update', collectReceiptUpdates(evt, []))
+		// Fan out one MessageUserReceiptUpdate per id (upstream emits
+		// per-id) and pick the timestamp slot from the receipt type so
+		// consumers branching on `receipt.readTimestamp` /
+		// `receipt.playedTimestamp` see the right field populated.
+		const participant = evt.isGroup ? evt.senderJid : undefined
+		const receipt: { receiptTimestamp?: number; readTimestamp?: number; playedTimestamp?: number } = {}
+		if (evt.receiptType === 'read' || evt.receiptType === 'read-self') {
+			receipt.readTimestamp = evt.timestamp
+		} else if (evt.receiptType === 'played' || evt.receiptType === 'played-self') {
+			receipt.playedTimestamp = evt.timestamp
+		} else {
+			receipt.receiptTimestamp = evt.timestamp
+		}
+		ctx.ev.emit(
+			'message-receipt.update',
+			evt.messageIds.map(id => ({
+				key: { remoteJid: evt.chatJid, id, fromMe: evt.isFromMe, participant },
+				receipt
+			}))
+		)
 	},
 
 	undecryptableMessage: (evt, { ctx }) => {
@@ -1231,39 +1207,9 @@ export const makeEventHandlers = (ctx: SocketContext, callbacks?: EventCallbacks
 			ctx.reportUnexpectedError(err, 'decoding the receipt wire batch')
 			return
 		}
-		// One emission for the whole batch instead of one per receipt: every
-		// receipt in a packed batch lands on the same channel, so the updates are
-		// collected into a single array and handed to the EventEmitter once. The
-		// per-receipt error containment `dispatchCanonicalEvent` provides is kept:
-		// a receipt that throws while being built drops itself, not the batch.
-		let updates: MessageUserReceiptUpdate[] | undefined
-		for (const data of receipts) {
-			// The decoded payload matches the single-event wire shape; the union's
-			// declared type is narrower than the adapter's tolerance.
-			const canonical = adaptBridgeEvent({ type: 'receipt', data } as unknown as WhatsAppEvent, ctx.logger)
-			if (!canonical) continue
-
-			// The receipt adapter only ever yields a receipt, but the batch must
-			// not silently swallow anything else, and flushing first keeps the
-			// observable ordering of the two channels intact.
-			if (canonical.type !== 'receipt') {
-				if (updates) {
-					emitReceiptUpdates(ctx, updates)
-					updates = undefined
-				}
-
-				dispatchCanonicalEvent(canonical, dispatchCtx)
-				continue
-			}
-
-			try {
-				updates = collectReceiptUpdates(canonical, updates ?? [])
-			} catch (err) {
-				ctx.reportUnexpectedError(err, "dispatching a 'receipt' event")
-			}
-		}
-
-		if (updates) emitReceiptUpdates(ctx, updates)
+		// The decoded payload matches the single-event wire shape; the union's
+		// declared type is narrower than the adapter's tolerance.
+		for (const data of receipts) onEvent({ type: 'receipt', data } as unknown as WhatsAppEvent)
 	}
 
 	const onServerAckBatch = (batch: ServerAckWireBatch) => {

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -75,9 +75,14 @@ const emitCBEvents = (ctx: SocketContext, node: BinaryNode) => {
 
 	// `for..in` over the attrs rather than `Object.entries`: this runs for every
 	// stanza the socket sees and the pair array it built was thrown away
-	// immediately. `attrs` is a plain string map, so there is nothing on the
-	// prototype for the walk to pick up.
+	// immediately. `Object.entries` was own-only by construction though, and
+	// `BinaryNode` is public, so the walk is guarded rather than trusting every
+	// caller to hand over an attrs map with a bare prototype. An inherited
+	// enumerable would otherwise fire CB events for an attr the stanza does not
+	// carry; the check costs nothing next to the emits below.
 	for (const key in l1) {
+		if (!Object.hasOwn(l1, key)) continue
+
 		const val = l1[key]
 		if (l2) ws.emit(`${DEF_CALLBACK_PREFIX}${l0},${key}:${val},${l2}`, node)
 		ws.emit(`${DEF_CALLBACK_PREFIX}${l0},${key}:${val}`, node)

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -25,7 +25,7 @@ import type {
 	WhatsAppEvent,
 	WhatsAppEventCallbacks
 } from '@oxidezap/whatsapp-rust-bridge'
-import type { CanonicalEvent, CanonicalMessage } from '../Bridge/index.ts'
+import type { CanonicalEvent, CanonicalMessage, CanonicalReceipt } from '../Bridge/index.ts'
 import { adaptBridgeEvent, adaptBridgeMessageWire } from '../Bridge/index.ts'
 import { decodeHistorySyncWireBatch } from '../Bridge/history-sync-wire.ts'
 import { bridgeGroupMetadataToBaileys } from '../Compatibility/group-metadata.ts'
@@ -34,6 +34,7 @@ import type {
 	BaileysEventMap,
 	BinaryNode,
 	ConnectionState,
+	MessageUserReceiptUpdate,
 	WACallEvent,
 	WACallUpdateType,
 	WAMessage,
@@ -72,7 +73,12 @@ const emitCBEvents = (ctx: SocketContext, node: BinaryNode) => {
 	const id = l1.id
 	if (id) ws.emit(`${DEF_TAG_PREFIX}${id}`, node)
 
-	for (const [key, val] of Object.entries(l1)) {
+	// `for..in` over the attrs rather than `Object.entries`: this runs for every
+	// stanza the socket sees and the pair array it built was thrown away
+	// immediately. `attrs` is a plain string map, so there is nothing on the
+	// prototype for the walk to pick up.
+	for (const key in l1) {
+		const val = l1[key]
 		if (l2) ws.emit(`${DEF_CALLBACK_PREFIX}${l0},${key}:${val},${l2}`, node)
 		ws.emit(`${DEF_CALLBACK_PREFIX}${l0},${key}:${val}`, node)
 		// Bare-key pattern (no value): upstream `socket.ts:610` emits this
@@ -364,6 +370,48 @@ const describeTempBan = (code: number | undefined): string => {
 const emitConnectionUpdate = (ctx: SocketContext, update: Partial<ConnectionState>) =>
 	ctx.ev.emit('connection.update', update as Partial<ConnectionState>)
 
+/**
+ * Append one `MessageUserReceiptUpdate` per message id (upstream emits per-id),
+ * picking the timestamp slot from the receipt type so consumers branching on
+ * `receipt.readTimestamp` / `receipt.playedTimestamp` see the right field
+ * populated. Takes the sink so a packed batch can fill one array for the whole
+ * batch instead of one array (and one emission) per receipt.
+ */
+const collectReceiptUpdates = (evt: CanonicalReceipt, into: MessageUserReceiptUpdate[]) => {
+	const participant = evt.isGroup ? evt.senderJid : undefined
+	const receipt: { receiptTimestamp?: number; readTimestamp?: number; playedTimestamp?: number } = {}
+	if (evt.receiptType === 'read' || evt.receiptType === 'read-self') {
+		receipt.readTimestamp = evt.timestamp
+	} else if (evt.receiptType === 'played' || evt.receiptType === 'played-self') {
+		receipt.playedTimestamp = evt.timestamp
+	} else {
+		receipt.receiptTimestamp = evt.timestamp
+	}
+
+	for (const id of evt.messageIds) {
+		into.push({
+			key: { remoteJid: evt.chatJid, id, fromMe: evt.isFromMe, participant },
+			receipt
+		})
+	}
+
+	return into
+}
+
+/**
+ * Release a collected receipt batch on the event channel, under the same
+ * containment `dispatchCanonicalEvent` gave the per-receipt emission it
+ * replaces: a throwing consumer must not escape back into the bridge. Kept at
+ * module scope so a batch does not allocate a closure to flush itself.
+ */
+const emitReceiptUpdates = (ctx: SocketContext, updates: MessageUserReceiptUpdate[]) => {
+	try {
+		ctx.ev.emit('message-receipt.update', updates)
+	} catch (err) {
+		ctx.reportUnexpectedError(err, "dispatching a 'receipt' event")
+	}
+}
+
 const DISPATCHERS: DispatcherMap = {
 	// ── Connection lifecycle ──
 	connected: (_, { ctx }) => emitConnectionUpdate(ctx, { connection: 'open' }),
@@ -595,26 +643,7 @@ const DISPATCHERS: DispatcherMap = {
 	},
 
 	receipt: (evt, { ctx }) => {
-		// Fan out one MessageUserReceiptUpdate per id (upstream emits
-		// per-id) and pick the timestamp slot from the receipt type so
-		// consumers branching on `receipt.readTimestamp` /
-		// `receipt.playedTimestamp` see the right field populated.
-		const participant = evt.isGroup ? evt.senderJid : undefined
-		const receipt: { receiptTimestamp?: number; readTimestamp?: number; playedTimestamp?: number } = {}
-		if (evt.receiptType === 'read' || evt.receiptType === 'read-self') {
-			receipt.readTimestamp = evt.timestamp
-		} else if (evt.receiptType === 'played' || evt.receiptType === 'played-self') {
-			receipt.playedTimestamp = evt.timestamp
-		} else {
-			receipt.receiptTimestamp = evt.timestamp
-		}
-		ctx.ev.emit(
-			'message-receipt.update',
-			evt.messageIds.map(id => ({
-				key: { remoteJid: evt.chatJid, id, fromMe: evt.isFromMe, participant },
-				receipt
-			}))
-		)
+		ctx.ev.emit('message-receipt.update', collectReceiptUpdates(evt, []))
 	},
 
 	undecryptableMessage: (evt, { ctx }) => {
@@ -1197,9 +1226,39 @@ export const makeEventHandlers = (ctx: SocketContext, callbacks?: EventCallbacks
 			ctx.reportUnexpectedError(err, 'decoding the receipt wire batch')
 			return
 		}
-		// The decoded payload matches the single-event wire shape; the union's
-		// declared type is narrower than the adapter's tolerance.
-		for (const data of receipts) onEvent({ type: 'receipt', data } as unknown as WhatsAppEvent)
+		// One emission for the whole batch instead of one per receipt: every
+		// receipt in a packed batch lands on the same channel, so the updates are
+		// collected into a single array and handed to the EventEmitter once. The
+		// per-receipt error containment `dispatchCanonicalEvent` provides is kept:
+		// a receipt that throws while being built drops itself, not the batch.
+		let updates: MessageUserReceiptUpdate[] | undefined
+		for (const data of receipts) {
+			// The decoded payload matches the single-event wire shape; the union's
+			// declared type is narrower than the adapter's tolerance.
+			const canonical = adaptBridgeEvent({ type: 'receipt', data } as unknown as WhatsAppEvent, ctx.logger)
+			if (!canonical) continue
+
+			// The receipt adapter only ever yields a receipt, but the batch must
+			// not silently swallow anything else, and flushing first keeps the
+			// observable ordering of the two channels intact.
+			if (canonical.type !== 'receipt') {
+				if (updates) {
+					emitReceiptUpdates(ctx, updates)
+					updates = undefined
+				}
+
+				dispatchCanonicalEvent(canonical, dispatchCtx)
+				continue
+			}
+
+			try {
+				updates = collectReceiptUpdates(canonical, updates ?? [])
+			} catch (err) {
+				ctx.reportUnexpectedError(err, "dispatching a 'receipt' event")
+			}
+		}
+
+		if (updates) emitReceiptUpdates(ctx, updates)
 	}
 
 	const onServerAckBatch = (batch: ServerAckWireBatch) => {

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -748,13 +748,58 @@ export const generateWAMessage = async (jid: string, content: AnyMessageContent,
 	return generateWAMessageFromContent(jid, await generateWAMessageContent(content, contentOptions), options)
 }
 
+/**
+ * The content keys that carry almost every message on a live socket, settled by
+ * identity before the structural predicate runs. Every name here already
+ * satisfies that predicate, so this only shortcuts the substring scan; it never
+ * changes which key wins.
+ */
+const isCommonContentKey = (key: string) => {
+	switch (key) {
+		case 'conversation':
+		case 'extendedTextMessage':
+		case 'imageMessage':
+		case 'videoMessage':
+		case 'audioMessage':
+		case 'stickerMessage':
+		case 'documentMessage':
+		case 'reactionMessage':
+		case 'protocolMessage':
+		case 'pollCreationMessage':
+			return true
+		default:
+			return false
+	}
+}
+
 /** Get the key to access the true type of content */
 export const getContentType = (content: proto.IMessage | undefined) => {
-	if (content) {
-		const keys = Object.keys(content)
-		const key = keys.find(k => (k === 'conversation' || k.includes('Message')) && k !== 'senderKeyDistributionMessage')
-		return key as keyof typeof content
+	if (!content) {
+		return undefined
 	}
+
+	// The answer stays positional (the first own key naming content wins), but
+	// the scan is an indexed loop with an early return instead of `Array.find`,
+	// so no closure is allocated and the common keys never reach `includes`.
+	//
+	// Deliberately still `Object.keys` and not `for..in`: a decoded
+	// `WAProto.Message` inherits a default for every field of the schema, so
+	// `for..in` would enumerate ~100 prototype keys per call (and would have to
+	// filter them back out with `hasOwn` to stay positional) where `Object.keys`
+	// yields only the handful that were actually set.
+	const keys = Object.keys(content)
+	for (let i = 0; i < keys.length; i++) {
+		const key = keys[i]!
+		if (isCommonContentKey(key)) {
+			return key as keyof typeof content
+		}
+
+		if (key.includes('Message') && key !== 'senderKeyDistributionMessage') {
+			return key as keyof typeof content
+		}
+	}
+
+	return undefined
 }
 
 const getFutureProofMessage = (message: WAMessageContent | null | undefined) =>

--- a/src/WABinary/jid-utils.ts
+++ b/src/WABinary/jid-utils.ts
@@ -88,9 +88,59 @@ export const jidDecode = (jid: string | undefined): FullJid | undefined => {
 	}
 }
 
+const CHAR_DEVICE_SEP = 58 // ':'
+const CHAR_AGENT_SEP = 95 // '_'
+
+/**
+ * Index at which the user component ends, given the index of the '@'.
+ *
+ * `jidDecode` derives the user by splitting the pre-`@` half on ':' and then on
+ * '_', so the user always runs to whichever of ':' or '_' comes first, and to
+ * the '@' when neither is there. Locating that boundary answers both callers
+ * below without the intermediate arrays and result object `jidDecode` allocates.
+ */
+const userEndBefore = (jid: string, sepIdx: number): number => {
+	for (let i = 0; i < sepIdx; i++) {
+		const code = jid.charCodeAt(i)
+		if (code === CHAR_DEVICE_SEP || code === CHAR_AGENT_SEP) {
+			return i
+		}
+	}
+
+	return sepIdx
+}
+
+/** As above, or -1 when the JID has no server part: the case `jidDecode` reports as `undefined`. */
+const userEnd = (jid: string): number => {
+	const sepIdx = jid.indexOf('@')
+	return sepIdx < 0 ? -1 : userEndBefore(jid, sepIdx)
+}
+
 /** Compare the user component of two JIDs, matching upstream Baileys. */
-export const areJidsSameUser = (jid1: string | undefined, jid2: string | undefined) =>
-	jidDecode(jid1)?.user === jidDecode(jid2)?.user
+export const areJidsSameUser = (jid1: string | undefined, jid2: string | undefined) => {
+	// Same answer as comparing `jidDecode(...)?.user`, compared in place: this
+	// runs once per participant check on the message pipeline, and decoding both
+	// sides allocated four arrays and two objects only to throw them away.
+	const end = typeof jid1 === 'string' ? userEnd(jid1) : -1
+	if (end !== (typeof jid2 === 'string' ? userEnd(jid2) : -1)) {
+		return false
+	}
+
+	// Neither side decodes, so upstream compares `undefined === undefined`.
+	if (end < 0) {
+		return true
+	}
+
+	const left = jid1 as string
+	const right = jid2 as string
+	for (let i = 0; i < end; i++) {
+		if (left.charCodeAt(i) !== right.charCodeAt(i)) {
+			return false
+		}
+	}
+
+	return true
+}
 
 export const isJidMetaAI = (jid: string | undefined) => jid?.endsWith('@bot')
 export const isPnUser = (jid: string | undefined) => jid?.endsWith('@s.whatsapp.net')
@@ -107,13 +157,29 @@ const botRegexp = /^1313555\d{4}$|^131655500\d{2}$/
 export const isJidBot = (jid: string | undefined) => jid && botRegexp.test(jid.split('@')[0]!) && jid.endsWith('@c.us')
 
 export const jidNormalizedUser = (jid: string | undefined) => {
-	const result = jidDecode(jid)
-	if (!result) {
+	if (typeof jid !== 'string') {
 		return ''
 	}
 
-	const { user, server } = result
-	return jidEncode(user, server === 'c.us' ? 's.whatsapp.net' : (server as JidServer))
+	const sepIdx = jid.indexOf('@')
+	if (sepIdx < 0) {
+		return ''
+	}
+
+	// Everything between the user and the '@' is exactly what normalization
+	// drops, so the boundary is all this needs. `jidDecode` would split the same
+	// half twice and box the pieces in an object only for them to be re-joined.
+	const end = userEndBefore(jid, sepIdx)
+
+	// Fast path for the shape that dominates the pipeline: nothing to strip and a
+	// server `jidEncode` re-emits verbatim, so the JID already is its own normal
+	// form and no new string has to be built at all.
+	if (end === sepIdx && !jid.endsWith('@c.us')) {
+		return jid
+	}
+
+	const server = jid.slice(sepIdx + 1)
+	return jidEncode(jid.slice(0, end), server === 'c.us' ? 's.whatsapp.net' : (server as JidServer))
 }
 
 export const transferDevice = (fromJid: string, toJid: string): string => {

--- a/src/__tests__/content-type-resolution.test.ts
+++ b/src/__tests__/content-type-resolution.test.ts
@@ -100,6 +100,17 @@ describe('getContentType — nothing to report', () => {
 	it('returns undefined when only senderKeyDistributionMessage is present', () => {
 		expect(getContentType(asContent({ senderKeyDistributionMessage: {}, messageContextInfo: {} }))).toBeUndefined()
 	})
+
+	// A decoded message inherits a default for every field of the schema, so a
+	// lookup that walked the prototype chain would report one of those instead of
+	// nothing. Only the fields actually set on the instance count.
+	it('ignores the schema defaults a decoded message inherits', () => {
+		const decoded = WAProto.Message.decode(
+			WAProto.Message.encode({ messageContextInfo: {} }).finish()
+		) as WAMessageContent
+		expect(Object.keys(decoded)).toEqual(['messageContextInfo'])
+		expect(getContentType(decoded)).toBeUndefined()
+	})
 })
 
 /**

--- a/src/__tests__/public-helpers-compatibility.test.ts
+++ b/src/__tests__/public-helpers-compatibility.test.ts
@@ -89,10 +89,12 @@ import {
 	S_WHATSAPP_NET,
 	WAJIDDomains,
 	getServerFromDomainType,
+	areJidsSameUser,
 	isJidBot,
 	isJidBroadcast,
 	isJidMetaAI,
 	isPnUser,
+	jidNormalizedUser,
 	transferDevice
 } from '../WABinary/jid-utils.ts'
 
@@ -414,6 +416,50 @@ describe('WABinary public helpers', () => {
 		assert.equal(isPnUser('123@c.us'), false)
 		assert.equal(isJidBot('13135551234@c.us'), true)
 		assert.equal(transferDevice('123:7@s.whatsapp.net', '456@s.whatsapp.net'), '456:7@s.whatsapp.net')
+	})
+
+	// Both helpers answer without decoding the JID, so the answers upstream gives
+	// for the awkward shapes are pinned here rather than left to the fuzz suite:
+	// device and agent suffixes, a missing server part on one or both sides, an
+	// empty user, and a JID carrying more than one '@'.
+	it('compares the user component the way a decode would', () => {
+		assert.equal(areJidsSameUser('5511999990000@s.whatsapp.net', '5511999990000@s.whatsapp.net'), true)
+		assert.equal(areJidsSameUser('5511999990000:12@s.whatsapp.net', '5511999990000@s.whatsapp.net'), true)
+		assert.equal(areJidsSameUser('5511999990000_1@s.whatsapp.net', '5511999990000@lid'), true)
+		assert.equal(areJidsSameUser('5511999990000_1:12@s.whatsapp.net', '5511999990000@c.us'), true)
+		assert.equal(areJidsSameUser('a@b@s.whatsapp.net', 'a@s.whatsapp.net'), true)
+		assert.equal(areJidsSameUser('@s.whatsapp.net', '@lid'), true)
+		assert.equal(areJidsSameUser('5511999990000@s.whatsapp.net', '5511999990001@s.whatsapp.net'), false)
+		assert.equal(areJidsSameUser('5511@s.whatsapp.net', '55110@s.whatsapp.net'), false)
+		// Two JIDs that both fail to decode compare their undefined users equal,
+		// while one that decodes never matches one that does not.
+		assert.equal(areJidsSameUser(undefined, undefined), true)
+		assert.equal(areJidsSameUser('nope', undefined), true)
+		assert.equal(areJidsSameUser('5511:1', '5511'), true)
+		assert.equal(areJidsSameUser(undefined, '5511@s.whatsapp.net'), false)
+		assert.equal(areJidsSameUser('', '@lid'), false)
+	})
+
+	it('normalizes the user JID without changing what a decode would produce', () => {
+		assert.equal(jidNormalizedUser('5511999990000@s.whatsapp.net'), '5511999990000@s.whatsapp.net')
+		assert.equal(jidNormalizedUser('5511999990000:12@s.whatsapp.net'), '5511999990000@s.whatsapp.net')
+		assert.equal(jidNormalizedUser('5511999990000_1:12@s.whatsapp.net'), '5511999990000@s.whatsapp.net')
+		assert.equal(jidNormalizedUser('5511999990000@c.us'), '5511999990000@s.whatsapp.net')
+		assert.equal(jidNormalizedUser('5511999990000:3@c.us'), '5511999990000@s.whatsapp.net')
+		assert.equal(jidNormalizedUser('123:4@lid'), '123@lid')
+		// Servers other than c.us are kept verbatim, including the ones the fast
+		// path does not name.
+		assert.equal(jidNormalizedUser('120363:2@g.us'), '120363@g.us')
+		assert.equal(jidNormalizedUser('status@broadcast'), 'status@broadcast')
+		assert.equal(jidNormalizedUser('123@hosted.lid'), '123@hosted.lid')
+		assert.equal(jidNormalizedUser('a@b@c.us'), 'a@b@c.us')
+		assert.equal(jidNormalizedUser('@c.us'), '@s.whatsapp.net')
+		assert.equal(jidNormalizedUser(':2@lid'), '@lid')
+		assert.equal(jidNormalizedUser('5511@'), '5511@')
+		// Anything without a server part has no user to normalize.
+		assert.equal(jidNormalizedUser(undefined), '')
+		assert.equal(jidNormalizedUser(''), '')
+		assert.equal(jidNormalizedUser('nope:1'), '')
 	})
 
 	it('reads child content and reduces stanza dictionaries', () => {

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -661,7 +661,7 @@ describe('dispatch: receipt fan-out', () => {
 		expect(updates.map(u => u.key.id)).toEqual(['A', 'B', 'C'])
 	})
 
-	it('coalesces a packed receipt batch into one emission carrying every update', () => {
+	it('dispatches a packed receipt batch identically to single events', () => {
 		const { ctx, ev } = makeCtx()
 		const updates: BaileysEventMap['message-receipt.update'][] = []
 		ev.on('message-receipt.update', payload => updates.push(payload))
@@ -685,18 +685,39 @@ describe('dispatch: receipt fan-out', () => {
 			])
 		)
 
-		// One EventEmitter round trip for the batch, not one per receipt, with
-		// the per-receipt fan-out and timestamp slots preserved in wire order.
-		expect(updates.length).toBe(1)
-		expect(updates[0]?.map(u => u.key.id)).toEqual(['A', 'B', 'C'])
-		expect(updates[0]?.map(u => u.key.remoteJid)).toEqual([
-			'5511@s.whatsapp.net',
-			'5511@s.whatsapp.net',
-			'5522@s.whatsapp.net'
-		])
+		expect(updates.length).toBe(2)
+		expect(updates[0]?.map(u => u.key.id)).toEqual(['A', 'B'])
 		expect(updates[0]?.[0]?.receipt.readTimestamp).toBe(1730000000)
-		expect(updates[0]?.[1]?.receipt.readTimestamp).toBe(1730000000)
-		expect(updates[0]?.[2]?.receipt.playedTimestamp).toBe(1730000001)
+		expect(updates[1]?.[0]?.receipt.playedTimestamp).toBe(1730000001)
+	})
+
+	// A packed batch stays one emission per receipt on purpose. Merging it into a
+	// single emission would be fewer EventEmitter round trips, but `emit` stops
+	// at the first listener that throws, so one bad consumer handler would take
+	// the whole batch down with it instead of just the receipt it choked on.
+	it('keeps a throwing listener from discarding the rest of a packed batch', () => {
+		const { ctx, ev } = makeCtx()
+		ev.on('message-receipt.update', (payload: BaileysEventMap['message-receipt.update']) => {
+			if (payload.some(update => update.key.id === 'B')) throw new Error('consumer listener threw')
+		})
+		const seen: string[] = []
+		ev.on('message-receipt.update', (payload: BaileysEventMap['message-receipt.update']) => {
+			for (const update of payload) seen.push(String(update.key.id))
+		})
+
+		makeEventHandlers(ctx).onReceiptBatch?.(
+			encodeReceiptWireBatch(
+				['A', 'B', 'C'].map((id, index) => ({
+					source: { chat: jid(`551${index}`), sender: jid(`551${index}`), is_group: false, is_from_me: false },
+					message_ids: [id],
+					timestamp: 1730000000 + index,
+					type: 'Read',
+					offline: false
+				}))
+			)
+		)
+
+		expect(seen).toEqual(['A', 'C'])
 	})
 
 	it('routes type=read into receipt.readTimestamp', () => {

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -1711,6 +1711,27 @@ describe('dispatch: emitCBEvents emits all upstream patterns', () => {
 		expect(fired).toContain('CB:iq,,pair-success')
 	})
 
+	// The attrs walk is `for..in`, which sees the prototype chain where the
+	// `Object.entries` it replaced did not. An attrs map that inherits an
+	// enumerable must not fire CB events for an attr the stanza never carried.
+	it('fires nothing for attrs inherited from the prototype chain', () => {
+		const { ctx, ws } = makeCtx()
+		const fired: string[] = []
+		const original = ws.emit.bind(ws)
+		ws.emit = (event, ...args) => {
+			if (typeof event === 'string') fired.push(event)
+			return original(event, ...args)
+		}
+		const attrs: BinaryNode['attrs'] = Object.create({ inherited: 'ghost' })
+		attrs.type = 'set'
+		makeEventHandler(ctx)({
+			type: 'raw_node',
+			data: { tag: 'iq', attrs, content: [] }
+		} as never)
+		expect(fired).toContain('CB:iq,type:set')
+		expect(fired.some(event => event.includes('inherited'))).toBe(false)
+	})
+
 	it('uses the raw node as the single lossless CB source for server ACKs', () => {
 		const { ctx, ev, ws } = makeCtx()
 		const rawAcks: BinaryNode[] = []

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -661,7 +661,7 @@ describe('dispatch: receipt fan-out', () => {
 		expect(updates.map(u => u.key.id)).toEqual(['A', 'B', 'C'])
 	})
 
-	it('dispatches a packed receipt batch identically to single events', () => {
+	it('coalesces a packed receipt batch into one emission carrying every update', () => {
 		const { ctx, ev } = makeCtx()
 		const updates: BaileysEventMap['message-receipt.update'][] = []
 		ev.on('message-receipt.update', payload => updates.push(payload))
@@ -685,10 +685,18 @@ describe('dispatch: receipt fan-out', () => {
 			])
 		)
 
-		expect(updates.length).toBe(2)
-		expect(updates[0]?.map(u => u.key.id)).toEqual(['A', 'B'])
+		// One EventEmitter round trip for the batch, not one per receipt, with
+		// the per-receipt fan-out and timestamp slots preserved in wire order.
+		expect(updates.length).toBe(1)
+		expect(updates[0]?.map(u => u.key.id)).toEqual(['A', 'B', 'C'])
+		expect(updates[0]?.map(u => u.key.remoteJid)).toEqual([
+			'5511@s.whatsapp.net',
+			'5511@s.whatsapp.net',
+			'5522@s.whatsapp.net'
+		])
 		expect(updates[0]?.[0]?.receipt.readTimestamp).toBe(1730000000)
-		expect(updates[1]?.[0]?.receipt.playedTimestamp).toBe(1730000001)
+		expect(updates[0]?.[1]?.receipt.readTimestamp).toBe(1730000000)
+		expect(updates[0]?.[2]?.receipt.playedTimestamp).toBe(1730000001)
 	})
 
 	it('routes type=read into receipt.readTimestamp', () => {


### PR DESCRIPTION
## Summary

Three hot paths on the message pipeline were allocating for work they never needed the allocations for. This removes the allocations and, where the shape allows it, the work.

- `areJidsSameUser` runs **3.0x-3.8x** faster and allocates **nothing** (was 44-84 B per call).
- `jidNormalizedUser` runs **3.4x-4.3x** faster; an already-normalized JID now allocates **nothing** at all (was 292 B), and the suffix-stripping path drops from 322 B to 21 B.
- `getContentType` runs **1.28x** faster and allocates **6 B** instead of 58 B per call.
- `emitCBEvents` drops the `Object.entries` pair array it built and discarded for every stanza the socket sees.

No public API changed and no observable behaviour changed. Every helper touched is covered by the differential fuzz suite against upstream Baileys, and the awkward edge cases are now pinned as unit tests too.

A fourth change, coalescing packed receipt batches into one `message-receipt.update` emission, was implemented, measured, and then **reverted**. See *Receipt batching, and why it is not here* below.

## Changes

### `src/WABinary/jid-utils.ts`

`areJidsSameUser` and `jidNormalizedUser` both ran the full `jidDecode`, which slices the JID in two, splits the user half on `':'` and again on `'_'`, and boxes the pieces in a result object. Neither caller wanted the decoded parts, only the index the user component ends at: the first `':'` device suffix, `'_'` agent suffix, or the `'@'`.

- New `userEndBefore` finds that boundary with a bounded `charCodeAt` scan.
- `areJidsSameUser` compares the two user components in place. Zero arrays, zero objects.
- `jidNormalizedUser` no longer calls `jidDecode`/`jidEncode` at all. It slices at most once, and gains a fast path: a JID with no suffix to strip whose server is anything but `c.us` re-encodes to itself, so it is returned as-is with no new string built. That is the shape the pipeline mostly sees.

`String.prototype.split` with a one-character separator was the dominant cost here, at roughly 180 ns per call in this workload, and `jidDecode` made two of them per JID.

Behaviour is preserved down to the awkward corners, all verified against upstream `baileys@7.0.0-rc13` before and after: two JIDs that both fail to decode still compare equal (upstream compares two `undefined` users), a JID carrying more than one `'@'` keeps its extra one, an empty user still normalizes to a bare `@server`, and a separator with no server part after it still means "no user at all".

### `src/Utils/messages.ts`

`getContentType` built an `Object.keys` array and walked it with `Array.find`, allocating both the key array and the predicate closure on every inspected message, then ran a substring scan over every key it looked at.

- The scan is now an indexed loop with an early return, so the closure is gone.
- A `switch` settles the ten content keys that carry almost every message on a live socket before the substring scan is reached. Every one of those names already satisfies the upstream predicate, so this only shortcuts *how* the answer is reached, never *which* key wins.

The result stays positional (the first own key naming content), which `content-type-resolution.test.ts` pins in both directions and the fuzz suite compares against upstream.

One deliberate deviation from the original plan: the fallback stays `Object.keys` rather than `for..in`. A decoded `WAProto.Message` inherits a default for *every* field of the schema, so `for..in` enumerates ~100 prototype keys per call and would need a `hasOwn` filter to stay positional. Measured on decoded messages that is **746 ns/op versus 50 ns/op** for the code it would have replaced, a 15x regression on the exact input that dominates the real path. `Object.keys` yields only the handful of fields actually set, so its one small allocation is by far the cheaper of the two. A test pins that the inherited defaults stay invisible.

### `src/Socket/events.ts`

`emitCBEvents` drops the `Object.entries` pair array for a direct `for..in` over the attrs. Same walk, without the array it threw away for every stanza the socket sees.

The walk is guarded with `Object.hasOwn`. `Object.entries` was own-only by construction and `BinaryNode` is a public type, so an attrs map reaching the dispatcher with an enumerable on its prototype chain would otherwise fire `CB:tag,key:value` and `CB:tag,key` for an attr the stanza never carried. Attrs hold a handful of keys and the loop body emits two or three events per key, so the guard costs nothing measurable against what it protects. Pinned with a test that builds an attrs map via `Object.create({ inherited: 'ghost' })` and asserts no CB event mentions it.

## Receipt batching, and why it is not here

Coalescing a packed receipt batch into a single `message-receipt.update` emission was built and measured: 16x fewer EventEmitter round trips for a 16-receipt batch, 64x for a 64-receipt one, worth 3-10% of the batch handler's wall clock and 4-9% of its garbage.

It was reverted, because it traded a correctness property for that throughput.

`EventEmitter.emit` stops at the first listener that throws. With one emission per receipt, a consumer handler that blows up costs exactly the receipt it choked on and the loop carries on. Merged into one emission it costs the entire batch. Measured directly, on a three-receipt batch whose listener throws on the second:

| | second listener receives |
|---|---|
| one emission per receipt | `["A", "C"]` |
| one emission per batch | `[]` |

The exception stays contained either way and never escapes into the bridge, so this is not a crash. It is silent loss: receipts drive read and delivery state, and dropping up to sixty-four of them because one handler threw is a worse outcome than the few percent the merge bought on a handler already dominated by `decodeReceiptWireBatch` crossing into WASM.

Per-receipt isolation and a single emission are mutually exclusive, so the isolation stays. Per-listener isolation (the pattern `event-buffer.ts` already uses for `connection.update`) would not have rescued it either: one listener throwing part-way through a merged array still loses the remainder of the batch.

The property is now pinned by a test, so the emission count reads as a deliberate contract rather than an implementation detail left to tune later. Credit to the Codex review on this PR for catching it.

## Benchmarks &amp; Cost

Synthetic benchmark, Node v22.22.2, median of 5 passes of 5M iterations. Allocation is measured in a separate short GC-free window so `heapUsed` is a faithful counter. The benchmark script was temporary and is not part of this diff.

| Benchmark | Baseline | Patch | Speedup | Bytes/op |
|---|---|---|---|---|
| `areJidsSameUser` (normalized JIDs) | 683.6 ns/op &mdash; 1.46 M ops/s | 225.5 ns/op &mdash; 4.43 M ops/s | **3.03x** | 44 &rarr; **0** |
| `areJidsSameUser` (device/agent suffixes) | 809.5 ns/op &mdash; 1.24 M ops/s | 213.8 ns/op &mdash; 4.68 M ops/s | **3.79x** | 84 &rarr; **0** |
| `jidNormalizedUser` (normalized JIDs) | 356.4 ns/op &mdash; 2.81 M ops/s | 82.3 ns/op &mdash; 12.16 M ops/s | **4.33x** | 292 &rarr; **0** |
| `jidNormalizedUser` (device/agent suffixes) | 439.3 ns/op &mdash; 2.28 M ops/s | 122.2 ns/op &mdash; 8.18 M ops/s | **3.59x** | 322 &rarr; 21 (-93%) |
| `getContentType` (12 mixed contents) | 60.6 ns/op &mdash; 16.50 M ops/s | 47.5 ns/op &mdash; 21.03 M ops/s | **1.28x** | 58 &rarr; 6 (-90%) |

### Where the JID cost went

Isolating the pieces of `jidDecode` on the same machine: the two `String.prototype.split` calls cost **367 ns/op** between them, while the result object allocation costs 7 ns and the enum lookup 5 ns. Removing the splits is essentially the whole win.

## Validation

Run on this branch, all green:

- `npm run lint` (`tsc` + `oxlint`) &mdash; clean
- `npm run format:check` &mdash; clean
- `npm test` &mdash; **1372 passing**, 1 skipped, 0 failing (1367 before; 5 tests added)
- `npm run build` &mdash; clean
- `npm run compat:check-waproto` &mdash; clean
- `npm run compat:audit:proto --strict` &mdash; exit 0, findings unchanged from `main`
- `npm run compat:audit:wire --strict` &mdash; exit 0, 311 cases, 1970 preserved, 0 dropped, 0 altered; the 2 `pollResultSnapshotMessageV3` divergences are pre-existing and unrelated
- Differential fuzz vs upstream `baileys@7.0.0-rc13` (`pure-differential.fuzz.test.ts`, `bridge-events.fuzz.test.ts`) &mdash; 100 passing. `jidDecode`, `jidNormalizedUser`, `areJidsSameUser` and `getContentType` are all fuzz targets there.
- 45 hand-picked JID edge cases diffed directly against upstream before and after: all match.

### Tests added

- `public-helpers-compatibility.test.ts` &mdash; two cases pinning `areJidsSameUser` and `jidNormalizedUser` across device suffixes, agent suffixes, missing server parts on one or both sides, empty users, and multi-`@` JIDs.
- `content-type-resolution.test.ts` &mdash; pins that the schema defaults a decoded `WAProto.Message` inherits stay invisible to `getContentType`.
- `regressions.test.ts` &mdash; pins that an attrs map inheriting an enumerable fires no CB events for it, and that a throwing `message-receipt.update` listener does not discard the rest of a packed batch.

Both new negative tests were verified to fail against the implementation they guard against, not just to pass against the current one.

### Note on the branch name

Pushed to `claude/perf-jid-contenttype-receipts-r7ghbg` rather than `perf/jid-normalization-content-type-and-receipt-coalescing`: this session is pinned to that branch and cannot push elsewhere. Happy to have it renamed on merge.
