### PR TITLE
deps: move to bridge 0.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,15 +374,19 @@ baileyrs auto-wraps, including `useLegacyMultiFileAuthState`. It does not apply
 to `useMultiFileAuthState`, whose `keys` is a projection over the engine's own
 store; the `bridge-` namespaces never surface through it.
 
-The move back down is not symmetric either. From 0.2.8 on, a
-`bridge-native-session` records a skipped-message key as its seed alone, where
-an earlier release wrote the derived triple beside it. Forward is fine: a record
-written before this carries both, and the newer engine still prefers the triple
-when it finds one. Backward is not — an older engine rejects a key that carries
-no triple, so after a downgrade a late message claiming one of those buffered
-keys fails to decrypt. The session still loads and everything else in it still
-works; what is lost is that one message. Nothing else in the store changes
-shape.
+The move back down is not symmetric either. From 0.2.8 on, the core buffers a
+skipped-message key as its seed alone, where an earlier release wrote the
+derived cipher/mac/iv triple beside it. Forward is fine — a record written
+before this carries both, and the newer engine reads it unchanged. Backward is
+not: an older engine cannot parse a record whose skipped keys carry no triple,
+and it fails on **the whole record**, not on the one key.
+
+Where that bites depends on which bytes you kept. A store this package wraps
+holds the Baileys projection, and v1 has only ever held seeds, so it downgrades
+cleanly. A `bridge-native-session` row holds the core's own bytes, and that is
+the one an older engine cannot read back. A session with no skipped keys
+buffered at the time is unaffected in either direction — the difference only
+exists while a chain is holding keys for messages that arrived out of order.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -374,6 +374,16 @@ baileyrs auto-wraps, including `useLegacyMultiFileAuthState`. It does not apply
 to `useMultiFileAuthState`, whose `keys` is a projection over the engine's own
 store; the `bridge-` namespaces never surface through it.
 
+The move back down is not symmetric either. From 0.2.8 on, a
+`bridge-native-session` records a skipped-message key as its seed alone, where
+an earlier release wrote the derived triple beside it. Forward is fine: a record
+written before this carries both, and the newer engine still prefers the triple
+when it finds one. Backward is not — an older engine rejects a key that carries
+no triple, so after a downgrade a late message claiming one of those buffered
+keys fails to decrypt. The session still loads and everything else in it still
+works; what is lost is that one message. Nothing else in the store changes
+shape.
+
 ## Disclaimer
 
 This project is not affiliated with, endorsed by, or in any way officially connected to

--- a/README.md
+++ b/README.md
@@ -381,12 +381,21 @@ before this carries both, and the newer engine reads it unchanged. Backward is
 not: an older engine cannot parse a record whose skipped keys carry no triple,
 and it fails on **the whole record**, not on the one key.
 
-Where that bites depends on which bytes you kept. A store this package wraps
-holds the Baileys projection, and v1 has only ever held seeds, so it downgrades
-cleanly. A `bridge-native-session` row holds the core's own bytes, and that is
-the one an older engine cannot read back. A session with no skipped keys
-buffered at the time is unaffected in either direction — the difference only
-exists while a chain is holding keys for messages that arrived out of order.
+Where that bites depends on which bytes the engine is handed, and a wrapped
+store is not automatically on the safe side of it. It holds the Baileys
+projection, which has only ever held seeds — but it also mirrors the core's
+exact bytes under `bridge-native-session`, and a read prefers that mirror for as
+long as its fingerprint still matches the projection. A downgrade can therefore
+be handed the newer record with a perfectly readable projection sitting right
+beside it.
+
+Dropping a mirror row makes the next read rebuild it from the projection, which
+is the format both versions agree on — but only for a session that has one. A
+session that turned native-only lives in that row alone, so dropping *that* one
+loses the session outright, which is the case the warning above is about. A
+session with no skipped keys buffered at the time is unaffected either way: the
+difference only exists while a chain is holding keys for messages that arrived
+out of order.
 
 ## Disclaimer
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.17.0",
+        "@oxidezap/whatsapp-rust-bridge": "0.18.0",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.17.0.tgz",
-      "integrity": "sha512-TxfCLJhF9uDlG2jdHmQDEham6vpmxOx8awG4DUEeRkL6CMtGvsWLcUPUnttLO3Rg8kGNcyYA+ywI4B0S6Tyxmw==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.18.0.tgz",
+      "integrity": "sha512-N0F9mvPrFxPluV/ruUbQmm75nRjX4Il+BMi93C4tw5BCvvgSoeKmsHpAvxu3QNKscUbw8yVLvnbmLVYay9SATg==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@oxidezap/whatsapp-rust-bridge": "0.17.0",
+    "@oxidezap/whatsapp-rust-bridge": "0.18.0",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"

--- a/src/Utils/__tests__/wrap-legacy-store-coverage.test.ts
+++ b/src/Utils/__tests__/wrap-legacy-store-coverage.test.ts
@@ -377,10 +377,16 @@ describe('wrap-legacy-store: core-owned skipped-message derivation', () => {
 		// and the triple is three fields the record no longer has to carry. The
 		// WAProto-visible half of the entry is therefore just the index — the
 		// seed lives in the local field below, which is the only copy there is.
-		for (const messageKey of mks) {
-			expect(messageKey.cipherKey ?? null).toBe(null)
-			expect(messageKey.macKey ?? null).toBe(null)
-			expect(messageKey.iv ?? null).toBe(null)
+		//
+		// Asked as "did the record frame this field", which is the claim, rather
+		// than as a nullish read: the decoder sets a field it saw as an own
+		// property, so absence is what distinguishes a seed-only entry, and a
+		// reader that later gave an unset `bytes` field an empty-buffer default
+		// would not quietly turn this into a check that passes on anything.
+		for (const field of ['cipherKey', 'macKey', 'iv'] as const) {
+			for (const messageKey of mks) {
+				expect(Object.hasOwn(messageKey, field)).toBe(false)
+			}
 		}
 
 		// So what a caller actually has to be able to rely on is that the seed

--- a/src/Utils/__tests__/wrap-legacy-store-coverage.test.ts
+++ b/src/Utils/__tests__/wrap-legacy-store-coverage.test.ts
@@ -4,7 +4,7 @@
  *   2. PreKey cross-impl (proto bytes ↔ {public, private}).
  *   3. Identity cross-impl (32 bytes ↔ 33 bytes with 0x05 prefix + key rewrite).
  *   4. Idempotent round-trip (write→read→write produces identical disk bytes).
- *   5. Skipped-message seeds delegated to the core's canonical derivation.
+ *   5. Skipped-message seeds delegated to the core, and preserved as seeds.
  */
 
 import { Buffer } from 'node:buffer'
@@ -318,7 +318,7 @@ describe('wrap-legacy-store: identity edge cases', () => {
 // ── 8. Core-owned skipped-message derivation ───────────────────────────
 
 describe('wrap-legacy-store: core-owned skipped-message derivation', () => {
-	test('upstream messageKeys cache → bridge proto carries derived cipher/mac/iv', async () => {
+	test('upstream messageKeys cache → bridge proto carries the seed, not a derivation', async () => {
 		const { wrapped, keys } = await makeWrapped()
 		const baseKey = Buffer.from(fill(33, 0xa0))
 		const senderRatchet = Buffer.from(fill(33, 0xb0))
@@ -370,27 +370,37 @@ describe('wrap-legacy-store: core-owned skipped-message derivation', () => {
 		const decoded = bridgeProto.RecordStructure.decode(protoOut)
 		const recv = decoded.currentSession?.receiverChains?.[0]
 		const mks = recv!.messageKeys ?? []
-		expect(mks.length).toBe(2)
+		expect(mks.map(messageKey => messageKey.index)).toEqual([3, 5])
 
-		// Fixed vectors keep the test independent without duplicating the
-		// derivation algorithm in this package.
-		const expected = {
-			3: {
-				cipher: '0486a5424aa9f1827b06f6e0a9b4e89556812974395d7b4ada46163a74d66cc3',
-				mac: '21b9410a1c534cd9a8915ac18b40e522605360fc089eeeadaa8d50db605092e9',
-				iv: 'effbd4ca570762d5a015327999ff77a2'
-			},
-			5: {
-				cipher: '67cc072ba07fff4a99523e38324d5e1b97bdb5bd8c8cc7bfb627d44ab83c7179',
-				mac: 'c19028710da3ea81abd6ecd1ec0cf6fbf3c80e0c5ab0654d1bee7307a5b00b81',
-				iv: 'd0d01c002af2b5db9e7d549293d0623a'
-			}
-		} as const
-		const byIndex = Object.fromEntries(mks.map(m => [m.index, m]))
-		for (const index of [3, 5] as const) {
-			expect(Buffer.from(byIndex[index]!.cipherKey!).toString('hex')).toBe(expected[index].cipher)
-			expect(Buffer.from(byIndex[index]!.macKey!).toString('hex')).toBe(expected[index].mac)
-			expect(Buffer.from(byIndex[index]!.iv!).toString('hex')).toBe(expected[index].iv)
+		// The core buffers a skipped key as its seed alone: expanding it costs a
+		// derivation per skipped counter on a jump that may claim none of them,
+		// and the triple is three fields the record no longer has to carry. The
+		// WAProto-visible half of the entry is therefore just the index — the
+		// seed lives in the local field below, which is the only copy there is.
+		for (const messageKey of mks) {
+			expect(messageKey.cipherKey ?? null).toBe(null)
+			expect(messageKey.macKey ?? null).toBe(null)
+			expect(messageKey.iv ?? null).toBe(null)
 		}
+
+		// So what a caller actually has to be able to rely on is that the seed
+		// survives, and it is not in the schema this decoder knows. Reading the
+		// record back through the adapter is what proves it did: a dropped seed
+		// comes back as a chain that skipped nothing.
+		await wrapped.set('session', BRIDGE_SESSION_KEY_LID, protoOut)
+		const roundTripped = keys.raw['session']?.[UPSTREAM_SESSION_KEY_LID] as {
+			_sessions: Record<string, LegacySessionShape>
+		}
+		const chains = Object.values(roundTripped._sessions)[0]!._chains
+		const receiving = chains[peerRatchet.toString('base64')]!
+		expect(receiving.messageKeys).toEqual({
+			'3': skipSeed3.toString('base64'),
+			'5': skipSeed5.toString('base64')
+		})
 	})
 })
+
+/** Only the shape this file reads back out of the legacy record. */
+interface LegacySessionShape {
+	_chains: Record<string, { messageKeys: Record<string, string> }>
+}


### PR DESCRIPTION
## Summary

Bridge 0.18.0 is mostly a spec bundle and three perf rounds, none of which this package has to react to. One thing in it does reach a record a host persists, and that is what the diff here is about.

## What landed

**The WA Web spec bundle moves to `2.3000.1045368834`** ([bridge#84](https://github.com/oxidezap/whatsapp-rust-bridge/pull/84)). That is the version stamp announced on connect, an A/B registry that grows by 105 flags, and a proto catalog that gains `ExtendedContentMessage`, `SyncActionValue.ctwaMessageReceivedAction`, two `DeviceCapabilities` fields and a large Minos/mailbox-crypto block. Nothing is removed: `comm -23` over the declarations in `proto-types.d.ts` between 0.17.0 and 0.18.0 is empty, and the client surface (`whatsapp_rust_bridge.d.ts`, `index.d.ts`, `wire-info.d.ts`, `proto-reader.d.ts`) diffs to one added doc comment and the renumbered `__wasm_bindgen_func_elem_*` internals.

The upstream break is `RotateEpochInput` / `RotateEpochOutput` being renumbered and retyped. It does not reach here: this package's WAProto facade is generated from `baileys`, not from the bridge's catalog, and `RotateEpoch` appears nowhere in `src/WAProto`. Both audits confirm it — `compat:audit:proto` and `compat:audit:wire` produce byte-identical output on 0.17.0 and 0.18.0, down to the same gap list and the same two `pollResultSnapshotMessageV3` divergences.

**Three perf rounds** ([bridge#82](https://github.com/oxidezap/whatsapp-rust-bridge/pull/82) and the core's own) — borrowed store batches, no zero-fill on `to_vec`, one decode per inline string region instead of one per value (-49% on 32-message batches), cheaper DM/group ratchet catch-up, single-buffer app-state encode. All of it is below the bridge's own surface and none of it changes what crosses.

## The one change that reaches a record

**A skipped-message key is now buffered as its seed alone.** Verified by decoding what the adapter actually produces for the same fixture on both versions:

| | 0.17.0 | 0.18.0 |
| --- | --- | --- |
| `MessageKey.index` | present | present |
| `cipherKey` / `macKey` / `iv` | present | **absent** |
| the core's local seed field | present | present |
| record size, this fixture | 1223 B | 923 B |

The derived triple was always a second copy: the seed was in the record next to it either way. So the entry the WAProto schema can see is now just the index, and the seed — which is the only copy there is — lives in the local field the core owns.

**The legacy adapter is unaffected in both directions.** `messageKeysFromLegacy` hands the core a v1 seed and `messageKeysToLegacy` reads a seed back; neither ever looked at the triple. Round-tripping the fixture through `wrapped.get` → `wrapped.set` returns `{"3": <seed3>, "5": <seed5>}` byte-identically on both versions.

## The test

`wrap-legacy-store: core-owned skipped-message derivation` asserted the derived triple against fixed hex vectors, so it fails on this bump — correctly, that is the thing that changed. It now asserts what the record actually guarantees:

- the WAProto-visible entries are the indices `[3, 5]` and carry no `cipherKey` / `macKey` / `iv`, which pins the new shape;
- the seeds survive, proved by reading the record back through the adapter rather than by naming a field the decoder does not know about. A dropped seed comes back as a chain that skipped nothing.

Checked against the mutation it exists for: swapping one expected seed in the round-trip assertion fails it. It is not passing on the shape of the object alone.

## The README

`Bridge state in your key store` already says not to drop the `bridge-` rows from a backup, because restoring only the non-bridge rows rolls those sessions back. The same section now says what a *version* rollback costs, since that is the other way to end up with a record an engine cannot read.

I first wrote that paragraph from the bridge's own account — "the session itself still loads, and only that decrypt is lost". That is not what the record does. Measured across the two versions:

| scenario | result |
| --- | --- |
| 0.17.0 → 0.18.0, chain holding skipped keys | reads fine, seeds preserved |
| 0.18.0 → 0.17.0, no skipped keys buffered | reads fine |
| 0.18.0 → 0.17.0, chain holding skipped keys | **whole record rejected** |

Isolated, not assumed: taking a 586-byte record 0.17.0 *does* accept and stripping only the triple out of its message keys — a byte-level rewrite that leaves every other field identical, and lands on the same 414 bytes 0.18.0 produces — reproduces the rejection. So it is the missing triple, not anything else in the bump.

I first scoped this to native stores only, on the reasoning that a wrapped store holds the Baileys projection and v1 has only ever held seeds. Review caught that, and it was wrong: `writeProjected` also mirrors the core's exact bytes under `bridge-native-session`, and `readProjected` prefers that mirror while its fingerprint still matches the projection. Measured in-process, a second `get` comes back with the 414-byte seed-only payload rather than the 586-byte record a rebuild produces — so a wrapped store can hand an older engine bytes it cannot parse.

The paragraph now says that, and gives dropping the mirror row as the remedy, with the caveat that a session which turned native-only lives in that row alone and cannot be rebuilt from anything.

What I deliberately did **not** put in the README as reassurance: in every cross-version run through a *serialized* store, the mirror was rejected and the record rebuilt from the projection, so 0.17.0 received a valid 586-byte record. That happens because `fingerprintLegacy` is not stable across a JSON round trip — `canonicalize` keeps an `undefined`-valued own key that `JSON.stringify` drops, and the real projection has exactly one (`pendingPreKey`, absent when there is no pending pre-key). That is the branch a file- or SQL-backed host lands in, but it rests on a digest instability rather than on anything intended, and it looks like it silently discards and rebuilds the mirror on most reloads. Pre-existing on `main`, not introduced here, and not something to fix inside a dependency bump — flagging it for its own issue.

## Compatibility

No API change, no event change, no method renamed, no `bridge-` namespace added or removed. `COMPATIBILITY_REPORT.json` is generated against `baileys` and does not move on a bridge bump.

## Validation

```
npm run format:check
npm run lint          # tsc + oxlint
npm test              # 1372 pass, 1 skip, 0 fail
npm run build
npm run compat:audit:proto   # identical to 0.17.0
npm run compat:audit:wire    # identical to 0.17.0
```

## Not verified

There is no mock server in this run, so nothing here proves the new version stamp is accepted by the server, or that a `2.3000.1045368834` client behaves as that build does — both are the core's claim. The downgrade table is measured through the legacy projection path, which is the record parser reachable from here — not through the decrypt path itself. A rejection there means the older engine cannot deserialize the record, which is why I stopped claiming the session survives; what a live decrypt does after a rollback was not run, and would need a paired session to show.

