### PR TITLE
fix(legacy-store): keep the native mirror valid across a store round trip

### DIFF
--- a/src/Compatibility/legacy-store/codecs/basic.ts
+++ b/src/Compatibility/legacy-store/codecs/basic.ts
@@ -134,11 +134,17 @@ function tcTokenCodec(): LegacyCodec {
 				token_timestamp?: number
 				sender_timestamp?: number | null
 			}
-			return {
+			// Added rather than set to `undefined`, matching upstream, which
+			// only carries the field when it has a value. An undefined-valued
+			// key survives in memory but not through a store, and the mirror
+			// fingerprint is taken on both sides of that boundary — see the
+			// note in `canonicalize`.
+			const legacy: { token: Buffer; timestamp: string; senderTimestamp?: string } = {
 				token: Buffer.from(requireByteArray(native.token, 'native TC token')),
-				timestamp: (native.token_timestamp ?? TimeValue.UNKNOWN_SECONDS).toString(),
-				senderTimestamp: native.sender_timestamp == null ? undefined : native.sender_timestamp.toString()
+				timestamp: (native.token_timestamp ?? TimeValue.UNKNOWN_SECONDS).toString()
 			}
+			if (native.sender_timestamp != null) legacy.senderTimestamp = native.sender_timestamp.toString()
+			return legacy
 		}
 	}
 }

--- a/src/Compatibility/legacy-store/codecs/signal.ts
+++ b/src/Compatibility/legacy-store/codecs/signal.ts
@@ -247,7 +247,16 @@ function coreEntryToLegacy(session: CoreLegacySessionV1): LegacySessionEntry {
 			messageKeys: messageKeysToLegacy(chain.messageKeys)
 		}
 	}
-	return {
+	// Both optional parts are *added* rather than set to `undefined`, which is
+	// what upstream does (`session_record.js` guards `if (this.pendingPreKey)`,
+	// `session_builder.js` guards `if (device.preKey)`). The distinction is
+	// invisible once the value reaches a store — JSON drops an undefined-valued
+	// key — but it is visible to the mirror fingerprint, which is taken from
+	// the live object on write and from the reloaded one on read. Emitting the
+	// key made those two disagree for every session without a pending pre-key,
+	// so the mirror was rejected on the next read and the record rebuilt from
+	// the projection, discarding the counter lease the rebuild cannot express.
+	const entry: LegacySessionEntry = {
 		registrationId: session.registrationId,
 		currentRatchet: {
 			ephemeralKeyPair: {
@@ -266,15 +275,18 @@ function coreEntryToLegacy(session: CoreLegacySessionV1): LegacySessionEntry {
 			created: session.index.createdAtMs,
 			remoteIdentityKey: toBase64(session.index.remoteIdentityKey)
 		},
-		_chains: chains,
-		pendingPreKey: session.pendingPreKey
-			? {
-					preKeyId: session.pendingPreKey.preKeyId,
-					signedKeyId: session.pendingPreKey.signedPreKeyId,
-					baseKey: toBase64(session.pendingPreKey.baseKey)
-				}
-			: undefined
+		_chains: chains
 	}
+	if (session.pendingPreKey) {
+		entry.pendingPreKey = {
+			signedKeyId: session.pendingPreKey.signedPreKeyId,
+			baseKey: toBase64(session.pendingPreKey.baseKey)
+		}
+		if (session.pendingPreKey.preKeyId !== undefined) {
+			entry.pendingPreKey.preKeyId = session.pendingPreKey.preKeyId
+		}
+	}
+	return entry
 }
 
 function sessionToLegacy(nativeBytes: Uint8Array): LegacySessionJsonRecord | typeof NATIVE_ONLY_PROJECTION {

--- a/src/Compatibility/legacy-store/common.ts
+++ b/src/Compatibility/legacy-store/common.ts
@@ -25,12 +25,27 @@ export const bytesToNumbers = (value: Uint8Array | Buffer): number[] => Array.fr
 type Canonical = null | boolean | number | string | Canonical[] | { [key: string]: Canonical }
 
 /**
+ * Marks a value JSON would not have kept, so the object and array branches can
+ * each drop it the way `JSON.stringify` does. A plain `undefined` return could
+ * not be told apart from a property that is genuinely absent.
+ */
+const ABSENT: unique symbol = Symbol('absent')
+
+/**
  * Stable, runtime-independent representation used only to notice legacy-side
  * ownership changes. Buffer and Uint8Array intentionally share one shape.
+ *
+ * `undefined` follows `JSON.stringify`, and that is deliberately asymmetric: an
+ * object property is dropped, an array element becomes `null`. The fingerprint
+ * is taken from the live projection when the mirror is written and from the
+ * reloaded one when it is read, so any distinction a store cannot carry makes
+ * the two disagree forever. Tagging `undefined` as its own value was such a
+ * distinction — no persisted store can express it, and the mirror it invalidated
+ * is the only copy of the record fields the projection has no room for.
  */
-function canonicalize(value: unknown, seen: Set<object>): Canonical {
+function canonicalize(value: unknown, seen: Set<object>): Canonical | typeof ABSENT {
 	if (value === null) return null
-	if (value === undefined) return { [CanonicalTag.UNDEFINED]: true }
+	if (value === undefined) return ABSENT
 	if (typeof value === 'string' || typeof value === 'boolean') return value
 	if (typeof value === 'number') {
 		if (Number.isNaN(value)) return { [CanonicalTag.NUMBER]: 'NaN' }
@@ -48,10 +63,16 @@ function canonicalize(value: unknown, seen: Set<object>): Canonical {
 	if (seen.has(value)) throw new TypeError('cannot fingerprint a cyclic legacy store value')
 	seen.add(value)
 	try {
-		if (Array.isArray(value)) return value.map(item => canonicalize(item, seen))
+		if (Array.isArray(value)) {
+			return value.map(item => {
+				const canonical = canonicalize(item, seen)
+				return canonical === ABSENT ? null : canonical
+			})
+		}
 		const out: Record<string, Canonical> = {}
 		for (const key of Object.keys(value).toSorted()) {
-			out[key] = canonicalize((value as Record<string, unknown>)[key], seen)
+			const canonical = canonicalize((value as Record<string, unknown>)[key], seen)
+			if (canonical !== ABSENT) out[key] = canonical
 		}
 		return out
 	} finally {
@@ -60,8 +81,13 @@ function canonicalize(value: unknown, seen: Set<object>): Canonical {
 }
 
 function fingerprintLegacy(value: unknown): Buffer {
-	const canonical = JSON.stringify(canonicalize(value, new Set()))
-	return createHash(MirrorEnvelope.HASH).update(canonical).digest()
+	// A top-level absent value hashes as `null`: a store reports a row it does
+	// not hold as either, and the two have to agree for the same reason the
+	// property case does.
+	const canonical = canonicalize(value, new Set())
+	return createHash(MirrorEnvelope.HASH)
+		.update(JSON.stringify(canonical === ABSENT ? null : canonical))
+		.digest()
 }
 
 export type NativeEnvelope = {

--- a/src/Compatibility/legacy-store/constants.ts
+++ b/src/Compatibility/legacy-store/constants.ts
@@ -115,7 +115,6 @@ export const CanonicalTag = Object.freeze({
 	BYTES: '$bytes',
 	DATE: '$date',
 	NUMBER: '$number',
-	UNDEFINED: '$undefined',
 	UNSUPPORTED: '$unsupported'
 } as const)
 

--- a/src/Utils/__tests__/legacy-store-fingerprint.test.ts
+++ b/src/Utils/__tests__/legacy-store-fingerprint.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The mirror fingerprint's one job is to notice that something else rewrote the
+ * legacy projection. It is computed from the live object on write and from
+ * whatever the store returns on read, so it can only key on distinctions that
+ * survive a store — and every persisted store round-trips through JSON.
+ *
+ * `canonicalize` therefore has to agree with `JSON.stringify` about `undefined`,
+ * which is deliberately asymmetric: an object property disappears, an array
+ * element becomes `null`. Collapsing both to "drop it" would trade one
+ * instability for another, so the array case is pinned here separately.
+ */
+
+import { Buffer } from 'node:buffer'
+import { describe, test } from 'node:test'
+import { encodeNativeEnvelope } from '../../Compatibility/legacy-store/common.ts'
+import { expect } from '../../__tests__/expect.ts'
+import { BufferJSON } from '../generics.ts'
+
+/** The envelope is magic + digest + payload; an empty payload leaves the digest. */
+const digest = (value: unknown): string => encodeNativeEnvelope(new Uint8Array(), value).subarray(4).toString('hex')
+
+const sameDigest = (a: unknown, b: unknown) => digest(a) === digest(b)
+
+/**
+ * What the store does to a value before it is fingerprinted again. `BufferJSON`
+ * is the upstream contract every Baileys-shaped store honours, and restoring
+ * bytes is part of it — a store that returned `{type:'Buffer'}` instead of a
+ * `Buffer` would already break upstream, so the fingerprint does not try to
+ * absorb that.
+ */
+const throughStore = (value: unknown): unknown =>
+	JSON.parse(JSON.stringify(value, BufferJSON.replacer) ?? 'null', BufferJSON.reviver)
+
+describe('legacy-store fingerprint: agrees with JSON about undefined', () => {
+	test('an undefined-valued property hashes as if the key were absent', () => {
+		expect(sameDigest({ a: 1, b: undefined }, { a: 1 })).toBe(true)
+	})
+
+	test('an undefined array element hashes as null, not as a hole', () => {
+		expect(sameDigest([1, undefined, 2], [1, null, 2])).toBe(true)
+	})
+
+	/**
+	 * The guard on the asymmetry. `JSON.stringify([1, undefined, 2])` is
+	 * `[1,null,2]`, not `[1,2]` — an implementation that dropped `undefined`
+	 * everywhere would make a two-element array collide with a three-element
+	 * one and stop noticing a real edit.
+	 */
+	test('an undefined array element is not dropped', () => {
+		expect(sameDigest([1, undefined, 2], [1, 2])).toBe(false)
+	})
+
+	test('a top-level absent value hashes as null', () => {
+		expect(sameDigest(undefined, null)).toBe(true)
+	})
+
+	test('nested undefined properties follow the same rule', () => {
+		expect(sameDigest({ outer: { a: 1, b: undefined } }, { outer: { a: 1 } })).toBe(true)
+	})
+})
+
+describe('legacy-store fingerprint: is stable across a store round trip', () => {
+	const CASES: Array<[string, unknown]> = [
+		['an undefined-valued property', { a: 1, b: undefined }],
+		['a nested undefined-valued property', { outer: { a: 1, b: undefined } }],
+		['an undefined array element', { list: [1, undefined, 2] }],
+		['a projection-shaped record', { _sessions: { key: { pendingPreKey: undefined, _chains: {} } }, version: 'v1' }],
+		['bytes', { key: Buffer.from([1, 2, 3]) }],
+		['a plain value', { a: 1, b: 'two', c: true, d: null }]
+	]
+
+	for (const [label, value] of CASES) {
+		test(`${label} survives JSON`, () => {
+			expect(sameDigest(value, throughStore(value))).toBe(true)
+		})
+	}
+})
+
+describe('legacy-store fingerprint: still notices a real edit', () => {
+	test('a changed value changes the digest', () => {
+		expect(sameDigest({ a: 1 }, { a: 2 })).toBe(false)
+	})
+
+	test('an added key changes the digest', () => {
+		expect(sameDigest({ a: 1 }, { a: 1, b: 2 })).toBe(false)
+	})
+
+	test('a key set to null is not the same as a key that is absent', () => {
+		expect(sameDigest({ a: null }, {})).toBe(false)
+	})
+
+	test('bytes and their base64 spelling are not the same', () => {
+		expect(sameDigest({ a: Buffer.from([1, 2, 3]) }, { a: Buffer.from([1, 2, 3]).toString('base64') })).toBe(false)
+	})
+
+	test('a reordered object is the same, since a store may not keep key order', () => {
+		expect(sameDigest({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true)
+	})
+})

--- a/src/Utils/__tests__/wrap-legacy-store-mirror-durability.test.ts
+++ b/src/Utils/__tests__/wrap-legacy-store-mirror-durability.test.ts
@@ -1,0 +1,352 @@
+/**
+ * The native mirror has to survive the host's own serialization.
+ *
+ * `bridge-native-*` holds the core's exact bytes and is gated on a fingerprint
+ * of the legacy projection beside it: taken from the live object when the
+ * mirror is written, and from whatever the store hands back when it is read.
+ * Every persisted store round-trips its values through JSON, so any difference
+ * JSON erases makes those two disagree permanently — the mirror is rejected on
+ * every read and the record rebuilt from a projection that cannot express the
+ * core's local record fields.
+ *
+ * Reading back in process hides all of this, which is why every case here goes
+ * through a store that serializes exactly like `useLegacyMultiFileAuthState`.
+ */
+
+import { Buffer } from 'node:buffer'
+import { describe, test } from 'node:test'
+import { proto as bridgeProto } from '@oxidezap/whatsapp-rust-bridge/proto-types'
+import { expect } from '../../__tests__/expect.ts'
+import { decodeNativeEnvelope, envelopeMatchesLegacy } from '../../Compatibility/legacy-store/common.ts'
+import type { AuthenticationState, SignalKeyStore } from '../../Types/index.ts'
+import { BufferJSON, initAuthCreds } from '../generics.ts'
+import { wrapLegacyStore } from '../wrap-legacy-store.ts'
+import { BRIDGE_SESSION_KEY_LID, fill } from './_legacy-store-fixtures.ts'
+
+/**
+ * Models `useLegacyMultiFileAuthState`: every value crosses `BufferJSON` in
+ * both directions, and `app-state-sync-key` is re-hydrated on read the way
+ * that store does it. `disk` stays enumerable so a test can name the buckets.
+ */
+function jsonBackedStore() {
+	const disk: Record<string, Record<string, string>> = {}
+	// What the adapter handed to `keys.set`, before serialization. A host with
+	// an in-memory store sees exactly this object, so it is the shape upstream
+	// compatibility is judged on — and the only place an undefined-valued key
+	// is still visible.
+	const live: Record<string, Record<string, unknown>> = {}
+	return {
+		disk,
+		live,
+		async get(type: string, ids: string[]) {
+			const bucket = disk[type] ?? {}
+			return Object.fromEntries(
+				ids.map(id => {
+					const raw = bucket[id]
+					if (raw === undefined) return [id, null]
+					const value: unknown = JSON.parse(raw, BufferJSON.reviver)
+					return [id, value]
+				})
+			)
+		},
+		async set(updates: Record<string, Record<string, unknown>>) {
+			for (const [type, bucket] of Object.entries(updates)) {
+				disk[type] ??= {}
+				live[type] ??= {}
+				for (const [id, value] of Object.entries(bucket ?? {})) {
+					if (value == null) {
+						delete disk[type]![id]
+						delete live[type]![id]
+					} else {
+						live[type]![id] = value
+						disk[type]![id] = JSON.stringify(value, BufferJSON.replacer)
+					}
+				}
+			}
+		}
+	}
+}
+
+async function wrapJsonBacked() {
+	const backing = jsonBackedStore()
+	const state = {
+		creds: initAuthCreds(),
+		keys: backing as unknown as SignalKeyStore
+	} as AuthenticationState
+	return { backing, wrapped: await wrapLegacyStore(state, async () => {}) }
+}
+
+type Backing = Awaited<ReturnType<typeof wrapJsonBacked>>['backing']
+
+/** The one mirror row and the one projection row, read the way the adapter reads them. */
+async function mirrorAccepted(backing: Backing): Promise<boolean> {
+	const nativeType = Object.keys(backing.disk).find(type => type.startsWith('bridge-native-'))
+	const legacyType = Object.keys(backing.disk).find(type => !type.startsWith('bridge-'))
+	if (!nativeType || !legacyType) throw new Error('expected both a mirror and a projection')
+	const nativeId = Object.keys(backing.disk[nativeType]!)[0]!
+	const legacyId = Object.keys(backing.disk[legacyType]!)[0]!
+	const [nativeBucket, legacyBucket] = await Promise.all([
+		backing.get(nativeType, [nativeId]),
+		backing.get(legacyType, [legacyId])
+	])
+	const envelope = decodeNativeEnvelope(nativeBucket[nativeId])
+	if (!envelope) throw new Error('expected a decodable mirror envelope')
+	return envelopeMatchesLegacy(envelope, legacyBucket[legacyId])
+}
+
+async function projectionEntry(backing: Backing): Promise<Record<string, unknown>> {
+	const legacyType = Object.keys(backing.disk).find(type => !type.startsWith('bridge-'))!
+	const legacyId = Object.keys(backing.disk[legacyType]!)[0]!
+	const bucket = await backing.get(legacyType, [legacyId])
+	return bucket[legacyId] as Record<string, unknown>
+}
+
+/**
+ * The projection as the adapter emitted it. Reading it back out of the store
+ * would not do: JSON has already dropped every undefined-valued key by then,
+ * which is exactly the difference these assertions exist to see.
+ */
+function liveProjectionEntry(backing: Backing): Record<string, unknown> {
+	const legacyType = Object.keys(backing.live).find(type => !type.startsWith('bridge-'))!
+	const legacyId = Object.keys(backing.live[legacyType]!)[0]!
+	return backing.live[legacyType]![legacyId] as Record<string, unknown>
+}
+
+// ── Session records ─────────────────────────────────────────────────────
+
+/**
+ * whatsapp-rust writes two fields the WAProto schema has no room for:
+ * 100, the sender-chain counter lease, and 101, the store incarnation that
+ * says whether a reload is exact. Only the exact mirror can carry them.
+ */
+const counterLease = (reservation: number) =>
+	Buffer.from([0xa0, 0x06, reservation, 0xaa, 0x06, 0x10, ...Array(16).fill(0x5a)])
+
+type SessionShape = {
+	senderChainIndex?: number
+	reservation?: number
+	receiverChainKey?: boolean
+	pendingPreKey?: { signedPreKeyId: number; baseKey: Uint8Array; preKeyId?: number }
+}
+
+function buildSessionRecord(shape: SessionShape = {}): Uint8Array {
+	const { senderChainIndex = 0, reservation, receiverChainKey = true, pendingPreKey } = shape
+	const body = bridgeProto.RecordStructure.encode(
+		bridgeProto.RecordStructure.create({
+			currentSession: bridgeProto.SessionStructure.create({
+				sessionVersion: 3,
+				localIdentityPublic: fill(33, 9),
+				remoteIdentityPublic: fill(33, 8),
+				rootKey: fill(32, 1),
+				previousCounter: 0,
+				senderChain: {
+					senderRatchetKey: fill(33, 2),
+					senderRatchetKeyPrivate: fill(32, 3),
+					chainKey: { index: senderChainIndex, key: fill(32, 4) }
+				},
+				receiverChains: [
+					{
+						senderRatchetKey: fill(33, 5),
+						chainKey: receiverChainKey ? { index: 1, key: fill(32, 6) } : { index: 1 }
+					}
+				],
+				aliceBaseKey: fill(33, 7),
+				remoteRegistrationId: 1234,
+				localRegistrationId: 5678,
+				...(pendingPreKey ? { pendingPreKey } : {})
+			})
+		})
+	).finish()
+	return new Uint8Array(
+		reservation === undefined ? body : Buffer.concat([Buffer.from(body), counterLease(reservation)])
+	)
+}
+
+const senderChainIndexOf = (record: Uint8Array) =>
+	bridgeProto.RecordStructure.decode(record).currentSession?.senderChain?.chainKey?.index ?? 0
+
+describe('legacy-store mirror: survives the host serialization', () => {
+	test('a session read back through a JSON store is the exact bytes that were written', async () => {
+		const { wrapped, backing } = await wrapJsonBacked()
+		const original = buildSessionRecord({ senderChainIndex: 7, reservation: 71 })
+
+		await wrapped.set('session', BRIDGE_SESSION_KEY_LID, original)
+		expect(await mirrorAccepted(backing)).toBe(true)
+
+		const read = (await wrapped.get('session', BRIDGE_SESSION_KEY_LID)) as Uint8Array
+		expect(Buffer.from(read).equals(Buffer.from(original))).toBe(true)
+	})
+
+	test("the core's local record fields (100, 101) reach the reader", async () => {
+		const { wrapped } = await wrapJsonBacked()
+		const lease = counterLease(71)
+		await wrapped.set('session', BRIDGE_SESSION_KEY_LID, buildSessionRecord({ reservation: 71 }))
+
+		const read = (await wrapped.get('session', BRIDGE_SESSION_KEY_LID)) as Uint8Array
+		expect(Buffer.from(read).includes(lease)).toBe(true)
+	})
+
+	/**
+	 * `chainKey.key` is emitted as `undefined` by upstream too
+	 * (`key: c.chainKey.key && ...`), so the projection cannot stop producing
+	 * it without diverging. Only `canonicalize` agreeing with JSON covers it —
+	 * this is the case the projection-side change alone does not reach.
+	 */
+	test('a chain with no chainKey.key does not invalidate the mirror', async () => {
+		const { wrapped, backing } = await wrapJsonBacked()
+		const original = buildSessionRecord({ receiverChainKey: false, reservation: 71 })
+
+		await wrapped.set('session', BRIDGE_SESSION_KEY_LID, original)
+		const entry = (await projectionEntry(backing))._sessions as Record<
+			string,
+			{ _chains: Record<string, { chainKey: object }> }
+		>
+		const chains = Object.values(Object.values(entry)[0]!._chains)
+		expect(chains.some(chain => !Object.hasOwn(chain.chainKey, 'key'))).toBe(true)
+
+		expect(await mirrorAccepted(backing)).toBe(true)
+		const read = (await wrapped.get('session', BRIDGE_SESSION_KEY_LID)) as Uint8Array
+		expect(Buffer.from(read).equals(Buffer.from(original))).toBe(true)
+	})
+
+	test('a pending pre-key without a preKeyId does not invalidate the mirror', async () => {
+		const { wrapped, backing } = await wrapJsonBacked()
+		const original = buildSessionRecord({
+			reservation: 71,
+			pendingPreKey: { signedPreKeyId: 9, baseKey: fill(33, 7) }
+		})
+
+		await wrapped.set('session', BRIDGE_SESSION_KEY_LID, original)
+		expect(await mirrorAccepted(backing)).toBe(true)
+		const read = (await wrapped.get('session', BRIDGE_SESSION_KEY_LID)) as Uint8Array
+		expect(Buffer.from(read).equals(Buffer.from(original))).toBe(true)
+	})
+
+	test('a tc_token with no senderTimestamp does not invalidate the mirror', async () => {
+		const { wrapped, backing } = await wrapJsonBacked()
+		const original = new TextEncoder().encode(
+			JSON.stringify({ token: Array.from(fill(16, 17)), token_timestamp: 5, sender_timestamp: null })
+		)
+
+		await wrapped.set('tc_token', '5511999999999@s.whatsapp.net', original)
+		expect(await mirrorAccepted(backing)).toBe(true)
+	})
+})
+
+// ── What the rejection actually costs ───────────────────────────────────
+
+describe('legacy-store mirror: the counter lease is not burned', () => {
+	/**
+	 * Field 100 is an exclusive upper bound on counters that may already have
+	 * been published. A projection carries no such field, so `toLegacy` loads
+	 * the record as a new incarnation and fast-forwards the sender chain to the
+	 * ceiling — the conservative recovery, and correct in isolation. It is only
+	 * correct to *serve* that rebuilt record when the mirror is genuinely gone:
+	 * doing it on every read burns a whole reservation batch per message, which
+	 * widens the gap a receiver has to jump and defeats the batching that makes
+	 * one durable flush cover many sends.
+	 */
+	test('a message costs one counter, not a whole reservation batch', async () => {
+		const { wrapped } = await wrapJsonBacked()
+		const BATCH = 64
+		const MESSAGES = 10
+
+		let chainIndex = 0
+		for (let message = 0; message < MESSAGES; message++) {
+			// The core advances one counter and keeps its lease a batch ahead.
+			chainIndex += 1
+			await wrapped.set(
+				'session',
+				BRIDGE_SESSION_KEY_LID,
+				buildSessionRecord({ senderChainIndex: chainIndex, reservation: chainIndex + BATCH })
+			)
+			const read = (await wrapped.get('session', BRIDGE_SESSION_KEY_LID)) as Uint8Array
+			chainIndex = senderChainIndexOf(read)
+		}
+
+		expect(chainIndex).toBe(MESSAGES)
+	})
+
+	test('a reader with no mirror still recovers conservatively', async () => {
+		const { wrapped, backing } = await wrapJsonBacked()
+		await wrapped.set('session', BRIDGE_SESSION_KEY_LID, buildSessionRecord({ senderChainIndex: 5, reservation: 32 }))
+
+		// Drop the mirror: the projection is all that is left, and it must not
+		// hand back counters the lease had already covered.
+		const nativeType = Object.keys(backing.disk).find(type => type.startsWith('bridge-native-'))!
+		delete backing.disk[nativeType]
+
+		const read = (await wrapped.get('session', BRIDGE_SESSION_KEY_LID)) as Uint8Array
+		expect(senderChainIndexOf(read)).toBe(32)
+	})
+})
+
+// ── The projection shape upstream produces ──────────────────────────────
+
+describe('legacy-store projection: matches the shape upstream writes', () => {
+	test('a session with no pending pre-key has no pendingPreKey key at all', async () => {
+		const { wrapped, backing } = await wrapJsonBacked()
+		await wrapped.set('session', BRIDGE_SESSION_KEY_LID, buildSessionRecord())
+
+		const sessions = liveProjectionEntry(backing)._sessions as Record<string, object>
+		const entry = Object.values(sessions)[0]!
+		expect(Object.hasOwn(entry, 'pendingPreKey')).toBe(false)
+	})
+
+	test('a pending pre-key without a preKeyId has no preKeyId key at all', async () => {
+		const { wrapped, backing } = await wrapJsonBacked()
+		await wrapped.set(
+			'session',
+			BRIDGE_SESSION_KEY_LID,
+			buildSessionRecord({ pendingPreKey: { signedPreKeyId: 9, baseKey: fill(33, 7) } })
+		)
+
+		const sessions = liveProjectionEntry(backing)._sessions as Record<string, { pendingPreKey: object }>
+		const { pendingPreKey } = Object.values(sessions)[0]!
+		expect(Object.hasOwn(pendingPreKey, 'signedKeyId')).toBe(true)
+		expect(Object.hasOwn(pendingPreKey, 'preKeyId')).toBe(false)
+	})
+
+	test('a pending pre-key with a preKeyId still carries it', async () => {
+		const { wrapped, backing } = await wrapJsonBacked()
+		await wrapped.set(
+			'session',
+			BRIDGE_SESSION_KEY_LID,
+			buildSessionRecord({ pendingPreKey: { signedPreKeyId: 9, baseKey: fill(33, 7), preKeyId: 7 } })
+		)
+
+		const sessions = (await projectionEntry(backing))._sessions as Record<
+			string,
+			{ pendingPreKey: { preKeyId: number } }
+		>
+		expect(Object.values(sessions)[0]!.pendingPreKey.preKeyId).toBe(7)
+	})
+
+	test('a tc_token with no sender timestamp has no senderTimestamp key at all', async () => {
+		const { wrapped, backing } = await wrapJsonBacked()
+		await wrapped.set(
+			'tc_token',
+			'5511999999999@s.whatsapp.net',
+			new TextEncoder().encode(
+				JSON.stringify({ token: Array.from(fill(16, 17)), token_timestamp: 5, sender_timestamp: null })
+			)
+		)
+
+		const token = liveProjectionEntry(backing)
+		expect(Object.hasOwn(token, 'timestamp')).toBe(true)
+		expect(Object.hasOwn(token, 'senderTimestamp')).toBe(false)
+	})
+
+	test('a tc_token with a sender timestamp still carries it', async () => {
+		const { wrapped, backing } = await wrapJsonBacked()
+		await wrapped.set(
+			'tc_token',
+			'5511999999999@s.whatsapp.net',
+			new TextEncoder().encode(
+				JSON.stringify({ token: Array.from(fill(16, 17)), token_timestamp: 5, sender_timestamp: 9 })
+			)
+		)
+
+		expect(liveProjectionEntry(backing).senderTimestamp).toBe('9')
+	})
+})


### PR DESCRIPTION
Fixes #85.

## What was wrong

`bridge-native-*` holds the core's exact bytes and is gated on a fingerprint of the legacy projection beside it — taken from the live object when the mirror is written, and from whatever the store returns when it is read. `canonicalize` gave an undefined-valued key its own tagged value:

```ts
if (value === undefined) return { [CanonicalTag.UNDEFINED]: true }
```

No persisted store can carry that distinction — `JSON.stringify` drops the key — so the two sides disagreed permanently. The mirror was rejected on every read and the record rebuilt from the projection.

The issue described this as a loss on reload. It is worse: with `useLegacyMultiFileAuthState` every `get` re-reads from disk, so it happens on **every read**, in the same process.

## What it actually cost

I got the `whatsapp-rust` source rather than guessing at the two fields the rebuild drops. `wacore/libsignal/src/protocol/local_field.rs`:

```rust
const COUNTER_RESERVATION_FIELD: u32 = 100;  // sender-chain counter lease
const STORE_INCARNATION_FIELD: u32 = 101;    // 16-byte cache incarnation
```

**There is no key reuse**, which was my first hypothesis and it was wrong. `session.rs:988` fast-forwards the sender chain to the lease ceiling whenever the incarnation does not match, and the adapter always loads without one — so it always takes the conservative branch. That is the documented "conservatively recover as a new incarnation" path.

The cost is that the recovery ran on every read instead of only when the mirror was genuinely gone, burning a whole reservation batch per message. Measured through a store that serializes the way the multi-file store does:

| | counters consumed by 10 messages |
| --- | --- |
| mirror rejected (before) | **650** |
| mirror accepted (after) | **10** |

`SENDER_CHAIN_RESERVATION_BATCH` is 64, and its own comment says it "bounds both the sync-flush amortization (one per this many sends) and the worst-case counter gap a receiver sees after a crash — keep it well under MAX_FORWARD_JUMPS". Both were defeated:

- **Receiver gap.** `MAX_FORWARD_JUMPS` is 2000. A peer that misses messages saw 65 counters of gap per message sent, so its tolerance fell from ~2000 missed messages to ~30 before it stops decrypting and falls back to the retry/SKDM path.
- **Flush amortization.** The burn leaves the chain at the ceiling, so every send is at the bound and needs a durable pre-wire flush — roughly one per message instead of one per 64. This one follows from the design doc plus the measured burn; I could not run the core's send path without a server, so I am flagging it as derived rather than measured.

## The fix

**`canonicalize` follows `JSON.stringify`**, which is asymmetric on purpose: an object property is dropped, an array element becomes `null`. Collapsing both to "drop it" would make `[1, undefined, 2]` collide with `[1, 2]` and stop noticing a real edit, so the array case is pinned by its own test.

**The two projections that emitted an undefined-valued key now omit it**, which is also what upstream does — `session_record.js:82` guards `if (this.pendingPreKey)`, `session_builder.js:37` guards `if (device.preKey)`, and the Baileys tc-token path only carries `senderTimestamp` when it has one. We were emitting a shape upstream never emits.

That second change alone would not have been enough, and this is the part worth reading twice: `chainKey.key` is emitted as `undefined` by upstream too (`key: c.chainKey.key && ...`), so the projection cannot stop producing it without diverging from upstream. Only the `canonicalize` change reaches that case.

## Existing mirrors stay valid

A projection with no undefined-valued key canonicalizes byte-identically to before, so its digest is unchanged. The ones that do have such a key are already rejected on every read today. No migration, no one-time rebuild beyond what already happens.

## Tests

28 new tests. Every one was checked against the mutation it exists for, by reverting each change in isolation:

| reverted | tests that fail |
| --- | --- |
| projection change only | 3 — the shape assertions |
| `canonicalize` only | 9 — fingerprint semantics, including the `chainKey.key` case |
| both | 9 of the 12 durability tests, including the counter-lease one |

Two things the existing suite was missing, which is why this went unnoticed:

- **Everything read back in process.** The one test that already asserted this contract (`wrap-legacy-store-coverage.test.ts:185`) uses the in-memory store, which keeps the live object and its undefined-valued key, and asserts it for `sender_key` — whose projection is a `Buffer` and was never affected. Every case here goes through a store that serializes exactly like `useLegacyMultiFileAuthState`.
- **The shape assertions have to read the live object**, not the stored one. My first draft read it back through the store and did not discriminate at all — JSON had already dropped the key, so it passed with the fix reverted. Caught by the reversion check.

## Scope

I audited all 9 projected stores through a JSON-backed store. Only `session` and `tc_token` had unstable fingerprints, and only `session` lost bytes. `sync_key` looked affected in a first pass and was a false positive of my harness — the store re-hydrates `app-state-sync-key` into a protobufjs message on read (`multi-file.ts:70`), which restores the in-memory shape.

A store that does not restore `Buffer` identity on read still invalidates the mirror for several namespaces, and this PR deliberately does not absorb that: `BufferJSON` is the upstream contract, and a store that breaks it already breaks Baileys.

## Validation

```
npm run format:check
npm run lint          # tsc + oxlint
npm test              # 1400 pass, 1 skip, 0 fail (1372 before)
npm run build
npm run compat:audit:proto   # unchanged
npm run compat:audit:wire    # unchanged
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the native `bridge-native-*` mirror valid across JSON-backed store round trips by aligning fingerprinting with JSON semantics and omitting undefined-valued keys in projections. Previously, `canonicalize` tagged `undefined`, stores dropped the key, fingerprints disagreed, and the mirror was rejected on every read, forcing session rebuilds that burned the counter lease.

- Canonicalization: drop `undefined` object properties, map `undefined` array elements to `null`, and treat a top-level absent value as `null`; remove the `UNDEFINED` tag from `CanonicalTag`.
- Projections: only add `pendingPreKey` when present; set `preKeyId` only when defined; only add `tc_token.senderTimestamp` when present. This matches upstream shapes and avoids undefined-valued keys.
- Impact: eliminates counter burn on reads (10 messages consume 10 counters, not 650). Mirror now stays accepted and preserves fields 100/101 in session bytes.
- Tests: add coverage for fingerprint stability and mirror durability through a JSON-backed store.
- Migration: none required. Existing stable fingerprints are unchanged; mirrors already rejected today will rebuild once and then remain valid.

<sup>Written for commit 4e09201cc7c9f8b052c8c4257aa830384de2c603. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when synchronizing legacy token and session records.
  * Prevented optional fields from being serialized when they have no value.
  * Improved fingerprint handling for missing values, nested data, arrays, and reordered properties.
  * Preserved session data and counter state more reliably across storage serialization and recovery.

* **Tests**
  * Added coverage for fingerprint stability, data changes, serialization round trips, and mirror durability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->