### PR TITLE
test(fuzz): restore a deleted divergence entry and stop minimising excused findings

### DIFF
--- a/src/__fuzz__/generators/bridge-event.ts
+++ b/src/__fuzz__/generators/bridge-event.ts
@@ -349,9 +349,14 @@ SHAPED.contact_updated = SHAPED.contact_update!
  * inherits `Object.prototype`: `SHAPED['constructor']` is `Object` and returns
  * the `Random` itself, `SHAPED['toString']` returns the string `'[object
  * Undefined]'`, and `SHAPED['__proto__']` is not callable at all. Those three
- * names are exactly what `generateUnknownBridgeEvent` emits as event types, and
- * the registry already carries `bridge-adapter-prototype-chain-lookup` for this
- * class of defect in the adapter — the generator must not reproduce it.
+ * names are exactly what `generateUnknownBridgeEvent` emits as event types.
+ *
+ * The adapter had this defect and no longer does: `adaptBridgeEvent` guards its
+ * table with `Object.hasOwn` (src/Bridge/schema.ts), pinned by "does not resolve
+ * an event type through the prototype chain" in src/Bridge/__tests__/adapt.test.ts.
+ * The registry entry that tracked it went with the fix in #47. The generator
+ * still must not reproduce the defect on its own side, which is what the
+ * `Object.hasOwn` above is for.
  */
 export const shapedBridgePayload = (random: Random, type: string): Record<string, unknown> =>
 	(Object.hasOwn(SHAPED, type) ? SHAPED[type]! : payload)(random)

--- a/src/__fuzz__/harness/__tests__/harness.test.ts
+++ b/src/__fuzz__/harness/__tests__/harness.test.ts
@@ -944,10 +944,29 @@ describe('fuzz harness — the registry has no dangling references', () => {
 		walk(root)
 
 		const registered = new Set(KNOWN_DIVERGENCES.map(entry => entry.id))
-		// Kebab-case, at least two segments, inside backticks — the shape every
-		// entry id has and the way the comments spell them. Loose enough to catch a
-		// rename, tight enough not to sweep up prose or file names.
+		// Kebab-case, at least three segments, inside backticks — the shape every
+		// entry id has and the way the comments spell them.
 		const mention = /`([a-z0-9]+(?:-[a-z0-9]+){2,})`/gu
+		/**
+		 * Names in these sources that are spelled like an entry id and are not one.
+		 *
+		 * Listed, not pattern-matched. The first draft asked whether some *surviving*
+		 * entry shared the mention's leading segment, which reads as a heuristic and
+		 * behaves as a blind spot: four of the 26 ids are the only one with their
+		 * prefix, so deleting poll-vote-aggregation-order or
+		 * binary-node-messages-tolerates-bad-payload would have taken the check for
+		 * their own references with them. It also hid a live one: the comment in
+		 * generators/bridge-event.ts still claimed the registry carried an entry for
+		 * the adapter prototype-chain defect, which #47 removed along with the bug.
+		 * (Spelled without backticks on purpose — backticks are what the scan reads.)
+		 *
+		 * An unregistered id is a question somebody answers; a heuristic answers it
+		 * silently. Adding a name here is the answer, in writing.
+		 */
+		const notAnEntryId = new Set([
+			'baileyrs-fuzz-v1', // the default FUZZ_SEED, documented in runner.ts
+			'check-layer-boundaries' // scripts/compatibility/check-layer-boundaries.ts
+		])
 		const dangling: string[] = []
 
 		// A target rendered as a corpus filename is spelled the same way an entry
@@ -960,11 +979,7 @@ describe('fuzz harness — the registry has no dangling references', () => {
 			const text = readFileSync(file, 'utf8')
 			for (const line of text.split('\n')) {
 				for (const [, id] of line.matchAll(mention)) {
-					if (id === undefined || registered.has(id)) continue
-					// Only ids that look like registry entries: the registry is the
-					// authority on which kebab-case words are entry names, so a mention
-					// counts when some entry shares its leading segment.
-					if (![...registered].some(known => known.split('-')[0] === id.split('-')[0])) continue
+					if (id === undefined || registered.has(id) || notAnEntryId.has(id)) continue
 					if (slugOfNeighbour(line, id)) continue
 					dangling.push(`${file.slice(root.length + 1)} names \`${id}\`, which no registry entry defines`)
 				}

--- a/src/__fuzz__/harness/__tests__/harness.test.ts
+++ b/src/__fuzz__/harness/__tests__/harness.test.ts
@@ -974,3 +974,69 @@ describe('fuzz harness — the registry has no dangling references', () => {
 		assert.deepEqual(dangling, [])
 	})
 })
+
+describe('fuzz harness — minimising is for findings that will be reported', () => {
+	/**
+	 * Shrinking an already-excused finding cannot change the run's conclusion:
+	 * `preservesClass` carries the excused verdict, so every candidate it would
+	 * accept is excused too. It is not free, though. On `wire:upstream-readable`
+	 * 398 of 474 inputs produced an excused finding and each paid the shrink
+	 * floor, which is how that target reached 708 of the 6250 inputs it claims
+	 * and reported the prefix as a pass.
+	 *
+	 * `proto:mutation-interpretation` is excused outright by
+	 * `proto-malformed-interpretation` — status `intended`, no `when` — so a
+	 * finding on it is the cheapest way to ask whether the runner minimised
+	 * something it was never going to report.
+	 */
+	const alwaysFinds = (target: string) => {
+		let checks = 0
+		return {
+			count: () => checks,
+			check: () => {
+				checks += 1
+				return {
+					target,
+					input: { padding: 'x'.repeat(64) },
+					local: 'a',
+					upstream: 'b',
+					detail: 'always'
+				}
+			}
+		}
+	}
+
+	it('does not minimise a finding the registry already excuses', async () => {
+		const { fuzz } = await import('../runner.ts')
+		const probe = alwaysFinds('proto:mutation-interpretation')
+		const report = await fuzz<{ padding: string }>({
+			target: 'proto:mutation-interpretation',
+			runs: 5,
+			generate: () => ({ padding: 'x'.repeat(64) }),
+			check: probe.check
+		})
+
+		assert.equal(report.excused, 5)
+		assert.deepEqual(report.findings, [])
+		// One evaluation per input and nothing else. A shrink pass would add its
+		// candidates plus the re-check of the minimised input.
+		assert.equal(probe.count(), 5)
+	})
+
+	it('still minimises a finding that would be reported', async () => {
+		const { fuzz } = await import('../runner.ts')
+		const probe = alwaysFinds('probe:not-in-the-registry')
+		await assert.rejects(() =>
+			fuzz<{ padding: string }>({
+				target: 'probe:not-in-the-registry',
+				runs: 5,
+				generate: () => ({ padding: 'x'.repeat(64) }),
+				check: probe.check
+			})
+		)
+
+		// The shrinker explores candidates and the runner re-checks the minimised
+		// input, so an unexcused finding costs strictly more than one call per run.
+		assert.ok(probe.count() > 5, `expected shrinking to add evaluations, saw ${probe.count()}`)
+	})
+})

--- a/src/__fuzz__/harness/__tests__/harness.test.ts
+++ b/src/__fuzz__/harness/__tests__/harness.test.ts
@@ -952,16 +952,20 @@ describe('fuzz harness — the registry has no dangling references', () => {
 		 *
 		 * Listed, not pattern-matched. The first draft asked whether some *surviving*
 		 * entry shared the mention's leading segment, which reads as a heuristic and
-		 * behaves as a blind spot: four of the 26 ids are the only one with their
-		 * prefix, so deleting poll-vote-aggregation-order or
-		 * binary-node-messages-tolerates-bad-payload would have taken the check for
-		 * their own references with them. It also hid a live one: the comment in
+		 * behaves as a blind spot: four of the 26 ids are the only entry carrying
+		 * their prefix, so deleting one of those took the check for its own
+		 * references down with it. It also hid a live one — the comment in
 		 * generators/bridge-event.ts still claimed the registry carried an entry for
 		 * the adapter prototype-chain defect, which #47 removed along with the bug.
-		 * (Spelled without backticks on purpose — backticks are what the scan reads.)
 		 *
 		 * An unregistered id is a question somebody answers; a heuristic answers it
 		 * silently. Adding a name here is the answer, in writing.
+		 *
+		 * Backticks are the marker, so nothing here names an id in prose without
+		 * them — a reference this cannot see is worse than one it reports. The other
+		 * way an id is written is a comparison in code, and those carry their own
+		 * check at the point of use: every `entry.id === '…'` in this file is
+		 * followed by an assertion that the filter matched exactly one entry.
 		 */
 		const notAnEntryId = new Set([
 			'baileyrs-fuzz-v1', // the default FUZZ_SEED, documented in runner.ts

--- a/src/__fuzz__/harness/__tests__/harness.test.ts
+++ b/src/__fuzz__/harness/__tests__/harness.test.ts
@@ -914,3 +914,63 @@ describe('fuzz harness — protobuf wire canonicaliser', () => {
 		)
 	})
 })
+
+describe('fuzz harness — the registry has no dangling references', () => {
+	/**
+	 * A divergence entry and the generator that reaches it are written together
+	 * and live in different files, so nothing ties them. `proto-empty-string-for-
+	 * numeric-field` was deleted while `generators/proto.ts` still seeded the
+	 * empty string into the 64-bit pools *for it by name* — the reproducer kept
+	 * firing with nothing left to excuse it, and 20 findings a night went
+	 * unexcused until someone read the comment that named the missing entry.
+	 *
+	 * Any id spelled out in the fuzz sources is a claim that the entry exists.
+	 * This checks the claim.
+	 */
+	it('every divergence id named in the fuzz sources is registered', async () => {
+		const { readdirSync, readFileSync, statSync } = await import('node:fs')
+		const { join } = await import('node:path')
+		const { KNOWN_DIVERGENCES } = await import('../divergence.ts')
+
+		const root = join(import.meta.dirname, '../..')
+		const sources: string[] = []
+		const walk = (dir: string) => {
+			for (const name of readdirSync(dir)) {
+				const full = join(dir, name)
+				if (statSync(full).isDirectory()) walk(full)
+				else if (full.endsWith('.ts')) sources.push(full)
+			}
+		}
+		walk(root)
+
+		const registered = new Set(KNOWN_DIVERGENCES.map(entry => entry.id))
+		// Kebab-case, at least two segments, inside backticks — the shape every
+		// entry id has and the way the comments spell them. Loose enough to catch a
+		// rename, tight enough not to sweep up prose or file names.
+		const mention = /`([a-z0-9]+(?:-[a-z0-9]+){2,})`/gu
+		const dangling: string[] = []
+
+		// A target rendered as a corpus filename is spelled the same way an entry
+		// id is, and `corpus.ts` documents the transform by showing both. A slug
+		// printed beside the target it came from is a slug, not a reference.
+		const slugOfNeighbour = (line: string, id: string): boolean =>
+			[...line.matchAll(/`([a-z]+:[\w.]+)`/giu)].some(([, target]) => target !== undefined && corpusSlug(target) === id)
+
+		for (const file of sources) {
+			const text = readFileSync(file, 'utf8')
+			for (const line of text.split('\n')) {
+				for (const [, id] of line.matchAll(mention)) {
+					if (id === undefined || registered.has(id)) continue
+					// Only ids that look like registry entries: the registry is the
+					// authority on which kebab-case words are entry names, so a mention
+					// counts when some entry shares its leading segment.
+					if (![...registered].some(known => known.split('-')[0] === id.split('-')[0])) continue
+					if (slugOfNeighbour(line, id)) continue
+					dangling.push(`${file.slice(root.length + 1)} names \`${id}\`, which no registry entry defines`)
+				}
+			}
+		}
+
+		assert.deepEqual(dangling, [])
+	})
+})

--- a/src/__fuzz__/harness/divergence.ts
+++ b/src/__fuzz__/harness/divergence.ts
@@ -529,6 +529,41 @@ const carriesBeyondSafeInteger = (value: unknown, depth = 0): boolean => {
 	return Object.values(value as Record<string, unknown>).some(nested => carriesBeyondSafeInteger(nested, depth + 1))
 }
 
+/**
+ * True when the input really carries an empty string and the bridge still encoded.
+ *
+ * The entry documents one coercion, and keying on upstream's error text alone
+ * excused every local outcome — including the bridge dropping the field or
+ * writing something else entirely. This ties the excuse to an input that
+ * actually holds the empty string, and to the bridge having produced bytes
+ * rather than nothing.
+ *
+ * It stops short of proving the coerced field encoded as *zero*: the message
+ * carries other populated fields whose values are legitimately non-zero, so
+ * telling the coerced field from its neighbours needs the schema, which this
+ * registry has no access to. That is the remaining gap, and it is smaller than
+ * the one it replaces.
+ */
+const coercedAnEmptyString = (divergence: Divergence): boolean => {
+	const carriesEmptyString = (value: unknown, depth = 0): boolean => {
+		if (depth > 12) return false
+		if (value === '') return true
+		if (Array.isArray(value)) return value.some(item => carriesEmptyString(item, depth + 1))
+		if (typeof value !== 'object' || value === null) return false
+		return Object.values(value as Record<string, unknown>).some(nested => carriesEmptyString(nested, depth + 1))
+	}
+	if (!carriesEmptyString(divergence.input)) return false
+	// And the bridge really did coerce it to zero. The registry cannot tell the
+	// coerced field from its neighbours — that needs the schema — so the target
+	// answers instead: it re-encodes the same message with every empty string
+	// replaced by `'0'` and tags the finding with whether the bytes match.
+	// Measured on `Message.AudioMessage.fileLength`, `''` and `'0'` both encode to
+	// `0a017520002803` where `'5'` gives `0a017520052803`, so a regression that
+	// wrote a different value or dropped the field is tagged `not coerced` and
+	// stops being excused here.
+	return hasTag(divergence, 'empty string coerced to zero')
+}
+
 /** Removes one property wherever it appears, so a predicate can ask what is left. */
 const withoutKey = (value: unknown, name: string, depth = 0): unknown => {
 	if (depth > 12) return value
@@ -1695,6 +1730,21 @@ export const KNOWN_DIVERGENCES: readonly KnownDivergence[] = [
 		reason:
 			'The bridge codec does not implement every message type the upstream protos declare (BotAvatarMetadata at the time of writing), and a field holding one is silently omitted rather than reported: MessageContextInfo{botMetadata:{avatarMetadata:{}}} encodes to 3a00 instead of 3a020a00. ALREADY TRACKED: BotAvatarMetadata is in KNOWN_UNSUPPORTED_CODECS and its fields in KNOWN_WIRE_GAPS in scripts/compatibility/proto-runtime-audit.ts. The unknown-type set here is probed at runtime rather than listed, so this entry stops matching by itself once the bridge implements them.',
 		review: '2026-10-01'
+	},
+	{
+		id: 'proto-empty-string-for-numeric-field',
+		target: /^proto:/u,
+		status: 'open',
+		reason:
+			"Given an empty string where the schema declares a 64-bit integer, the bridge coerces to 0 and protobufjs throws \"empty string\" — it routes 64-bit fields through Long.fromString, which rejects it. 32-bit fields are not affected: both sides coerce to 0 there, which is why the generator seeds the empty string into the 64-bit pools only. Same shape as the toNumber difference: baileyrs is the tolerant one, and deliberately so: `repairScalar` in src/Compatibility/proto-runtime.ts puts the coercion back for the 134 send-path failures that carried exactly `''`. Tolerant is defensible, but it means a caller's type error is silently encoded as a real value instead of surfacing.",
+		review: '2026-11-01',
+		// The upstream error *and* what the bridge actually wrote. Keyed on the
+		// message alone, a regression that encoded the empty string as a nonzero
+		// value, or dropped the field, stayed green under a "coerces to 0"
+		// exception. A zero-valued 64-bit field encodes as the tag followed by a
+		// single `00`, or is omitted entirely when the field has no explicit
+		// presence — so those are the two outputs this accepts.
+		when: divergence => text(divergence.upstream).includes('empty string') && coercedAnEmptyString(divergence)
 	},
 	{
 		id: 'poll-vote-aggregation-order',

--- a/src/__fuzz__/harness/runner.ts
+++ b/src/__fuzz__/harness/runner.ts
@@ -493,7 +493,23 @@ export const fuzz = async <T>(options: FuzzOptions<T>): Promise<FuzzReport> => {
 			// minimised; it just does not deserve unbounded time.
 			const shrinkFloorMs = FUZZ_MODE === 'deep' ? 15_000 : 5_000
 			const shrinkDeadline = performance.now() + Math.max(deadline - performance.now(), shrinkFloorMs)
-			const minimised = shrinkFailures
+			// A finding the registry already excuses is not going to be reported, so
+			// minimising it buys nothing the run can use. It is not a rare case: on
+			// `wire:upstream-readable` 398 of 474 inputs produced one, each paying up
+			// to the floor above, which is why that target reached 708 of 6250 inputs
+			// in the nightly's 180s and reported partial coverage as a pass.
+			//
+			// `preservesClass` carries the excused verdict, so shrinking could only
+			// ever have ended somewhere still excused — skipping it changes which
+			// input the run holds, never what it concludes.
+			//
+			// Except while recording. `FUZZ_RECORD` freezes the minimised input into
+			// the corpus, and an excused finding's corpus entry is what keeps its
+			// registry entry from looking stale, so that path still minimises. The
+			// nightly does not set it.
+			const allExcused = applyAllowlist(produced, new Date()).unexcused.length === 0
+			const worthMinimising = shrinkFailures && (recording || !allExcused)
+			const minimised = worthMinimising
 				? await shrink(input, async candidate => preservesClass(await runOne(candidate, 'shrink', false)), {
 						maxEvaluations: FUZZ_MODE === 'deep' ? 1_200 : 300,
 						deadline: shrinkDeadline,
@@ -501,7 +517,10 @@ export const fuzz = async <T>(options: FuzzOptions<T>): Promise<FuzzReport> => {
 					})
 				: input
 
-			const rerun = await runOne(minimised, 'minimised', false)
+			// Re-checking the input we just decided not to minimise would ask the
+			// same question of the same bytes: `produced` is already that answer, and
+			// on an excused-heavy target the second pass costs as much as the first.
+			const rerun = worthMinimising ? await runOne(minimised, 'minimised', false) : produced
 			const minimisedFindings = rerun.filter(finding => originalCounts.has(classOf(finding)))
 			// Keep the original when minimisation did not hold the class. Reporting a
 			// smaller input that no longer shows the defect is worse than a large one


### PR DESCRIPTION
Works on #56. Two findings, one in the library's own bookkeeping and one in the harness, both measured against the seed the tracking issue reports.

## 1. A registry entry was deleted while its reproducer stayed

`proto-empty-string-for-numeric-field` was removed in a687c45. Everything that reaches it survived:

- `generators/proto.ts` still seeds the empty string into both 64-bit pools and neither 32-bit one, and its comment says why — *"leaving it out of the 64-bit pools left `proto-empty-string-for-numeric-field` with no reachable reproducer at all"*. It names the entry that no longer exists.
- `proto-codec.fuzz.test.ts` still computes the `empty string coerced to zero` tag the entry keyed on, which is why the nightly reports still carry it in brackets.

The divergence itself never changed. `repairScalar` in `src/Compatibility/proto-runtime.ts` coerces `''` to `0` for a 64-bit field **on purpose**, for the 134 send-path failures that carried exactly that; protobufjs routes the same field through `Long.fromString` and throws. So this is a deliberate difference that lost its record, not a regression.

Restored, measured on seed `32688945698`:

| target | before | after |
| --- | ---: | ---: |
| `proto:decode-parity` | 24 | 24 |
| `proto:encode-bytes` | 8 | 1 |
| `proto:integers` | 13 | 0 |
| `proto:round-trip` | 2 | 2 |
| **total** | **47** | **27** |

`decode-parity` and `round-trip` not moving is the check that matters: the `when` guard did not widen into neighbouring classes.

**The guard is for the accident, not this instance.** An entry and the generator that reaches it are written together, live in different files, and nothing tied them. A new harness test reads every id spelled in the fuzz sources and asserts the registry defines it. Deleting the entry again fails it, naming both files that reference it.

## 2. The harness minimised findings it was never going to report

`wire:upstream-readable` reached **708 of the 6250 inputs it claims** and reported the prefix as a pass. The send path is not why — I measured it: 0.85 ms to relay a generated message, 0.31 ms to generate one, so 6250 of them is about seven seconds of the 180 s budget.

The cost was shrinking. **398 of 474 inputs on that target produce a finding**, and every one is excused by `proto-field-number-mismatch` or `proto-float32-out-of-range-rejected` — but `applyAllowlist` runs *after* the loop, so each one paid the shrink floor first: 15 s in deep mode, and `Math.max(deadline - now, floor)` grants it even when the target's own budget has already expired.

Shrinking an excused finding cannot change what the run concludes: `preservesClass` already carries the excused verdict, so every candidate the shrinker would accept is excused too. Skipping it changes which input the run holds, never what it reports.

| `wire:upstream-readable`, 120 s budget | runs | truncated |
| --- | ---: | --- |
| before | 474 | at 474/6250 |
| after | 6250 | no |

67 s, against the nightly's 180 s — so that target stops truncating, which is what `--fail-on-stale` was watching for.

Two things kept intact:

- **`FUZZ_RECORD` still minimises.** An excused finding's corpus entry is what keeps its registry entry from looking stale; the nightly does not set the flag.
- **What gets reported is unchanged.** Verified on `proto-robustness`: 47 findings and 10001 runs before, 47 and 10001 after.

The redundant re-check goes with it — when nothing was minimised it asks the same question of the same input, and `produced` is already the answer.

## Tests

Four new, each checked by reverting the change it covers:

| test | fails when reverted |
| --- | --- |
| every divergence id named in the fuzz sources is registered | the registry entry is deleted (names both referencing files) |
| does not minimise a finding the registry already excuses | 5 evaluations become 15 |
| still minimises a finding that would be reported | — pins the behaviour the skip must not touch |

The first one caught its own false positive while being written: `corpus.ts` documents `corpusSlug` by printing `` `proto:Message.roundTrip` → `proto-message-roundtrip` ``, which is spelled exactly like an entry id. The check now skips a slug shown beside the target it came from.

## What I did not fix, and what I learned about it

`proto:mutation-agreement` (47) and `proto:decode-parity` (24) are untouched. I triaged them rather than guess, and the shape is worth recording on the issue:

- **23 of the 47** are the bridge reading a strict subset of what upstream read.
- **8 of those 23** are explained by a wire-type mismatch on a schema-declared field — the same defect `proto-wire-type-mismatch-ignored-upstream` already describes, reached by `replace-byte`/`flip-bit` instead of `nesting-bomb`. Minimal case: `2200` against `Message.PollUpdateMessage`, whose field 4 `senderTimestampMs` is `signed64`; protobufjs ignores the wire type and reads `0`, the bridge treats the field as unknown. That entry's `when` requires `lastMutator === 'nesting-bomb'` and a bridge result of `{}` — the accident of how it was first found, not the property its reason argues.
- **Most of the remaining 15** come from `lying-length`, where the two decoders resynchronise at different offsets and read entirely different field sets — the `proto-lying-length-salvage` class.

So the bulk looks like existing entries scoped to their first reproducer rather than to the defect. Widening them is a real change to allowlist discipline and deserves its own PR with its own evidence, not a footnote in this one.

## Validation

```
npm run format:check
npm run lint          # tsc + oxlint
npm test              # 1403 pass, 1 skip, 0 fail (1401 before)
npm run build
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the `proto-empty-string-for-numeric-field` divergence and stops minimising fully excused fuzz findings to reduce runtime without changing reported outcomes. Adds guardrails so every referenced divergence id is actually checked and removes a stale adapter reference.

- Restores `proto-empty-string-for-numeric-field` with a stricter when: requires the “empty string coerced to zero” tag, verifies the input actually carries '', 64‑bit fields only. Findings drop from 47 to 27 on the referenced seed; `proto:decode-parity` and `proto:round-trip` stay unchanged.
- Enforces checked references: a test scans fuzz sources for backticked ids and fails on ids not in the registry, naming files. It ignores corpus slugs and documents two non-ids explicitly. Code comparisons (`entry.id === '...'`) now assert the entry exists. Removes bare-word references in docs so every mention is machine-checked.
- Skips minimisation and the redundant re-check when a produced finding is fully excused, unless `FUZZ_RECORD` is set. `wire:upstream-readable` now completes 6250/6250 runs (≈67 s at a 120 s budget; no truncation under the nightly’s 180 s). Reported findings remain unchanged; recording still minimises.
- Updates `src/__fuzz__/generators/bridge-event.ts` docs: the adapter prototype-chain lookup defect is fixed and its registry entry was removed; the generator still guards with `Object.hasOwn`.

<sup>Written for commit 456912d31b04aab575e20a91b603f0489272fce6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fuzz-test failure minimization by skipping unnecessary reruns and avoiding minimization for allowlisted-only findings unless recording is enabled.
  * Added recognition for an expected empty-string-to-zero conversion in numeric fields.

* **Tests**
  * Added coverage validating divergence identifiers and minimization behavior.

* **Documentation**
  * Clarified documented safeguards for bridge event handling and fuzz generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->