### PR TITLE
test(fuzz): decide the pollResultSnapshotMessageV3 renumbering against the client

### DIFF
--- a/scripts/compatibility/__tests__/wire-fidelity.test.ts
+++ b/scripts/compatibility/__tests__/wire-fidelity.test.ts
@@ -18,6 +18,12 @@ const SEED = 20260808
  * `pollResultSnapshotMessageV3` sits at field 115 in the bridge proto and 114 in
  * baileys 7.0.0-rc13. Both codecs read their own bytes, so it is a schema gap
  * rather than a send-path one; pinned here so a second divergence fails.
+ *
+ * 115 is the conforming number: WhatsApp Web's own field table assigns it there
+ * and leaves 114 unassigned — see `proto-field-number-mismatch` in
+ * src/__fuzz__/harness/divergence.ts for the citation. The gap closes when
+ * upstream regenerates its proto, so this stays a divergence rather than
+ * something to match.
  */
 const KNOWN_DIVERGENT = ['pollResultSnapshotMessageV3']
 

--- a/scripts/compatibility/proto-runtime-audit.ts
+++ b/scripts/compatibility/proto-runtime-audit.ts
@@ -61,6 +61,11 @@ const KNOWN_WIRE_GAPS = [
 	'Message.MessageHistoryMetadata.oldestMessageTimestamp',
 	'Message.StickerMessage.mediaKeyDomain',
 	'Message.VideoMessage.mediaKeyDomain',
+	// Renumbered, not absent: the bridge writes field 115 and baileys 7.0.0-rc13
+	// declares 114. WhatsApp Web assigns 115 and leaves 114 unassigned, so the
+	// bridge is the conforming side and the gap closes when upstream regenerates
+	// its proto. `proto-field-number-mismatch` in src/__fuzz__/harness/divergence.ts
+	// carries the client citation and a minimal reproducer.
 	'Message.pollResultSnapshotMessageV3',
 	'SyncActionValue.AgentAction.deviceID',
 	'SyncActionValue.ChatAssignmentAction.deviceAgentID',

--- a/src/__fuzz__/harness/__tests__/harness.test.ts
+++ b/src/__fuzz__/harness/__tests__/harness.test.ts
@@ -486,6 +486,67 @@ describe('fuzz harness — known-divergence allowlist', () => {
 		assert.ok(excused('proto:type-coverage', 'BotAvatarMetadata', 'a', 'b'), 'the sweeps still match by name alone')
 	})
 
+	// The one entry whose direction is settled by the client rather than by either
+	// library, so what it must *not* excuse is the interesting half.
+	it('excuses the field renumbering wherever it shows, and only when it is the whole difference', async () => {
+		const { KNOWN_DIVERGENCES } = await import('../divergence.ts')
+		const registry = KNOWN_DIVERGENCES.filter(entry => entry.id === 'proto-field-number-mismatch')
+		assert.equal(registry.length, 1, 'the entry under test is still in the registry')
+
+		const excused = (target: string, input: unknown, local: unknown, upstream: unknown): boolean =>
+			applyAllowlist([{ target, input, local, upstream }], new Date('2026-01-01'), registry).unexcused.length === 0
+
+		// `proto:mutation-agreement` hands both decoders raw bytes, so its input is
+		// a hex string that can never name a field. Before this, no branch of the
+		// entry could see the renumbering here at all, and every mutated payload
+		// that happened to carry tag 115 was reported as an unexplained decode
+		// difference.
+		const mutation = 'proto:mutation-agreement'
+		const bytes = { path: 'Message.ImageMessage', mutator: 'flip-bit', bytes: '9a07020a00' }
+		const snapshot = { pollResultSnapshotMessageV3: { pollType: '0' } }
+
+		assert.ok(
+			excused(
+				mutation,
+				bytes,
+				{ caption: 'a', contextInfo: { quotedMessage: snapshot } },
+				{ caption: 'a', contextInfo: { quotedMessage: {} } }
+			),
+			'the bridge reading field 115 where upstream skips it'
+		)
+		// The client assigns 115, so the reverse — upstream reading its 114 where
+		// the bridge does not — is the same renumbering seen from the other end.
+		assert.ok(
+			excused(mutation, bytes, { caption: 'a' }, { caption: 'a', ...snapshot }),
+			'upstream reading field 114 where the bridge skips it'
+		)
+		// The half that matters: a mutated payload routinely carries more than one
+		// difference, and the renumbering must not carry the rest in with it.
+		assert.ok(
+			!excused(mutation, bytes, { caption: 'a', ...snapshot }, { caption: 'b' }),
+			'a changed value beside the renumbering is still unexplained'
+		)
+		assert.ok(
+			!excused(mutation, bytes, { caption: 'a', ...snapshot }, { caption: 'a', mediaKeyDomain: '0' }),
+			'a second missing field beside the renumbering is still unexplained'
+		)
+		// Naming the field is never enough on its own, on any target.
+		assert.ok(
+			!excused(mutation, bytes, { ...snapshot }, { ...snapshot }),
+			'two sides that already agree are not a divergence to explain'
+		)
+		// And the branches that were already there still answer for themselves: the
+		// number sweep is pinned to the two numbers, not to the name.
+		assert.ok(
+			excused('proto:field-numbers', 'Message.pollResultSnapshotMessageV3', 'field 115', 'field 114'),
+			'the number sweep, with both numbers'
+		)
+		assert.ok(
+			!excused('proto:field-numbers', 'Message.pollResultSnapshotMessageV3', 'field 116', 'field 114'),
+			'a third number on the same field is a new defect'
+		)
+	})
+
 	it('composes the field rename with a field the bridge never writes, and nothing else', async () => {
 		const { KNOWN_DIVERGENCES } = await import('../divergence.ts')
 		const registry = KNOWN_DIVERGENCES.filter(entry => entry.id === 'proto-field-renamed-and-dropped')

--- a/src/__fuzz__/harness/__tests__/harness.test.ts
+++ b/src/__fuzz__/harness/__tests__/harness.test.ts
@@ -535,6 +535,37 @@ describe('fuzz harness — known-divergence allowlist', () => {
 			!excused(mutation, bytes, { ...snapshot }, { ...snapshot }),
 			'two sides that already agree are not a divergence to explain'
 		)
+		// A payload can carry tag 114 *and* tag 115, and then both decoders report
+		// the field from their own number. Deleting it from both sides compares
+		// equal however far apart the two values are, so the field has to be on one
+		// side only for the renumbering to be the explanation.
+		assert.ok(
+			!excused(
+				mutation,
+				bytes,
+				{ pollResultSnapshotMessageV3: { name: 'a' } },
+				{ pollResultSnapshotMessageV3: { name: 'b' } }
+			),
+			'conflicting values under both tags are not explained by the renumbering'
+		)
+		// The same, one level down, where the shallow check would not see it.
+		assert.ok(
+			!excused(
+				mutation,
+				bytes,
+				{ contextInfo: { quotedMessage: { pollResultSnapshotMessageV3: { name: 'a' } } } },
+				{ contextInfo: { quotedMessage: { pollResultSnapshotMessageV3: { name: 'b' } } } }
+			),
+			'conflicting values nested under both tags are not explained either'
+		)
+		// The raw-output fallback is for the targets that put the two codecs on the
+		// two sides. `proto:mutation-stability` takes raw bytes too and matches this
+		// entry's target pattern, but both of its sides are the bridge — a fixed
+		// point it fails to reach is the bridge disagreeing with itself.
+		assert.ok(
+			!excused('proto:mutation-stability', bytes, { caption: 'a' }, { caption: 'a', ...snapshot }),
+			'a bridge self-inconsistency is never an upstream renumbering'
+		)
 		// And the branches that were already there still answer for themselves: the
 		// number sweep is pinned to the two numbers, not to the name.
 		assert.ok(

--- a/src/__fuzz__/harness/divergence.ts
+++ b/src/__fuzz__/harness/divergence.ts
@@ -850,6 +850,21 @@ const sameShape = (left: unknown, right: unknown): boolean => {
 	return keys.every(key => Object.hasOwn(b, key) && sameShape(a[key], b[key]))
 }
 
+/** True when both sides carry `name` at the same path, where its value could differ unseen. */
+const sharesKey = (left: unknown, right: unknown, name: string, depth = 0): boolean => {
+	if (depth > 12) return false
+	if (Array.isArray(left) || Array.isArray(right)) {
+		if (!Array.isArray(left) || !Array.isArray(right)) return false
+		return left.some((item, index) => sharesKey(item, right[index], name, depth + 1))
+	}
+	if (typeof left !== 'object' || left === null || typeof right !== 'object' || right === null) return false
+	const a = left as Record<string, unknown>
+	const b = right as Record<string, unknown>
+	return Object.keys(a).some(
+		key => Object.hasOwn(b, key) && (key === name || sharesKey(a[key], b[key], name, depth + 1))
+	)
+}
+
 /**
  * True when deleting `pollResultSnapshotMessageV3` closes the gap completely.
  *
@@ -860,11 +875,25 @@ const sameShape = (left: unknown, right: unknown): boolean => {
  * field, survives the deletion and is not this entry — which is what keeps a
  * real decoder difference on a message that happens to hold this field from
  * riding along with a renumbering that is already decided.
+ *
+ * One side only, and that is the reason for `sharesKey`. Nothing stops a
+ * payload from carrying tag 114 *and* tag 115, and then both decoders report
+ * the field — each reading its own number. Deleting it from both sides compares
+ * equal however far apart the two values are, so a corrupted read of the
+ * renumbered field would leave on the renumbering's ticket. Not reached by any
+ * finding measured so far (0 of the 23 that name the field, across
+ * mutation-agreement, decode-parity, round-trip and encode-bytes on seed
+ * 32688945698), which is exactly why it has to be written down rather than
+ * relied on.
  */
 const renumberingIsTheWholeDifference = (divergence: Divergence): boolean => {
-	const mine = withoutKey(normalise(divergence.local), 'pollResultSnapshotMessageV3')
-	const theirs = withoutKey(normalise(divergence.upstream), 'pollResultSnapshotMessageV3')
-	return sameShape(mine, theirs) && !sameShape(normalise(divergence.local), normalise(divergence.upstream))
+	const mine = normalise(divergence.local)
+	const theirs = normalise(divergence.upstream)
+	if (sharesKey(mine, theirs, 'pollResultSnapshotMessageV3')) return false
+	return (
+		sameShape(withoutKey(mine, 'pollResultSnapshotMessageV3'), withoutKey(theirs, 'pollResultSnapshotMessageV3')) &&
+		!sameShape(mine, theirs)
+	)
 }
 
 /**
@@ -1581,6 +1610,15 @@ export const KNOWN_DIVERGENCES: readonly KnownDivergence[] = [
 			// carry a second changed value beside it.
 			const namesField = (value: unknown): boolean => text(value).includes('pollResultSnapshotMessageV3')
 			if (!namesField(divergence.input)) {
+				// And only where the two codecs are the two sides.
+				// `proto:mutation-stability` also takes raw bytes and also matches this
+				// entry's target pattern, but it puts the bridge on *both* sides —
+				// `first.value` against `second.value` across decode → encode → decode
+				// — so a fixed point it fails to reach on this field is the bridge
+				// disagreeing with itself, which no renumbering explains. Named rather
+				// than excluded, so a new cross-codec byte-level target has to be
+				// added here deliberately instead of inheriting the excuse.
+				if (divergence.target !== 'proto:mutation-agreement') return false
 				if (!namesField(divergence.local) && !namesField(divergence.upstream)) return false
 				return renumberingIsTheWholeDifference(divergence)
 			}

--- a/src/__fuzz__/harness/divergence.ts
+++ b/src/__fuzz__/harness/divergence.ts
@@ -851,6 +851,23 @@ const sameShape = (left: unknown, right: unknown): boolean => {
 }
 
 /**
+ * True when deleting `pollResultSnapshotMessageV3` closes the gap completely.
+ *
+ * The renumbering shows up as the field being present on exactly one side, so
+ * the test is the shape rather than the name: remove the key wherever it
+ * appears, and the two decodes have to become identical *and* have differed
+ * before. A finding that carries a second changed value, or a second missing
+ * field, survives the deletion and is not this entry — which is what keeps a
+ * real decoder difference on a message that happens to hold this field from
+ * riding along with a renumbering that is already decided.
+ */
+const renumberingIsTheWholeDifference = (divergence: Divergence): boolean => {
+	const mine = withoutKey(normalise(divergence.local), 'pollResultSnapshotMessageV3')
+	const theirs = withoutKey(normalise(divergence.upstream), 'pollResultSnapshotMessageV3')
+	return sameShape(mine, theirs) && !sameShape(normalise(divergence.local), normalise(divergence.upstream))
+}
+
+/**
  * Renders either side of a divergence for a predicate to match against.
  *
  * `String(value)` yields "[object Object]" for the decoded objects these
@@ -1534,10 +1551,13 @@ export const KNOWN_DIVERGENCES: readonly KnownDivergence[] = [
 		// so a real regression on either would have been excused whenever the
 		// generated input happened to carry this field.
 		target: /^proto:|^wire:upstream-readable$/u,
-		status: 'open',
+		status: 'intended',
 		reason:
-			'Message.pollResultSnapshotMessageV3 is field 115 in the bridge codec and field 114 upstream — the only such disagreement across all 2421 non-map fields. ALREADY TRACKED, and documented in exactly these terms: scripts/compatibility/__tests__/wire-fidelity.test.ts pins it as KNOWN_DIVERGENT and proto-runtime-audit.ts lists it in KNOWN_WIRE_GAPS. The proto:field-numbers sweep exists because it proves the question is answered exhaustively rather than by a hand-kept list — it found this one and nothing else, which is the useful result.',
-		review: '2026-10-01',
+			'Message.pollResultSnapshotMessageV3 is field 115 in the bridge codec and field 114 upstream — the only such disagreement across all 2421 non-map fields. Decided against the client rather than between the two libraries: WhatsApp Web assigns 115 and leaves 114 unassigned. Its own field table, in module WAWebProtobufsE2E.pb of the WA Web bundle for WhatsApp 2.3000.1045368834, reads `newsletterFollowerInviteMessageV2:[113,...],pollResultSnapshotMessageV3:[115,...],newsletterAdminProfileMessage:[116,...]`, and the whatspec IR extracted from that bundle spells the same run at generated/proto/WAProto.proto:3459. So the bridge is conforming and upstream is not: baileys 7.0.0-rc13 declares the field at 114 (WAProto/WAProto.proto:2161) and its generated codec follows — encode writes tag 914 (WAProto/index.js:36333), decode reads case 114 (:36722) — which means a poll result snapshot it sends lands on a number WhatsApp does not read, and one WhatsApp sends is dropped. Minimal reproducer: proto.Message.encode({pollResultSnapshotMessageV3:{name:""}}).finish() is 9207020a00 where the bridge and the client both write 9a07020a00, and proto.Message.decode(Buffer.from("9a07020a00","hex")) reads nothing back. Nothing else in Message claims either number on either side, so neither spelling can misframe another field. ALREADY TRACKED as a difference: scripts/compatibility/__tests__/wire-fidelity.test.ts pins it as KNOWN_DIVERGENT and proto-runtime-audit.ts lists it in KNOWN_WIRE_GAPS; what is new is which side conforms. It closes when upstream regenerates its proto, not here. The proto:field-numbers sweep exists because it proves the question is answered exhaustively rather than by a hand-kept list — it found this one and nothing else, which is the useful result.',
+		// Was 'open' pending a decision on which number is correct. The client
+		// answers that, so there is nothing left to choose: matching upstream here
+		// would mean writing a field WhatsApp does not read.
+		review: '2027-02-01',
 		// The field numbers, not just the name. Any finding mentioning the field was
 		// accepted, so a rejection of it, a corrupted value, or a decode difference
 		// with another cause was absorbed by the entry that describes a renumbering.
@@ -1549,7 +1569,21 @@ export const KNOWN_DIVERGENCES: readonly KnownDivergence[] = [
 		// two decodes of the same bytes — so there the claim is that the bridge
 		// read nothing where upstream read the field.
 		when: divergence => {
-			if (!text(divergence.input).includes('pollResultSnapshotMessageV3')) return false
+			// The generative targets name the field in their input, and every branch
+			// below is written against one of those spellings. The byte-level ones
+			// cannot: `proto:mutation-agreement` hands both decoders raw mutated
+			// bytes, so a payload that happens to carry tag 115 shows the renumbering
+			// only in the decoded sides — the bridge reads the field, upstream skips
+			// an unknown number — and this gate rejected all of them before any
+			// branch could look. Measured on seed 32688945698: 14 of the 47 unexcused
+			// mutation-agreement findings name the field, 12 of them have it as their
+			// whole difference, and the shape test still rejects the other 2, which
+			// carry a second changed value beside it.
+			const namesField = (value: unknown): boolean => text(value).includes('pollResultSnapshotMessageV3')
+			if (!namesField(divergence.input)) {
+				if (!namesField(divergence.local) && !namesField(divergence.upstream)) return false
+				return renumberingIsTheWholeDifference(divergence)
+			}
 			if (divergence.target === 'proto:field-numbers') {
 				return text(divergence.local).includes('115') && text(divergence.upstream).includes('114')
 			}
@@ -1578,9 +1612,7 @@ export const KNOWN_DIVERGENCES: readonly KnownDivergence[] = [
 					(divergence.detail ?? '').includes('; renumbering only')
 				)
 			}
-			const mine = withoutKey(normalise(divergence.local), 'pollResultSnapshotMessageV3')
-			const theirs = withoutKey(normalise(divergence.upstream), 'pollResultSnapshotMessageV3')
-			return sameShape(mine, theirs) && !sameShape(normalise(divergence.local), normalise(divergence.upstream))
+			return renumberingIsTheWholeDifference(divergence)
 		}
 	},
 	{

--- a/src/__fuzz__/harness/schema-context.ts
+++ b/src/__fuzz__/harness/schema-context.ts
@@ -107,12 +107,14 @@ const fieldFactsByPath = new Map<string, FieldFacts>()
  * Every number a field is written under, asking both encoders rather than one.
  *
  * The two disagree on exactly one field out of 2421 —
- * `Message.pollResultSnapshotMessageV3` is 114 upstream and 115 in the bridge —
- * and the payloads these scans read are bridge-produced, so upstream's number
- * alone leaves the bridge's spelling of that submessage looking like opaque
- * bytes. Both are recorded because both are correct, each for the encoder that
- * wrote the payload; nothing else in `Message` claims either number, on either
- * side, so recording both cannot make a different field misframe.
+ * `Message.pollResultSnapshotMessageV3` is 114 upstream and 115 in the bridge,
+ * and 115 is the number WhatsApp Web itself uses — and the payloads these scans
+ * read are bridge-produced, so upstream's number alone leaves the bridge's
+ * spelling of that submessage looking like opaque bytes. Both are recorded
+ * anyway: each is the number its own encoder wrote, and a scan that refused
+ * upstream's would misframe upstream's payloads for as long as upstream keeps
+ * writing it. Nothing else in `Message` claims either number, on either side,
+ * so recording both cannot make a different field misframe.
  *
  * Measured rather than listed: a hardcoded exception would be exactly the
  * hand-kept list the field-number sweep exists to replace. A field only one


### PR DESCRIPTION
Closes one `open` entry from the nightly (#56) with the client's answer, and makes it reach the target where it shows up most. One further finding is diagnosed but not acted on — it needs a call that is not mine.

## The divergence

`proto-field-number-mismatch` said the bridge writes `Message.pollResultSnapshotMessageV3` at field **115** and baileys 7.0.0-rc13 declares **114**, and was `open` — nobody had established which number is right.

### Reproduced

```sh
FUZZ_SEED=32688945698 FUZZ_MODE=deep FUZZ_ONLY="proto:mutation-agreement" \
  FUZZ_REPORT_DIR=/tmp/rep FUZZ_TIME_BUDGET_MS=180000 \
  node --expose-gc --test --test-timeout=900000 "./src/__fuzz__/proto-robustness.fuzz.test.ts"
```

47 unexcused findings, matching the nightly for that seed. Clustering them by the differing keys: **14 of the 47** are the bridge decoding `pollResultSnapshotMessageV3` where upstream decodes nothing.

### Layer isolated

Measured, not read, and in separate processes — `src/WAProto/runtime.ts` mutates the bridge namespace on import, so the raw bridge is measured on its own:

```
bridge   decodeProto('Message', 9207020a00)          -> {}
bridge   encodeProto('Message', {pollResultSnapshotMessageV3:{name:''}}) -> 9a07020a00
upstream proto.Message.decode(9207020a00)            -> {pollResultSnapshotMessageV3:{name:''}}
upstream proto.Message.encode(...).finish()          -> 9207020a00
```

`0x9207` is varint 914 = field 114; `0x9a07` is varint 922 = field 115. Not a decoder difference — a schema difference. Neither side reads the other's number.

### What the client does

WhatsApp Web assigns **115**, and leaves 114 unassigned. Its own field table, module `WAWebProtobufsE2E.pb` in the WA Web bundle for WhatsApp `2.3000.1045368834`:

```
https://static.whatsapp.net/rsrc.php/v4iKdU4/yK/l/en_US-j/OaHqXfmMAEyCrpuFvd-ku944UUbY4SUwX.js
sha256 657a32007737e50b0cb0292ce9c364e21e48291b558129753b25e3ec2a4c13b7
```

pinned in `whatspec/generated/bundles.lock.json`; the bytes I read hash to that value. The table reads:

```
newsletterFollowerInviteMessageV2: 113
pollResultSnapshotMessageV3:       115
newsletterAdminProfileMessage:     116
```

Quoted by field number and field name only. The third element of each entry is a minifier-assigned binding whose name is not stable across captures of the same bundle, so it is not part of the citation; the number is what is load-bearing, and 114 appears nowhere in the table.

The whatspec IR extracted from that same bundle agrees — `generated/proto/WAProto.proto:3459`, and its `Message` runs 113 → 115 → 116 with no 114 anywhere.

### Decision

**Upstream bug; we are already right.** The entry moves `open` → `intended`, with the citation and reproducer in its `reason`.

Rejected: matching upstream at 114. That is the compatibility-first default, and it is wrong here — it would mean encoding a poll result snapshot on a number WhatsApp does not read, and dropping the one WhatsApp sends. Compatibility with upstream is the goal while upstream is right; this is the case where it isn't.

The cross-references now say which side conforms — `KNOWN_WIRE_GAPS` in `scripts/compatibility/proto-runtime-audit.ts`, `KNOWN_DIVERGENT` in `scripts/compatibility/__tests__/wire-fidelity.test.ts`, and the both-numbers comment in `src/__fuzz__/harness/schema-context.ts` (which stays as it is: each number is the one its own encoder wrote, and refusing upstream's would misframe upstream's payloads for as long as upstream keeps writing it).

### The entry could not fire where the divergence shows

Its gate asked whether the **input** named the field. The generative targets spell it; the byte-level ones cannot — `proto:mutation-agreement` hands both decoders raw mutated bytes, so the renumbering shows only in the decoded sides. All 14 findings were rejected before any branch could look.

The gate now falls through to a shape test when the decoded sides name the field: delete the key on both sides, and the two must become identical *and* have differed before.

| | before | after |
|---|---|---|
| `proto:mutation-agreement` unexcused (seed 32688945698) | 47 | **35** |

12 absorbed; the **2** that also carry a second changed value (`ctwaSignals`, a corrupted `fileName`) are still reported, which is the point of testing the shape rather than the name.

### Two holes closed after review

Both raised by review bots on the first commit, both confirmed against the code, both fixed in 401e3f3.

**Conflicting values under both tags.** Nothing stops a mutated payload carrying tag 114 *and* tag 115, and then both decoders report the field — each reading its own number. Deleting the key from both sides compared equal however far apart the two values were, so a corrupted read of the renumbered field would have left on the renumbering's ticket. The shape test now requires the field to sit on one side only (`sharesKey`, a parallel walk, so a co-located occurrence nested inside a quoted message is caught too). Not reached by any finding measured so far — 0 of the 23 that name the field across `proto:mutation-agreement`, `proto:decode-parity`, `proto:round-trip` and `proto:encode-bytes` — which is why it needed writing down rather than assuming.

**`proto:mutation-stability` inheriting the excuse.** That target matches this entry's `^proto:` pattern and also takes raw bytes, but it puts the bridge on *both* sides (`first.value` against `second.value` across decode → encode → decode). A fixed point it fails to reach on this field is the bridge disagreeing with itself, which no renumbering explains. The fallback is now named to `proto:mutation-agreement`, so a new cross-codec byte-level target has to be added deliberately instead of inheriting it.

### Test that fails on revert

`excuses the field renumbering wherever it shows, and only when it is the whole difference` in `harness/__tests__/harness.test.ts`. Every guard verified by reverting it:

- restore the input-only gate → **fails**
- make the shape test return `true` unconditionally → **fails**
- remove the `sharesKey` guard → **fails**
- remove the `proto:mutation-agreement` restriction → **fails**

It pins both directions of the renumbering, both kinds of second difference, conflicting values flat and nested, a `proto:mutation-stability` finding, the already-agreeing case, and the number sweep's existing `115 vs 114` branch.

## To report upstream (baileys)

`Message.pollResultSnapshotMessageV3` is declared at field 114; WhatsApp Web assigns it 115. Consequence: a poll result snapshot baileys sends is written on a field the client does not declare, and one the client sends is silently dropped.

- `WAProto/WAProto.proto:2161` — `optional PollResultSnapshotMessage pollResultSnapshotMessageV3 = 114;`
- `WAProto/index.js:36333` — encode writes `w.uint32(914)` (field 114)
- `WAProto/index.js:36722` — decode reads `case 114:`

114 is the last field baileys' `Message` declares; the client's runs on to 116, 117, 118, 119, 120.

```js
const { proto } = await import('baileys')

const encoded = Buffer.from(proto.Message.encode({ pollResultSnapshotMessageV3: { name: 'x' } }).finish())
console.log('baileys encodes to     ', encoded.toString('hex'), '(tag 0x9207 = varint 914 = field 114)')

const fromClient = Buffer.from('9a07030a0178', 'hex') // tag 0x9a07 = varint 922 = field 115
console.log('client sends           ', fromClient.toString('hex'), '(tag 0x9a07 = varint 922 = field 115)')
console.log('baileys decodes it as  ', JSON.stringify(proto.Message.decode(fromClient)))
```

```
baileys encodes to      9207030a0178 (tag 0x9207 = varint 914 = field 114)
client sends            9a07030a0178 (tag 0x9a07 = varint 922 = field 115)
baileys decodes it as   {}
```

The fix is a proto regeneration on their side; nothing here needs to change when it lands, and the entry says so.

---

## One finding diagnosed, not acted on: `proto:decode-parity` never converges

24 unexcused on this seed, 17–29 on every nightly since the issue opened. **All 24 are compositions of gaps already in `KNOWN_WIRE_GAPS`** — I resolved every differing key path back to its declaring type through the schema and checked membership:

```
proto:decode-parity: 24/24 explained entirely by the documented gaps
```

They are unexcused because `DECODE_OMITTED_PATHS` in `harness/divergence.ts` is keyed by the **route from the decoded root** — `ContextInfo.quotedMessage.audioMessage.mediaKeyDomain` — where the gap is a property of the **declaring type**, `Message.AudioMessage.mediaKeyDomain`. There are six measured routes in that set and the generator finds new ones every night, so the count cannot converge. Every finding here is `mediaKeyDomain` under a holder nobody has hit yet, one of the three documented renames, `businessBroadcastAssociationAction`, or the renumbering above.

Keying by declaration would also be *safer* than the current route key: the comment defending the route key worries that a bare leaf name is not unique (`messageParamsJson` on two types), and a type-qualified key answers that directly, which a route key only does by accident of having been measured.

I did not make the change, because the obvious way to do it needs the schema inside `divergence.ts`, and that module deliberately depends on nothing but the harness. Two options, and this is the call I am asking for:

- **Tag it at the target.** `proto:decode-parity` already imports both codecs and the schema, and this is the established pattern here (`emptyStringCoercionTag`, `stanzaCarriesUnreadablePayload`, the `[renumbering only]` tag). The registry reads the tag. Costs: the gap list has to be reachable from the target, and it already exists in three places (`NOT_ENCODED_FIELDS`, `RENAMED_PROTO_FIELDS`, `KNOWN_WIRE_GAPS`) — a fourth copy would be worse than the problem, so this wants one canonical list first.
- **Let the registry read the schema table.** `src/WAProto/compatibility-schema.ts` is a static field table, not one of the two implementations under test, so it does not compromise the isolation the comment is actually defending. But it does widen a stated dependency rule, which is not mine to widen.

Either way the excused set stays exactly `KNOWN_WIRE_GAPS`, which `compat:audit:proto --strict` already enforces, and each underlying gap keeps its own `open` entry and stays printed every run.

### Not a finding: the `wire:upstream-readable` truncation is already fixed on main

An earlier revision of this description treated the nightly's `wire:upstream-readable: ~700–870 of 6250` warning as open, and proposed re-running the nightly at `1061bdb` and `0c049f8` to attribute it. **That would have been wasted work — #88 already diagnosed and fixed it**, and its commit message names this target and these numbers: 398 of 474 inputs on `wire:upstream-readable` produced an excused finding, each paying the shrink floor, "which is why that target reached 708 of 6250 inputs in the nightly's 180s and reported partial coverage as a pass."

#88 landed on `main` at 14:09 on 2026-08-24, after the 04:15 nightly, so the last run in #56 still shows the old figure. Running the nightly command verbatim on this branch — same seed, same 180 s budget, same glob, 4 cores as `ubuntu-latest` — **nothing truncates**: `wire:upstream-readable` completes 6250/6250, as does every other target. The next nightly is the confirmation, and no CI-side archaeology is needed.

## Validation

```
npm run format:check     pass
npm run lint             pass (tsc + oxlint)
npm test                 1407 pass, 0 fail, 1 skipped
npm run build            pass
npm run compat:audit:proto   byte-identical to before the change
npm run compat:audit:wire    byte-identical to before the change
```

Full deep fuzz with `FUZZ_STRICT_ALLOWLIST=1` on seed 32688945698: no stale entries, no entry past review, `proto-field-number-mismatch` no longer printed as an open finding. Unexcused, this branch vs the nightly for the same seed:

| target | nightly | this branch |
|---|---|---|
| `proto:decode-parity` | 24 | 24 |
| `proto:encode-bytes` | 8 | 1 |
| `proto:integers` | 13 | 0 |
| `proto:mutation-agreement` | 47 | **35** |
| `proto:round-trip` | 2 | 2 |
| **total** | **94** | **62** |

`encode-bytes` and `integers` are #88, already on `main`; the `mutation-agreement` drop is this branch.