### PR TITLE
fix(messages): give a poll and an event the message secret their sender needs

### DIFF
--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -167,6 +167,8 @@ export type PollMessageOptions = {
 	name: string
 	selectableCount?: number
 	values: string[]
+	/** 32 byte message secret to encrypt poll selections */
+	messageSecret?: Uint8Array
 	toAnnouncementGroup?: boolean
 }
 

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -541,30 +541,6 @@ export const generateWAMessageContent = async (
 			m.eventMessage.joinLink = (message.event.call === 'audio' ? CALL_AUDIO_PREFIX : CALL_VIDEO_PREFIX) + token
 		}
 
-		// The sender's copy of the key that encrypts responses to this event.
-		// `decryptEventResponse` takes it as `eventEncKey`, and the only place a
-		// caller can get it is the event message they sent — so an event created
-		// without one can never have its own responses read back. WhatsApp Web
-		// generates it here too, on the sender, at creation
-		// (`WAWebSendEventCreationMsgAction`:
-		// `messageSecret: self.crypto.getRandomValues(new Uint8Array(32))`), and
-		// refuses to build an event edit when it is missing
-		// (`WAWebCreateEncryptedEventEditMsgData` throws
-		// `EventCreationValidationError`).
-		//
-		// The core settles `messageSecret` on relay for messages that reach it
-		// without one — see the comment in `Socket/messages.ts` — but it settles it
-		// on the *wire*, where the caller never sees it. That is right for the
-		// reporting token and wrong for a key the caller has to keep.
-		//
-		// Spread rather than upstream's wholesale assignment: nothing else writes
-		// `messageContextInfo` on this branch today, so the two cannot differ, and
-		// this cannot silently drop a field a later change puts there.
-		m.messageContextInfo = {
-			...m.messageContextInfo,
-			messageSecret: message.event.messageSecret || randomBytes(32)
-		}
-
 		m.eventMessage.name = message.event.name
 		m.eventMessage.description = message.event.description
 		m.eventMessage.startTime = startTime
@@ -573,6 +549,32 @@ export const generateWAMessageContent = async (
 		m.eventMessage.extraGuestsAllowed = message.event.extraGuestsAllowed
 		m.eventMessage.isScheduleCall = message.event.isScheduleCall ?? false
 		m.eventMessage.location = message.event.location
+
+		// The sender's copy of the key that encrypts responses to this event;
+		// `decryptEventResponse` takes it as `eventEncKey`. WhatsApp Web writes it
+		// on the sender at creation (`WAWebSendEventCreationMsgAction`) and refuses
+		// to build an event edit without it (`WAWebCreateEncryptedEventEditMsgData`
+		// throws `EventCreationValidationError`).
+		//
+		// The core settles `messageSecret` on relay for messages that reach it
+		// without one — see the comment in `Socket/messages.ts` — but it settles it
+		// on the wire, where the caller never sees it. That is right for the
+		// reporting token and wrong for a key the caller has to keep.
+		//
+		// Written after `m.eventMessage`, for the reason spelled out on the poll
+		// branch below: the blocks that attach `contextInfo` take `Object.keys(m)[0]`
+		// as the content key. `event` is not `Mentionable` or `Contextable` today,
+		// so this is ordering that stays correct rather than ordering that is
+		// currently load-bearing — but it costs nothing and the poll branch shows
+		// what getting it wrong looks like.
+		//
+		// Spread rather than upstream's wholesale assignment: nothing else writes
+		// `messageContextInfo` on this branch today, so the two cannot differ, and
+		// this cannot silently drop a field a later change puts there.
+		m.messageContextInfo = {
+			...m.messageContextInfo,
+			messageSecret: message.event.messageSecret || randomBytes(32)
+		}
 	} else if (hasNonNullishProperty(message, 'poll')) {
 		message.poll.selectableCount ||= 0
 		message.poll.toAnnouncementGroup ||= false
@@ -585,21 +587,6 @@ export const generateWAMessageContent = async (
 			throw new Boom(`poll.selectableCount in poll should be >= 0 and <= ${message.poll.values.length}`, {
 				statusCode: 400
 			})
-		}
-
-		// Same as the event branch above: this is the key that encrypts votes, and
-		// `decryptPollVote` takes it as `pollEncKey`. Without it here the poll goes
-		// out fine but its own sender can never read the votes, because the copy
-		// they store — the message `sendMessage` returns and emits as
-		// `messages.upsert` — is this object, and only `key.id` is patched from the
-		// relay result. WhatsApp Web generates it on the sender at creation as well
-		// (`WAWebPollsSendPollCreationMsgAction`:
-		// `messageSecret: ... self.crypto.getRandomValues(new Uint8Array(32))`) and
-		// reuses the stored one for poll edits
-		// (`WAWebPollsGeneratePollEditMessageProto`).
-		m.messageContextInfo = {
-			...m.messageContextInfo,
-			messageSecret: message.poll.messageSecret || randomBytes(32)
 		}
 
 		const pollCreationMessage = {
@@ -619,6 +606,30 @@ export const generateWAMessageContent = async (
 				// poll for multiple choice polls
 				m.pollCreationMessage = pollCreationMessage
 			}
+		}
+
+		// The key that encrypts the votes. `decryptPollVote` takes it as
+		// `pollEncKey`, and without it here the poll goes out fine but its own
+		// sender can never read the votes: the copy they store — the message
+		// `sendMessage` returns and emits as `messages.upsert` — is this object,
+		// and only `key.id` is patched from the relay result. WhatsApp Web writes it
+		// on the sender at creation too (`WAWebPollsSendPollCreationMsgAction`) and
+		// reuses the stored one for poll edits
+		// (`WAWebPollsGeneratePollEditMessageProto`).
+		//
+		// After the payload, not before, and that ordering is load-bearing: the
+		// `mentions` and `contextInfo` blocks below pick their target with
+		// `Object.keys(m)[0]`, so a `messageContextInfo` written first becomes the
+		// content key they attach to. `contextInfo` is not a field of
+		// `IMessageContextInfo`, so the encoder drops it and a poll sent with
+		// mentions loses them silently. `poll` is `Mentionable & Contextable`, so
+		// that is a combination callers can and do write. Upstream assigns it
+		// before the payload and has exactly that bug; measured on
+		// `{poll, mentions:['x@s.whatsapp.net']}`, its output carries no
+		// `mentionedJid` at all.
+		m.messageContextInfo = {
+			...m.messageContextInfo,
+			messageSecret: message.poll.messageSecret || randomBytes(32)
 		}
 	} else if (hasNonNullishProperty(message, 'sharePhoneNumber')) {
 		m.protocolMessage = {

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -31,6 +31,7 @@ import { proto } from '../WAProto/runtime.ts'
 import { isJidGroup, isJidNewsletter, isJidStatusBroadcast, jidNormalizedUser } from '../WABinary/index.ts'
 import { assertArgumentDomain } from './argument-domain.ts'
 import { Boom } from './boom.ts'
+import { randomBytes } from 'node:crypto'
 import { sha256 } from './crypto.ts'
 import { getKeyAuthor, toNumber, unixTimestampSeconds } from './generics.ts'
 import type { ILogger } from './logger.ts'
@@ -540,6 +541,30 @@ export const generateWAMessageContent = async (
 			m.eventMessage.joinLink = (message.event.call === 'audio' ? CALL_AUDIO_PREFIX : CALL_VIDEO_PREFIX) + token
 		}
 
+		// The sender's copy of the key that encrypts responses to this event.
+		// `decryptEventResponse` takes it as `eventEncKey`, and the only place a
+		// caller can get it is the event message they sent — so an event created
+		// without one can never have its own responses read back. WhatsApp Web
+		// generates it here too, on the sender, at creation
+		// (`WAWebSendEventCreationMsgAction`:
+		// `messageSecret: self.crypto.getRandomValues(new Uint8Array(32))`), and
+		// refuses to build an event edit when it is missing
+		// (`WAWebCreateEncryptedEventEditMsgData` throws
+		// `EventCreationValidationError`).
+		//
+		// The core settles `messageSecret` on relay for messages that reach it
+		// without one — see the comment in `Socket/messages.ts` — but it settles it
+		// on the *wire*, where the caller never sees it. That is right for the
+		// reporting token and wrong for a key the caller has to keep.
+		//
+		// Spread rather than upstream's wholesale assignment: nothing else writes
+		// `messageContextInfo` on this branch today, so the two cannot differ, and
+		// this cannot silently drop a field a later change puts there.
+		m.messageContextInfo = {
+			...m.messageContextInfo,
+			messageSecret: message.event.messageSecret || randomBytes(32)
+		}
+
 		m.eventMessage.name = message.event.name
 		m.eventMessage.description = message.event.description
 		m.eventMessage.startTime = startTime
@@ -560,6 +585,21 @@ export const generateWAMessageContent = async (
 			throw new Boom(`poll.selectableCount in poll should be >= 0 and <= ${message.poll.values.length}`, {
 				statusCode: 400
 			})
+		}
+
+		// Same as the event branch above: this is the key that encrypts votes, and
+		// `decryptPollVote` takes it as `pollEncKey`. Without it here the poll goes
+		// out fine but its own sender can never read the votes, because the copy
+		// they store — the message `sendMessage` returns and emits as
+		// `messages.upsert` — is this object, and only `key.id` is patched from the
+		// relay result. WhatsApp Web generates it on the sender at creation as well
+		// (`WAWebPollsSendPollCreationMsgAction`:
+		// `messageSecret: ... self.crypto.getRandomValues(new Uint8Array(32))`) and
+		// reuses the stored one for poll edits
+		// (`WAWebPollsGeneratePollEditMessageProto`).
+		m.messageContextInfo = {
+			...m.messageContextInfo,
+			messageSecret: message.poll.messageSecret || randomBytes(32)
 		}
 
 		const pollCreationMessage = {

--- a/src/__tests__/poll-event-message-secret.test.ts
+++ b/src/__tests__/poll-event-message-secret.test.ts
@@ -1,0 +1,92 @@
+import { Buffer } from 'node:buffer'
+import { describe, it } from 'node:test'
+import type { PollMessageOptions } from '../Types/index.ts'
+import { generateWAMessageContent } from '../Utils/messages.ts'
+import { expect } from './expect.ts'
+
+/**
+ * A poll and an event each carry the key that encrypts the replies to them, in
+ * `messageContextInfo.messageSecret`.
+ *
+ * It has to be written by the *sender*, at creation, because the sender is the
+ * only party that can keep it: `decryptPollVote` takes it as `pollEncKey` and
+ * `decryptEventResponse` as `eventEncKey`, and the only copy a caller ever gets
+ * is the message `sendMessage` returns and emits as `messages.upsert` — which is
+ * this object, with only `key.id` patched from the relay result. Generated
+ * without one, the poll still sends and other clients still vote; its own sender
+ * simply can never read those votes.
+ *
+ * The core settles `messageSecret` on relay for messages that arrive without one
+ * (see `Socket/messages.ts`), but it settles it on the wire, where the caller
+ * cannot see it — right for the reporting token, wrong for a key the caller has
+ * to keep. WhatsApp Web generates it on the sender at creation for both
+ * (`WAWebPollsSendPollCreationMsgAction`, `WAWebSendEventCreationMsgAction`) and
+ * refuses to build an event edit without it
+ * (`WAWebCreateEncryptedEventEditMsgData`).
+ */
+
+// The same shape `pin-message.test.ts` uses: neither branch under test reaches
+// the logger or the media client, and stubbing them would only hide it if one
+// started to.
+const options = () => ({ logger: undefined, waClient: undefined as never })
+
+describe('poll and event carry a sender-side messageSecret', () => {
+	it('generates a 32-byte secret for every poll shape', async () => {
+		// All three poll protos, since the branch that picks between them is the
+		// one the secret is written beside: a regression that moved the write
+		// inside a shape check would still pass on the shape it was left in.
+		const shapes: PollMessageOptions[] = [
+			{ name: 'q', values: ['a', 'b'], selectableCount: 1 },
+			{ name: 'q', values: ['a', 'b'], selectableCount: 2 },
+			{ name: 'q', values: ['a', 'b'], toAnnouncementGroup: true }
+		]
+		for (const poll of shapes) {
+			const content = await generateWAMessageContent({ poll }, options())
+			const secret = content.messageContextInfo?.messageSecret
+			expect(secret).toBeTruthy()
+			expect(secret!.length).toEqual(32)
+		}
+	})
+
+	it('generates a 32-byte secret for an event', async () => {
+		const content = await generateWAMessageContent(
+			{ event: { name: 'e', startDate: new Date(1_700_000_000_000) } },
+			options()
+		)
+		const secret = content.messageContextInfo?.messageSecret
+		expect(secret).toBeTruthy()
+		expect(secret!.length).toEqual(32)
+	})
+
+	it('honours a caller-supplied secret rather than replacing it', async () => {
+		// The public contract upstream declares on `PollMessageOptions` and
+		// `EventMessageOptions`. A caller that persists its own key — the reason to
+		// pass one at all — gets a message it cannot decrypt if this is regenerated.
+		const mine = new Uint8Array(32).fill(0x2b)
+
+		const poll = await generateWAMessageContent(
+			{ poll: { name: 'q', values: ['a'], selectableCount: 1, messageSecret: mine } },
+			options()
+		)
+		expect([...(poll.messageContextInfo?.messageSecret ?? [])]).toEqual([...mine])
+
+		const event = await generateWAMessageContent(
+			{ event: { name: 'e', startDate: new Date(1_700_000_000_000), messageSecret: mine } },
+			options()
+		)
+		expect([...(event.messageContextInfo?.messageSecret ?? [])]).toEqual([...mine])
+	})
+
+	it('draws a fresh secret per message when the caller supplies none', async () => {
+		// Reusing one key across two polls would let a voter on the first decrypt
+		// votes on the second, so "has a secret" is not enough on its own.
+		const secretOf = async () => {
+			const content = await generateWAMessageContent({ poll: { name: 'q', values: ['a'] } }, options())
+			return Buffer.from(content.messageContextInfo?.messageSecret ?? []).toString('hex')
+		}
+		const first = await secretOf()
+		const second = await secretOf()
+		expect(first.length).toEqual(64)
+		expect(first).not.toBe(second)
+	})
+})

--- a/src/__tests__/poll-event-message-secret.test.ts
+++ b/src/__tests__/poll-event-message-secret.test.ts
@@ -77,6 +77,41 @@ describe('poll and event carry a sender-side messageSecret', () => {
 		expect([...(event.messageContextInfo?.messageSecret ?? [])]).toEqual([...mine])
 	})
 
+	it('writes the secret after the content key, so mentions and contextInfo survive', async () => {
+		// `poll` is `Mentionable & Contextable`, and the blocks that attach those
+		// pick their target with `Object.keys(m)[0]`. A `messageContextInfo` written
+		// *before* the poll payload becomes that key, and since `contextInfo` is not
+		// a field of `IMessageContextInfo` the encoder drops it — the poll sends
+		// with its mentions silently gone. Upstream assigns it before the payload
+		// and has exactly that bug.
+		const mentioned = await generateWAMessageContent(
+			{ poll: { name: 'q', values: ['a', 'b'], selectableCount: 1 }, mentions: ['x@s.whatsapp.net'] },
+			options()
+		)
+		expect(Object.keys(mentioned)[0]).toBe('pollCreationMessageV3')
+		expect(mentioned.pollCreationMessageV3?.contextInfo?.mentionedJid).toEqual(['x@s.whatsapp.net'])
+		// and the secret is still there — the ordering fix must not undo the fix.
+		expect(mentioned.messageContextInfo?.messageSecret?.length).toEqual(32)
+
+		const contextual = await generateWAMessageContent(
+			{
+				poll: { name: 'q', values: ['a', 'b'], selectableCount: 1 },
+				contextInfo: { forwardingScore: 3, isForwarded: true }
+			},
+			options()
+		)
+		expect(contextual.pollCreationMessageV3?.contextInfo?.forwardingScore).toEqual(3)
+		expect(contextual.messageContextInfo?.messageSecret?.length).toEqual(32)
+
+		// The event branch keeps its content key first for the same reason, even
+		// though `event` is not mentionable today.
+		const event = await generateWAMessageContent(
+			{ event: { name: 'e', startDate: new Date(1_700_000_000_000) } },
+			options()
+		)
+		expect(Object.keys(event)[0]).toBe('eventMessage')
+	})
+
 	it('draws a fresh secret per message when the caller supplies none', async () => {
 		// Reusing one key across two polls would let a voter on the first decrypt
 		// votes on the second, so "has a secret" is not enough on its own.


### PR DESCRIPTION
A bug in this library, not a registry decision. A poll sent through baileyrs can never have its own votes read back by the account that sent it.

## The defect

A poll carries the key that encrypts its votes, and an event the key that encrypts its responses, in `messageContextInfo.messageSecret`. Neither branch of `generateWAMessageContent` wrote one.

That key is only useful to the sender, and the sender is the only party who can keep it:

- `decryptPollVote` takes it as `pollEncKey` (`Utils/process-message.ts:141`)
- `decryptEventResponse` takes it as `eventEncKey` (`Utils/process-message.ts:151`)
- the only copy a caller ever gets is the message `sendMessage` returns and emits as `messages.upsert` — and that is the object built here, with **only `key.id`** patched from the relay result (`Socket/messages.ts`)

So the poll sends fine and other clients vote on it fine. Its sender is the one who cannot read the votes.

## Reproduced

A differential over `generateWAMessageContent`, non-media content only (media reaches the upload stub, which is the reason this helper has never been fuzzed — see the "What this does not cover" table in `src/__fuzz__/README.md`). 22 content shapes, ours against `baileys`:

```
agree 2 · differ 20 · both-threw 1
```

Every one of the 20 was the same thing — upstream attaches `messageContextInfo.messageSecret`, we attach none:

```
### poll
  ours    : {"pollCreationMessageV3":{"name":"q","options":[…],"selectableOptionsCount":1}}
  upstream: {"messageContextInfo":{"messageSecret":"blN+aFLY…"},
             "pollCreationMessageV3":{"name":"q","options":[…],"selectableOptionsCount":1}}
```

## Layer isolated — and most of that difference is *not* a bug

18 of the 20 are upstream's `shouldIncludeReportingToken(m)` path (`Utils/messages.js:543-548`), which stamps a generic secret onto every content type. Ours is deliberately elsewhere: the core settles `messageSecret` / `reportingTokenVersion` on relay, reusing a caller-set one rather than replacing it. That decision is documented in `Socket/messages.ts` and pinned by `relay-message-context-info.test.ts` ("keeps a caller-set messageSecret"). **Not reopened.**

The poll and event branches are a different claim, and the documented decision does not cover them. Upstream writes those two independently of the reporting-token gate:

```js
// Utils/messages.js:440  (poll)      and  :415 (event)
m.messageContextInfo = { messageSecret: message.poll.messageSecret || randomBytes(32) };
```

The core settling a secret *on the wire* is correct for a reporting token, which nobody has to read back. It is wrong for a key the caller has to keep: by the time the core invents one, the object the caller stores has already been built without it.

## What the client does

WhatsApp Web generates the secret **on the sender, at creation**, for both — WA Web bundle for WhatsApp `2.3000.1045368834`:

| module | what it does |
|---|---|
| `WAWebPollsSendPollCreationMsgAction` | poll creation sets `messageSecret: … self.crypto.getRandomValues(new Uint8Array(32))` |
| `WAWebSendEventCreationMsgAction` | event creation sets `messageSecret: self.crypto.getRandomValues(new Uint8Array(32))` |
| `WAWebPollsGeneratePollEditMessageProto` | a poll edit reuses the **stored** secret: `messageContextInfo:{messageSecret:t.messageSecret}` |
| `WAWebCreateEncryptedEventEditMsgData` | reads `t.messageSecret` and **throws `EventCreationValidationError` when it is null** |

The last two are the ones that settle it: the client treats the secret as something the sender persists with the message and needs again later. A sender that never had one is in a state the client refuses to be in.

## Decision

**Our bug, in both branches.** Fixed by writing the secret at creation, honouring a caller-supplied one:

```ts
m.messageContextInfo = {
  ...m.messageContextInfo,
  messageSecret: message.poll.messageSecret || randomBytes(32)
}
```

Spread rather than upstream's wholesale `m.messageContextInfo = { … }`: nothing else writes `messageContextInfo` on either branch today, so the two cannot differ, and the spread cannot silently drop a field a later change puts there.

Rejected: teaching the core to hand the settled secret back so `sendMessage` could merge it into `fullMsg`. It would work, but it makes a key the caller owns depend on a round trip through the bridge, needs a bridge API change for a value the JS side can generate correctly on its own, and still leaves `generateWAMessage` — a public, standalone API — returning a poll with no secret.

### Public type

`PollMessageOptions` was also missing the field upstream declares:

```ts
/** 32 byte message secret to encrypt poll selections */
messageSecret?: Uint8Array
```

So a caller persisting its own key could not pass one, and would not have been honoured if it had. `EventMessageOptions` already declared it — and was ignoring it, which is the same defect one layer down.

**The declaration auditor cannot see this.** `compat:audit` compares the named alias on each side and prints `PollMessageOptions` for both without expanding it, so a property missing *inside* a shared type name reads as a match. That is why a field upstream has carried all along went unnoticed. Not fixed here — widening the auditor to expand aliases is its own change with its own blast radius — but it is worth someone's call.

## Test that fails on revert

`src/__tests__/poll-event-message-secret.test.ts`, four cases: every poll shape (v2/v3/plain, because the branch that picks between them is the one the write sits beside), an event, a caller-supplied secret being honoured, and two polls drawing different secrets — reusing one key across polls would let a voter on the first decrypt votes on the second, so "has a secret" is not enough on its own.

Verified three ways, each failing differently:

| reverted | result |
|---|---|
| poll branch only | 3 of 4 fail |
| event branch only | 2 of 4 fail |
| keep the write, drop `message.poll.messageSecret \|\|` | 1 of 4 fails |

## Validation

```
npm run format:check     pass
npm run lint             pass (tsc + oxlint)
npm test                 1411 pass, 0 fail, 1 skipped  (1407 before; +4 new)
npm run build            pass
npm run compat:audit:proto   byte-identical to main
npm run compat:audit:wire    byte-identical to main
```

Send-path fuzz on the surface this changes, strict allowlist:

```sh
FUZZ_STRICT_ALLOWLIST=1 FUZZ_MODE=deep FUZZ_TIME_BUDGET_MS=30000 \
  node --expose-gc --test --test-timeout=900000 "./src/__fuzz__/wire-fidelity.fuzz.test.ts"
# 3 pass, 0 fail
```

---

## Also measured, not acted on: the event buffer

While looking for this I rebuilt the `createBufferedFunction` consolidation differential that `src/__fuzz__/README.md` records as *written and withdrawn* ("worth closing"). 20,000 generated event sequences over all 12 bufferable events, classified by direction:

| | signatures |
|---|---|
| only **we** lose data upstream keeps | **0** |
| only **upstream** loses data we keep | 70 |
| both differ | 589 — all the same `null` vs `undefined` normalisation |

So the withdrawn differential's two findings are both upstream defects, and we are the correct side of each:

- **`groups.update` drops every repeat.** `event-buffer.js:499-502` puts the `Object.assign` *inside* `if (!data.groupUpdates[id])`, so only the first update for a group in a buffer window survives. Two updates for one group — say `subject` then `desc` — deliver as `{id, subject}`, and `desc` is gone. Ours merges unconditionally. Not documented anywhere; worth reporting upstream.
- **`contacts.upsert` discards its own merge.** `event-buffer.js:373-376` computes `upsert = Object.assign(data.contactUpdates[id], trimUndefined(contact))` into a local and never writes it back to `data.contactUpserts`, so a pending `contacts.update` is dropped rather than folded in. Our code already documents this in the opposite direction ("Fields only the update carried still survive, which upstream drops").

The 589 "both differ" are `messaging-history.set` carrying `syncType: null` / `peerDataRequestSessionId: null`, which we normalise to `undefined`. I checked whether real values survive before calling it anything: `syncType` 0, 2 and a string id all round-trip identically on both sides, so this is `null` normalisation and not a lost sync type.

Landing that as a fuzz target is a separate PR — it needs allowlist entries for the two upstream defects rather than riding in on this one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NXnMq9axCY3FqhNX5JJoHA)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes polls and events missing a sender-side messageSecret, which blocked senders from decrypting their own votes/responses. Previously `generateWAMessageContent` omitted `messageContextInfo.messageSecret` and, when present, writing it before the payload could drop poll mentions/contextInfo; now we set it at creation and write it after the payload.

- Write `messageContextInfo.messageSecret` for `poll` and `event` after the content payload, preserving existing `messageContextInfo` fields and keeping poll mentions/contextInfo intact.
- Honor `message.poll.messageSecret` and `message.event.messageSecret`; otherwise generate a fresh 32‑byte key per message.
- Add `messageSecret?: Uint8Array` to `PollMessageOptions` so callers can supply a persisted key.
- No wire/proto changes; compat audits unchanged. Tests cover all poll shapes and events for presence, honoring caller input, per-message uniqueness, and mentions/contextInfo preservation.

<sup>Written for commit 5766f68bcf60064a431eabdf1209f30d65303cf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for secure message secrets in poll and event messages.
  * Callers can provide a message secret, or one is generated automatically when omitted.
  * Poll and event messages now receive a fresh 32-byte secret for encryption.

* **Bug Fixes**
  * Preserved message mentions and context information while adding encryption secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->