### PR TITLE
deps: move to bridge 0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,12 @@ A few behaviors that differ from upstream — almost always to your advantage:
   the same message two or three times; the engine now recognises the repeat and
   emits one. It is a short-lived, in-memory window (five minutes), so the one
   case still open is a sender whose retry spans a restart of your process. If
-  your handler has side effects, keying them on `key.id` remains the thing that
-  makes it safe — that was true before this and is still true for the gap.
+  your handler has side effects, keying them on the whole `key` — `remoteJid`,
+  `id`, `fromMe` and `participant` — remains the thing that makes it safe. Not
+  on `id` alone: the id is the sending client's to choose, so two participants
+  of one group can pick the same one, and a handler that keys on it would drop
+  the second person's message rather than a duplicate. That is why the engine's
+  own check carries the sender too.
 - **`Boom` ships in the box.** baileyrs exports its own
   `@hapi/boom`-compatible `Boom`, so the existing
   `(err as Boom).output.statusCode` pattern works unchanged. If your

--- a/README.md
+++ b/README.md
@@ -243,6 +243,15 @@ A few behaviors that differ from upstream — almost always to your advantage:
   `connectTimeoutMs`, `qrTimeout`, `printQRInTerminal`, `ignoreOfflineMessages`,
   `downloadHistory`, `agent`, `fetchAgent`, `mobile`, `mediaCache`,
   `userDevicesCache`, `callOfferCache` and `placeholderResendCache`.
+- **A sender's resend reaches you once, not once per delivery.** When a
+  sender's network is bad, their client re-runs its own outbox and sends the
+  same message again — same `key.id`, re-encrypted. Upstream Baileys emits a
+  `messages.upsert` for each of those deliveries, so an auto-reply bot answers
+  the same message two or three times; the engine now recognises the repeat and
+  emits one. It is a short-lived, in-memory window (five minutes), so the one
+  case still open is a sender whose retry spans a restart of your process. If
+  your handler has side effects, keying them on `key.id` remains the thing that
+  makes it safe — that was true before this and is still true for the gap.
 - **`Boom` ships in the box.** baileyrs exports its own
   `@hapi/boom`-compatible `Boom`, so the existing
   `(err as Boom).output.statusCode` pattern works unchanged. If your

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^9.1.4",
-        "@oxidezap/whatsapp-rust-bridge": "0.18.0",
+        "@oxidezap/whatsapp-rust-bridge": "0.19.0",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.18.0.tgz",
-      "integrity": "sha512-N0F9mvPrFxPluV/ruUbQmm75nRjX4Il+BMi93C4tw5BCvvgSoeKmsHpAvxu3QNKscUbw8yVLvnbmLVYay9SATg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.19.0.tgz",
+      "integrity": "sha512-1105rs8yu21w5beUR1czeCu3YZNBa2Z3FW3IsfC33B2DSTDfX2bmzCukmR57K/MrUrkmfykeVfWv+7GlYRDKRQ==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.1.4",
-    "@oxidezap/whatsapp-rust-bridge": "0.18.0",
+    "@oxidezap/whatsapp-rust-bridge": "0.19.0",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"


### PR DESCRIPTION
## Summary

Bridge 0.19.0 is one fix and a set of engine work below the surface. The fix is the reason to take it: [whatsapp-rust#1352](https://github.com/oxidezap/whatsapp-rust/pull/1352), reported here as a bot answering the same message two or three times.

## What landed

**A sender's resend no longer becomes a second `messages.upsert`.** When a sender's network is bad their client re-runs its own outbox: same message id, fresh ciphertext on a new ratchet iteration. The Signal ratchet calls a repeat a duplicate only when the *same* iteration comes back — which covers the byte-identical stanza the server replays and nothing else — so every resend decrypted cleanly and was handed over as another message. The engine now recognises the repeat by message identity and hands it over once, acking the rest.

It was reported by an operator whose bot replied three times to one ping, intermittently and only for some senders. The engine's own production logs put it at 0.33% to 1.0% of group message ids, with up to six deliveries of a single id, and the same repeated ids appear in two different bots' logs — which places the resend at the sender, not in any client.

Worth knowing about the shape of the fix, because it decides what is still open:

- The window is **in-memory and short-lived** (five minutes, sized against the measured resend interval), so a sender still retrying across a restart of your process delivers twice.
- The identity is `(chat, id, sender)`, not `(chat, id)`. That is not caution for its own sake: the same logs caught **two different participants of one group using the same 32-character id, 116 seconds apart**. Keying without the sender would have dropped the second person's message.
- What is suppressed is the *event*. A message secret the resend carried is still captured, and an app-state key-share request it carried is still scheduled, so nothing that the resend was also delivering is lost with it.

**PN/LID pairs are now harvested from conversation metadata** during history sync, from a source that was previously read past, so the mapping fills in from more of what already arrives. The same engine change **stops logging push names** — a display name, and therefore PII. A consumer that greps the engine's logs for them will no longer find them.

**Engine performance**, all below the bridge's surface and none of it changing what crosses: media upload/download batch crypto with in-place decryption, history-sync LID mappings, tctoken candidates, group secret allocations, usync query building, prekey extraction and sender key allocations.

## Surface

Unchanged. Diffing the shipped declarations between 0.18.0 and 0.19.0, the only file that moves is `whatsapp_rust_bridge.d.ts` and the only change in it is six renumbered `__wasm_bindgen_func_elem_*` internals. `index.d.ts`, `proto-types.d.ts`, `proto.d.ts`, `proto-namespace.d.ts`, `proto-reader.d.ts` and `wire-info.d.ts` are byte-identical, which is expected: the engine range touches no `waproto`, no `.proto` and no generated catalog.

So there is no adapter here to update, and no audit to re-baseline.

## Not carried

- **VoIP.** The engine range renames `CallHandle::hangup` to `hangup_local` and makes `set_muted` async and fallible — a real break upstream of us that reaches nothing, because the bridge compiles no VoIP surface.
- **The chat store** moved to its own repository in the same range. Nothing here referenced it.
- **The gate's controls.** The engine exposes a cache knob for the suppression window (capacity 0 turns it off) and two counters that say what it did — `messages_suppressed_duplicate` and the cache occupancy. The bridge surfaces none of the three, so from here the window cannot be tuned or disabled, and a host cannot tell "a message went missing" apart from "the engine collapsed a resend". Flagged in [bridge#86](https://github.com/oxidezap/whatsapp-rust-bridge/pull/86) rather than decided inside a bump; exposing it is a change of its own.

## Compatibility

Behaviour only, and it is a **deliberate divergence from upstream**: upstream Baileys emits one `messages.upsert` per wire delivery, so it answers a resent message as many times as the sender sent it. This package now emits one. A consumer counting deliveries will see fewer; a consumer answering messages will answer once, which is the point.

Nothing changes about what a caller passes or receives, no method was renamed, no event payload changed shape.

The README's **Gotchas** — the list of behaviours that differ from upstream — gains a bullet for it, including the restart gap and the standing advice that a handler with side effects should key them on `key.id` regardless. That advice was already the right one before this change and remains the thing that closes the gap this leaves.

## Validation

Nothing run locally. The bump is a lockfile change plus a README bullet, the bridge declarations were diffed rather than trusted (see **Surface**), and `npm test`, `npm run lint`, `npm run format:check` and `npm run build` all run on this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@oxidezap/whatsapp-rust-bridge` from 0.18.0 to 0.19.0, fixing a bug where a sender's resend was delivered as multiple `messages.upsert` events — a bot answering messages could respond two or three times to one message.

- Resends (same message id, fresh ciphertext) are now recognized and emitted once; upstream Baileys still emits per wire delivery, so this is a deliberate divergence.
- The dedupe window is in-memory for five minutes and keyed by `(chat, id, sender)`, so a retry spanning a process restart still delivers twice, and two participants reusing an id in one group are not collapsed.
- Only the event is suppressed — a resend's message secret and app-state key-share request are still captured.
- The engine also stops logging push names (PII) and harvests PN/LID pairs from conversation metadata; both are behavior-only changes.
- The declared surface is unchanged — the `.d.ts` diff is just renumbered `__wasm_bindgen_func_elem_*` internals — so this PR is a version bump plus a README Gotchas bullet, which now advises keying side effects on the whole `key` (`remoteJid`, `id`, `fromMe`, `participant`) rather than `id` alone.

<sup>Written for commit a3d750a6ac90f5b7480c765d7e03898bd12c516b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Re-sent messages are now reported as a single message event instead of generating duplicate events during repeated delivery.
  * Duplicate detection applies within a five-minute window, improving message processing consistency.

* **Documentation**
  * Added guidance explaining repeated-message handling and recommending message IDs as the safe way to identify messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->