### PR TITLE
ci(preview): publish a pkg.pr.new build for every commit and pull request

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,72 @@
+name: Preview Release
+
+# Continuous releases through pkg.pr.new: every commit on main and every pull
+# request gets an installable, npm-compatible tarball. Someone hitting a bug can
+# try the fix from the pull request that carries it, instead of waiting for the
+# release cycle to reach them — and a reviewer can check a change against a real
+# install rather than a diff.
+#
+# Nothing reaches npm here, and no secret is involved. The pkg.pr.new GitHub App
+# (https://github.com/apps/pkg-pr-new) has to be installed on the repository; it
+# authorises the upload from the workflow run itself, which is why this job asks
+# for no permissions at all. Without the App installed the publish step fails and
+# nothing else about the repository changes.
+#
+# Fork pull requests publish too, and that is the point of the feature — the
+# preview URL names the commit it was built from, and the tarball is exactly the
+# code already running in the build, test and lint workflows on the same event.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+# The App is the only authority the publish needs, and the job runs pull request
+# code: give the token nothing.
+permissions: {}
+
+# One preview per ref. A superseded commit's tarball interests nobody, and the
+# comment pkg.pr.new keeps up to date on the pull request should name the newest
+# push rather than whichever run happened to finish last.
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Publish preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      # --ignore-scripts skips `prepare`, so this does not build. The build below
+      # is not missing: pkg-pr-new packs with `npm pack`, which runs `prepack` —
+      # the same build and the same pack guard a real `npm publish` goes through.
+      # Building here as well would only do it twice, and a preview that skipped
+      # the guard would not be the tarball people are about to install.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # From the lockfile rather than npx: the version that publishes previews is
+      # the one the repository reviewed and pinned.
+      #
+      # --previewVersion stamps the tarball as 0.0.0-preview-<sha> instead of
+      # leaving it on the released version it was branched from. A preview that
+      # calls itself 0.2.10 can stay pinned in a consumer's lockfile as the answer
+      # to `^0.2.10` long after the real 0.2.10 exists; a 0.0.0- prefix cannot
+      # satisfy that range at all.
+      #
+      # --no-template drops the StackBlitz template. It is a browser sandbox, and
+      # this package needs a WebSocket to WhatsApp and a Node runtime for the WASM
+      # bridge, so the template would only lengthen the comment.
+      - name: Publish preview packages
+        run: npm exec -- pkg-pr-new publish --previewVersion --no-template

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -6,11 +6,8 @@ name: Preview Release
 # release cycle to reach them — and a reviewer can check a change against a real
 # install rather than a diff.
 #
-# Nothing reaches npm here, and no secret is involved. The pkg.pr.new GitHub App
-# (https://github.com/apps/pkg-pr-new) has to be installed on the repository; it
-# authorises the upload from the workflow run itself, which is why this job asks
-# for no permissions at all. Without the App installed the publish step fails and
-# nothing else about the repository changes.
+# Nothing reaches npm here, and no secret is involved: the upload is authorised
+# from the workflow run itself, which is why this job asks for no permissions.
 #
 # Fork pull requests publish too, and that is the point of the feature — the
 # preview URL names the commit it was built from, and the tarball is exactly the
@@ -22,8 +19,8 @@ on:
       - main
   pull_request:
 
-# The App is the only authority the publish needs, and the job runs pull request
-# code: give the token nothing.
+# Nothing here reads or writes through the token, and the job runs pull request
+# code: give it nothing.
 permissions: {}
 
 # One preview per ref, but cancelling only on pull requests: a superseded push

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -26,12 +26,14 @@ on:
 # code: give the token nothing.
 permissions: {}
 
-# One preview per ref. A superseded commit's tarball interests nobody, and the
-# comment pkg.pr.new keeps up to date on the pull request should name the newest
-# push rather than whichever run happened to finish last.
+# One preview per ref, but cancelling only on pull requests: a superseded push
+# there has a newer commit behind it, and the comment should name that one rather
+# than whichever run happened to finish last. On main every commit is a point
+# someone may later want to install by sha, and a cancelled run is a `@<sha>` URL
+# that does not exist — so those queue instead.
 concurrency:
   group: preview-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   preview:
@@ -40,10 +42,13 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      # Pinned by sha rather than by major tag, like the release workflow. This job
+      # produces a tarball people install, so what ran to build it should be the
+      # code that was reviewed and not whatever the tag points at that week.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/@oxidezap/baileyrs?color=cb3837&logo=npm)](https://www.npmjs.com/package/@oxidezap/baileyrs)
 [![npm downloads](https://img.shields.io/npm/dm/@oxidezap/baileyrs?color=cb3837&logo=npm)](https://www.npmjs.com/package/@oxidezap/baileyrs)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/oxidezap/baileyrs)
+[![pkg.pr.new](https://pkg.pr.new/badge/oxidezap/baileyrs)](https://pkg.pr.new/~/oxidezap/baileyrs)
 
 A Rust-powered WhatsApp Web library for JavaScript, with a Baileys-compatible API.
 
@@ -86,6 +87,41 @@ That writes the alias to your `package.json` (with the latest version at install
 
 Every `import { makeWASocket } from '@whiskeysockets/baileys'` in your codebase
 now resolves to baileyrs.
+
+### Preview builds
+
+Every commit on `main` and every pull request publishes an installable build
+through [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new). Nothing is
+published to npm — the tarball is served from a URL, so a fix can be tried
+before it reaches a release:
+
+```sh
+# the head of a pull request, following it as new commits land
+npm install https://pkg.pr.new/@oxidezap/baileyrs@94
+
+# one specific commit
+npm install https://pkg.pr.new/@oxidezap/baileyrs@f59ae6f
+```
+
+Projects using the Baileys alias point it at the same URL:
+
+```jsonc
+{
+  "dependencies": {
+    "@whiskeysockets/baileys": "https://pkg.pr.new/@oxidezap/baileyrs@94"
+  }
+}
+```
+
+Every open pull request comments the URL for its own head, and
+[pkg.pr.new/~/oxidezap/baileyrs](https://pkg.pr.new/~/oxidezap/baileyrs) lists
+what is available.
+
+Preview builds carry the version `0.0.0-preview-<sha>`, which no range written
+for a real release can match — an install is a deliberate pin, and it stays on
+that commit until you change it. They are for trying a change, not for running
+one: they are unreleased code, and the URL is not a substitute for a published
+version in anything that has to keep resolving.
 
 ## Quick Start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "oxfmt": "^0.59.0",
         "oxlint": "1.74.0",
         "pino-pretty": "^13.1.3",
+        "pkg-pr-new": "^0.0.88",
         "tsc-esm-fix": "^3.1.2",
         "typescript": "^7.0.2",
         "typescript-compat-auditor": "npm:typescript@6.0.3"
@@ -2931,6 +2932,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.13.0"
+      }
+    },
+    "node_modules/pkg-pr-new": {
+      "version": "0.0.88",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.88.tgz",
+      "integrity": "sha512-Xc6PMJ2gher0WZP+rtjefFk26hIb7V1PTLL30bmy1Z2vsRmSvqiss7Ag1XUdyplTGYzIlFNJp4L3vMNmK44N6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pkg-pr-new": "bin/cli.js"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "oxfmt": "^0.59.0",
     "oxlint": "1.74.0",
     "pino-pretty": "^13.1.3",
+    "pkg-pr-new": "^0.0.88",
     "tsc-esm-fix": "^3.1.2",
     "typescript": "^7.0.2",
     "typescript-compat-auditor": "npm:typescript@6.0.3"


### PR DESCRIPTION
Adds continuous releases through [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new): every commit on `main` and every pull request uploads an npm-compatible tarball to a URL, and the app keeps one comment per pull request pointing at its head.

Two things this buys, and they are different:

- A fix that lands on `main` is reachable only once a release cycle carries it. `npm i https://pkg.pr.new/@oxidezap/baileyrs@<pr>` makes the fix installable while the pull request is still open — which for a WhatsApp client, where a break tends to be urgent and account-specific, is most of the value.
- A reviewer judging a change has the diff. With this they can install the branch into a real integration and watch it connect.

## What runs

One new workflow, `.github/workflows/preview.yml`, and `pkg-pr-new` pinned as a devDependency. No source change.

```yaml
- name: Install dependencies
  run: npm ci --ignore-scripts

- name: Publish preview packages
  run: npm exec -- pkg-pr-new publish --previewVersion --no-template
```

## Setup this needs before it works

**The [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) has to be installed on the repository.** That is the only manual step, and it is not something this PR can do. Until it is installed the publish step fails and nothing else about the repository changes — no other workflow, no release path, and nothing that can reach npm. The permissions the app asks for are explained in [stackblitz-labs/pkg.pr.new#305](https://github.com/stackblitz-labs/pkg.pr.new/issues/305).

There is no secret and no token: the app authorises the upload from the workflow run itself, which is why the job declares `permissions: {}`.

## The decisions worth arguing about

### `permissions: {}` and fork pull requests

The job runs on `pull_request`, forks included, and asks the `GITHUB_TOKEN` for nothing at all. That is deliberate on both ends. Fork previews are the feature — a contributor's fix should be installable by the person who reported the bug — and a fork pull request already runs its own code in `build.yml`, `test.yml` and `lint.yml` on the same event, so this adds no new execution of untrusted code. What it adds is a tarball of that code at a URL, named by the commit it came from and reachable only by that name.

`e2e.yml`'s fork guard is not the same situation: that one exists because forks get no secrets and cannot pull the private mock-server image. Here there is nothing to withhold.

The alternative the upstream README calls its recommended setup — publish only after a write-access maintainer approves the pull request — trades away exactly the case that motivates this: a reporter trying a fix before anyone has reviewed it. Worth revisiting if preview URLs are ever abused; it is a one-file change.

### No build step, on purpose

`pkg-pr-new` packs with `npm pack`, which runs `prepack` — `npm run build && node scripts/check-pack.ts`. So the preview goes through the same build and the same pack guard that a real `npm publish` does, and a build step in the workflow would only run the build a second time. It also means a preview can never be a tarball shape that `check-pack` would have rejected at release time.

That is why the install is `npm ci --ignore-scripts`: it skips `prepare` so the build happens once, at pack time. Same flag, and the same reasoning about dependency lifecycle scripts, as the publish job in `release.yml`.

### `--previewVersion`

Without it a preview keeps the version it was branched from. A tarball calling itself `0.2.10` can sit in a consumer's lockfile as the resolution of `^0.2.10` long after the real 0.2.10 is published, and nothing about the install looks wrong. With it, every preview is `0.0.0-preview-<sha>`, which no range written for a real release can satisfy — the install is a deliberate pin and stays one.

### `--no-template`

The default StackBlitz template is a browser sandbox. This package needs a Node runtime for the WASM bridge and a WebSocket to WhatsApp, so the template would only lengthen the comment with something nobody can run.

### `pkg-pr-new` as a devDependency rather than `npx`

The upstream README is explicit that CI should run it from the lockfile. Pinned at `0.0.88`, zero dependencies of its own (`+11` lines in `package-lock.json`), so the version that publishes previews is the one this repository reviewed.

### `ci(...)` commit type

Hidden in `release-please-config.json` and not one of the types that produces a release, which is what this should be: the change ships no library code.

## Also in this PR

`README.md` gains a **Preview builds** section under Installation — the pull-request URL, the commit URL, the aliased-`@whiskeysockets/baileys` form, and what `0.0.0-preview-<sha>` means — plus the pkg.pr.new badge next to the existing ones.

## Validation

The publish itself only runs inside a workflow, so what can be checked locally is the pack path it depends on — which is the part that would actually break:

```
npm ci --ignore-scripts       pass
npm pack --json               pass — prepack built, check-pack clean, 291 files
npm exec -- pkg-pr-new --help pass — --previewVersion and --no-template exist in 0.0.88
```

No source file changed, so `lint`, `format:check` and the test suite are untouched by this diff.

The one thing that cannot be verified before merge is the publish step itself: it needs the app installed, and it will fail visibly on the first run if that has not happened.

---
_Generated by [Claude Code](https://claude.ai/code/session_013rKNdY6C8cSJS1qQtZ8iFq)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds continuous preview releases through [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new): every commit on `main` and every pull request serves an npm-compatible tarball from a URL, so a fix can be installed from its pull request instead of waiting for a release cycle, and a reviewer can try the branch in a real integration rather than reading the diff.

The [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr.new) must be installed on the repository before the publish step works; no secret or token is involved, and nothing reaches npm. Previews are stamped `0.0.0-preview-<sha>` so they cannot satisfy a range written for a released version, and fork pull requests publish too since they already run the same code in the build, test, and lint workflows.

Adds `.github/workflows/preview.yml`, pins `pkg-pr.new` as a devDependency, and documents preview installs in the README. No source code changed.

**Workflow behavior**
- `actions/checkout` and `actions/setup-node` are pinned by sha so installable tarballs are built by the code that was reviewed.
- Superseded runs cancel only on pull requests; on `main` runs queue so every commit sha keeps a published preview someone can install later.

<sup>Written for commit 2ce2a7191edd460aac07b0c0e5cc54a87fe9d8d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added installable preview builds for commits to the main branch and pull requests.
  * Added preview versioning based on the commit identifier.
  * Added a README badge and instructions for installing preview builds.

* **Documentation**
  * Documented preview build availability, installation commands, version format, and unreleased-status warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->