### PR TITLE
chore(ci): batch dependency updates into grouped pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+# Dependency updates arrive as two batched pull requests a week, not one per
+# package. CI here is lint, tests, the build and the e2e suite; batching is what
+# keeps a routine week from running all of that once per bumped dependency.
+# Configuration reference:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    # Group PRs, not individual bumps — 5 is headroom for the two groups below
+    # plus anything Dependabot has to split out (a security advisory opens its
+    # own PR regardless of grouping).
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+    groups:
+      # The routine weekly batch, runtime and dev together: one PR, one CI run,
+      # one merge. `npm ci` reads a single lockfile, so splitting the two would
+      # only produce two PRs that each rewrite the same file and conflict.
+      npm:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      # Majors in their own PR: this package's dependencies are mostly 1.x or
+      # later, where a major really is the breaking one, and it usually needs
+      # code changes that should not hold the routine batch.
+      npm-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
+    ignore:
+      # `typescript-compat-auditor` is an alias for typescript@6.0.3, a second
+      # compiler kept deliberately behind the ^7 one the package builds with:
+      # scripts/compatibility/audit-core.ts imports it to audit against that
+      # older baseline. Bumping it to match the main compiler is what makes the
+      # audit stop measuring anything, so which baseline it pins is a decision
+      # to make by hand, not one to take from a weekly batch.
+      - dependency-name: typescript-compat-auditor
+
+  # Not previously configured, and the workflows show the drift that allows:
+  # actions/checkout, actions/setup-node and actions/upload-artifact each appear
+  # both SHA-pinned with a version comment and riding a bare major tag, at
+  # different versions. One weekly PR moves them together; SHA pins are updated
+  # in place and their trailing version comment with them.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot was not configured here at all, so nothing tracked the npm dependencies or the actions. This adds `.github/dependabot.yml` in the shape that costs the least CI — a run here is lint, tests, the build and the e2e suite.

## npm

Two groups:

- **`npm`** — every `minor` and `patch` bump in one PR, runtime and dev together. `npm ci` reads a single lockfile, so splitting the two would only produce two PRs that each rewrite `package-lock.json` and conflict.
- **`npm-major`** — majors in their own PR. This package's dependencies are mostly 1.x or later, where a major really is the breaking one and usually needs code changes that should not hold the routine batch.

### One ignore: `typescript-compat-auditor`

It is an alias for `typescript@6.0.3`, a second compiler kept deliberately behind the `^7` one the package builds with — `scripts/compatibility/audit-core.ts` imports it to audit against that older baseline. Bumping it to match the main compiler is what makes the audit stop measuring anything, so which baseline it pins should be a decision made by hand, not one taken from a weekly batch.

This is the one opinion in the diff that is easy to disagree with; drop the `ignore` block if you'd rather see the bump proposed.

## GitHub Actions

New, and the workflows show the drift its absence allowed: `actions/checkout`, `actions/setup-node` and `actions/upload-artifact` each appear both SHA-pinned with a version comment *and* riding a bare major tag, at different versions. One weekly grouped PR moves them together; SHA pins are updated in place, with the trailing version comment updated with them.

## Verification

Config-only; nothing any job reads changes. Every key used is in the [configuration options reference](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file), and the file round-trips through a YAML parser. GitHub validates it on merge under Insights → Dependency graph → Dependabot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Kon6DPzicxxWU1dMEqG7p

---
_Generated by [Claude Code](https://claude.ai/code/session_018Kon6DPzicxxWU1dMEqG7p)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Dependabot configuration to batch npm and GitHub Actions dependency updates into three weekly PRs, reducing the number of CI runs triggered per week.

**Notes**
- Groups npm minor/patch updates into one PR, npm major updates into another, and actions into a third.
- Ignores `typescript-compat-auditor` so its compiler baseline stays a manual decision.
- Config-only; no build or runtime behavior changes.

<sup>Written for commit b5474ac12183bdb9d494b0d4c5eeb89354c3f98c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly checks for npm and GitHub Actions updates.
  * Dependency update pull requests are grouped and limited to reduce notification volume.
  * Configured consistent chore commit messages for automated updates.
  * Excluded a TypeScript compatibility tool from automated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->