### PR TITLE
deps: move to bridge 0.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
-        "@oxidezap/whatsapp-rust-bridge": "0.19.0",
+        "@oxidezap/whatsapp-rust-bridge": "0.20.0",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -36,7 +36,7 @@
       "peerDependencies": {
         "audio-decode": "^2.1.3",
         "jimp": "^1.6.0",
-        "link-preview-js": "^5.0.0",
+        "link-preview-js": "^3.0.0",
         "sharp": "*"
       },
       "peerDependenciesMeta": {
@@ -952,9 +952,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.19.0.tgz",
-      "integrity": "sha512-1105rs8yu21w5beUR1czeCu3YZNBa2Z3FW3IsfC33B2DSTDfX2bmzCukmR57K/MrUrkmfykeVfWv+7GlYRDKRQ==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.20.0.tgz",
+      "integrity": "sha512-Mu5FXISUUp0y1W7iRUMwGsNyleNOG2P5YIFeT0HaP10B4E0nN7w7H7GgEVIzRBA7Cv5dzItsbZdtfftPobHgXg==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",
-    "@oxidezap/whatsapp-rust-bridge": "0.19.0",
+    "@oxidezap/whatsapp-rust-bridge": "0.20.0",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"

--- a/src/Bridge/__tests__/adapt.test.ts
+++ b/src/Bridge/__tests__/adapt.test.ts
@@ -716,6 +716,15 @@ describe('adaptBridgeEvent — anti-corruption layer', () => {
 			})
 		})
 
+		it('offline_sync_interrupted stays a noop (an interrupted drain is not completion)', () => {
+			// Pinned exactly: the fuzz sweep tolerates `noop` for every inert
+			// type, so a future change surfacing this as a public event would
+			// pass there. This is the test that must fail then.
+			expect(
+				adaptBridgeEvent({ type: 'offline_sync_interrupted', data: { total: 10, delivered: 4 } } as never)
+			).toEqual({ type: 'noop', bridgeType: 'offline_sync_interrupted' })
+		})
+
 		it('server_ack preserves the typed fields needed by the internal ACK handler', () => {
 			expect(
 				adaptBridgeEvent({

--- a/src/Bridge/schema.ts
+++ b/src/Bridge/schema.ts
@@ -521,6 +521,11 @@ const ADAPTERS = {
 		count: asNumber(data?.count) ?? 0
 	}),
 	offline_sync_preview: () => ({ type: 'noop', bridgeType: 'offline_sync_preview' }),
+	// Counterpart of `offline_sync_completed`, not a variant: the drain ended
+	// without its end marker, so the client is *not* caught up and the backlog
+	// is redelivered on the next connection. Emitting `receivedPendingNotifications`
+	// here would be a lie, so this stays a noop until the next preview/completion.
+	offline_sync_interrupted: () => ({ type: 'noop', bridgeType: 'offline_sync_interrupted' }),
 	dirty_state: data => {
 		const dirtyType = asString(data?.dirty_type)
 		if (!dirtyType) return null

--- a/src/__fuzz__/bridge-events.fuzz.test.ts
+++ b/src/__fuzz__/bridge-events.fuzz.test.ts
@@ -136,6 +136,7 @@ const UNCONDITIONALLY_INERT: ReadonlySet<string> = new Set([
 	'self_push_name_updated',
 	'client_expiration_changed',
 	'offline_sync_preview',
+	'offline_sync_interrupted',
 	'device_list_update',
 	'identity_change',
 	'business_status_update',


### PR DESCRIPTION
Moves `@oxidezap/whatsapp-rust-bridge` 0.19.0 → 0.20.0. That release is three PRs up from here: the username surface (#89), the tsify boundary migration (#95, internal), and the core bump to `0aa87c64` (#96, flagged breaking).

## What 0.20.0 changes for this package

- **Username surface now populated.** The adapter already mapped `username`, `pn_jid`/`pnJid` and `participant_username` defensively (they always read `undefined` on 0.19.0); on 0.20.0 they carry values: contact `username` + lookup + own handle, `UsyncBusinessResult.pn_jid`, `Connected` version fallback, group notification subject-owner PN/username. No code change — the mappings were waiting for the data. No README note: this is convergence toward upstream, not a new divergence.
- **`offline_sync_interrupted` mapped to noop.** The one new event variant (a backlog drain that ended without its end marker because the connection dropped). Its counterpart `offline_sync_completed` emits `connection.update { receivedPendingNotifications: true }`; emitting that here would be a lie — the client is *not* caught up and the backlog is redelivered on the next connection — so it stays a noop until the next preview/completion, same as `offline_sync_preview`.
- **Core perf internals (no surface):** `SendResult` returns (the bridge still unwraps to the previous JS shapes), `MessageInfo` shrink (`meta_info` optional, `comment_target`/`ephemeral_expiration` on `InboundMessage`), boxed event payloads (serde-transparent), `PresencePolicy` defaulting to `Automatic`. Nothing in `src/` read the moved fields, and `push_name` reads go through `asString`, so no adaptation needed beyond the event map.

## Changes in this PR

- `package.json` / `package-lock.json`: bridge 0.20.0 (exact pin, as before).
- `src/Bridge/schema.ts`: `offline_sync_interrupted` → noop adapter entry (keeps the `AdapterMap` exhaustive).
- `src/__fuzz__/bridge-events.fuzz.test.ts`: new type added to `UNCONDITIONALLY_INERT` (noop is only allowed where it is the adapter's whole behaviour).

## Evidence

- `npm run build` green, no TS errors (before: `TS2741` on the missing adapter entry).
- `npm run format:check` green (290 files); `oxlint` clean on the touched files.
- `npm test`: 1412 pass, 1 fail — the single failure is the pre-existing untracked `src/__tests__/effect-buffer-experiment.test.ts`, which imports the `effect` package that is not installed (`ERR_MODULE_NOT_FOUND`). Unrelated to this bump; left untouched.
- Targeted `src/__fuzz__/bridge-events.fuzz.test.ts`: 8/8, including "adapts every declared event type".

## Not verified

- `npm run test:e2e` not run locally (needs the mock server CI waits for).
- Full `npm run lint` (`tsc`) still reports the pre-existing untracked `experiments/` files (`effect-buffer.ts` type errors, rootDir complaint). Same story as the test failure above — dirt already in the tree, not from this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `@oxidezap/whatsapp-rust-bridge` from 0.19.0 to 0.20.0 and maps the new `offline_sync_interrupted` event to a noop so the adapter stays exhaustive.

The 0.20.0 release also starts populating username fields (`username`, `pn_jid`, `participant_username`) that previously always read `undefined`; the existing mappings already handle them, so no code change is needed there.

**Changes**
- Bumps the bridge dependency in `package.json` / `package-lock.json` (exact pin).
- Adds `offline_sync_interrupted` as a noop adapter entry in `src/Bridge/schema.ts` — its counterpart `offline_sync_completed` emits `receivedPendingNotifications: true`, but emitting it here would mislead consumers since the backlog redelivers on the next connection.
- Adds `offline_sync_interrupted` to the `UNCONDITIONALLY_INERT` set in `src/__fuzz__/bridge-events.fuzz.test.ts` and pins its noop behavior in `src/Bridge/__tests__/adapt.test.ts`.

<sup>Written for commit c3249bb32657e13732e1d103f31b034848b08948. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of interrupted offline synchronization.
  - Prevented interrupted syncs from triggering misleading pending-notification events.
  - Ensured unfinished message backlogs are redelivered when the client reconnects, helping keep conversations synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->