### PR TITLE
fix(bridge): receipt and timestamp fidelity on both wire routes

### DIFF
--- a/src/Bridge/__tests__/wire-event-fidelity.test.ts
+++ b/src/Bridge/__tests__/wire-event-fidelity.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test'
 import { decodeReceiptWireBatch, encodeReceiptWireBatch } from '@oxidezap/whatsapp-rust-bridge'
 import type { WhatsAppEvent } from '@oxidezap/whatsapp-rust-bridge'
 import { adaptBridgeEvent } from '../adapt.ts'
+import { toUnixSeconds } from '../index.ts'
 import type { CanonicalReceipt } from '../types.ts'
 import { expect } from '../../__tests__/expect.ts'
 
@@ -48,10 +49,25 @@ describe('wire-event fidelity — receipt type across object and packed routes',
 		expect(receipt?.receiptTypeRaw).toBe('FutureType')
 	})
 
-	it('normalizes a known value wrapped in { Other } without a raw residue', () => {
-		const receipt = adaptReceipt({ Other: 'Read' })
-		expect(receipt?.receiptType).toBe('read')
-		expect(receipt?.receiptTypeRaw).toBeUndefined()
+	it('treats the Other wrapper as authoritative on spelling collisions', () => {
+		// The packed codec round-trips `{ Other: value }` verbatim and never
+		// synthesizes it for a known variant, so a wrapped payload is an
+		// unrecognized wire value even when its spelling matches one.
+		for (const [payload, raw] of [
+			[{ Other: 'Read' }, 'Read'],
+			[{ Other: 'read' }, 'read'],
+			[{ Other: '' }, ''],
+			[{ Other: 'FutureType' }, 'FutureType']
+		] as const) {
+			const receipt = adaptReceipt(payload)
+			expect(receipt?.receiptType).toBe('other')
+			expect(receipt?.receiptTypeRaw).toBe(raw)
+		}
+		// Unwrapped spellings still normalize through the known-variant table.
+		expect(adaptReceipt('Read')?.receiptType).toBe('read')
+		expect(adaptReceipt('read')?.receiptType).toBe('read')
+		expect(adaptReceipt({ type: 'Read' })?.receiptType).toBe('read')
+		expect(adaptReceipt('Read')?.receiptTypeRaw).toBeUndefined()
 	})
 
 	it('maps an unknown bare string to other and preserves the original value', () => {
@@ -74,25 +90,26 @@ describe('wire-event fidelity — receipt type across object and packed routes',
 	})
 
 	it('decodes an { Other } receipt through the packed batch without losing the value', () => {
+		const mk = (type: string | { Other: string }) => ({
+			source: { chat: jid('5511'), sender: jid('5511'), is_group: false, is_from_me: false },
+			message_ids: ['M1'],
+			timestamp: 1_734_000_000,
+			type,
+			offline: false
+		})
 		const decoded = decodeReceiptWireBatch(
-			encodeReceiptWireBatch([
-				{
-					source: { chat: jid('5511'), sender: jid('5511'), is_group: false, is_from_me: false },
-					message_ids: ['M1'],
-					timestamp: 1_734_000_000,
-					type: { Other: 'FutureType' },
-					offline: false
-				}
-			])
+			encodeReceiptWireBatch([mk({ Other: 'FutureType' }), mk({ Other: 'Read' }), mk('Read')])
 		)
-		expect(decoded.length).toBe(1)
-		const first = decoded[0]
-		if (!first) throw new Error('expected one decoded receipt')
-		expect(first.type).toEqual({ Other: 'FutureType' })
+		expect(decoded.length).toBe(3)
+		expect(decoded[0]?.type).toEqual({ Other: 'FutureType' })
+		// A colliding spelling crosses the codec still wrapped: the wrapper,
+		// not the spelling, tells known from unknown.
+		expect(decoded[1]?.type).toEqual({ Other: 'Read' })
+		expect(decoded[2]?.type).toBe('Read')
 	})
 
 	it('adapts the same logical receipt identically on the object and packed routes', () => {
-		for (const type of ['Read', { Other: 'FutureType' }, 'FutureType'] as const) {
+		for (const type of ['Read', { Other: 'FutureType' }, { Other: 'Read' }, 'FutureType'] as const) {
 			const viaObject = adaptReceipt(type)
 			const [packed] = decodeReceiptWireBatch(
 				encodeReceiptWireBatch([
@@ -193,5 +210,19 @@ describe('wire-event fidelity — optional timestamps stay absent when invalid',
 		} as unknown as WhatsAppEvent)
 		if (result?.type !== 'serverAck') throw new Error('expected canonical serverAck')
 		expect(result.timestamp).toBeUndefined()
+	})
+})
+
+describe('wire-event fidelity — retained toUnixSeconds export', () => {
+	it('coerces valid numbers, zero, and RFC3339 strings', () => {
+		expect(toUnixSeconds(1_734_000_000)).toBe(1_734_000_000)
+		expect(toUnixSeconds(0)).toBe(0)
+		expect(toUnixSeconds('2026-04-18T05:00:00Z')).toBe(Math.floor(Date.parse('2026-04-18T05:00:00Z') / 1000))
+	})
+
+	it('rejects invalid input by throwing instead of fabricating the epoch', () => {
+		for (const invalid of ['not-a-date', '', undefined, null, Number.NaN, Number.POSITIVE_INFINITY, {}, 0n]) {
+			expect(() => toUnixSeconds(invalid)).toThrow(RangeError)
+		}
 	})
 })

--- a/src/Bridge/__tests__/wire-event-fidelity.test.ts
+++ b/src/Bridge/__tests__/wire-event-fidelity.test.ts
@@ -1,0 +1,197 @@
+import { describe, it } from 'node:test'
+import { decodeReceiptWireBatch, encodeReceiptWireBatch } from '@oxidezap/whatsapp-rust-bridge'
+import type { WhatsAppEvent } from '@oxidezap/whatsapp-rust-bridge'
+import { adaptBridgeEvent } from '../adapt.ts'
+import type { CanonicalReceipt } from '../types.ts'
+import { expect } from '../../__tests__/expect.ts'
+
+const jid = (user: string, server = 's.whatsapp.net') => ({ user, server, agent: 0, device: 0, integrator: 0 })
+
+const ABSENT = Symbol('absent timestamp')
+
+const receiptData = (type: unknown, timestamp: unknown = 1_734_000_000) => ({
+	source: { chat: jid('5511'), sender: jid('5511'), is_group: false, is_from_me: false },
+	message_ids: ['M1'],
+	type,
+	...(timestamp === ABSENT ? {} : { timestamp })
+})
+
+const adaptReceipt = (type: unknown, timestamp: unknown = 1_734_000_000): CanonicalReceipt | null => {
+	const result = adaptBridgeEvent({ type: 'receipt', data: receiptData(type, timestamp) } as unknown as WhatsAppEvent)
+	if (result === null) return null
+	if (result.type !== 'receipt') throw new Error(`expected canonical receipt, got ${result.type}`)
+	return result
+}
+
+describe('wire-event fidelity — receipt type across object and packed routes', () => {
+	it('keeps known bare-string variants without a raw residue', () => {
+		const receipt = adaptReceipt('Read')
+		expect(receipt?.receiptType).toBe('read')
+		expect(receipt?.receiptTypeRaw).toBeUndefined()
+	})
+
+	it('keeps known snake_case variants without a raw residue', () => {
+		const receipt = adaptReceipt('enc_rekey_retry')
+		expect(receipt?.receiptType).toBe('enc-rekey-retry')
+		expect(receipt?.receiptTypeRaw).toBeUndefined()
+	})
+
+	it('keeps the tagged { type } serde form', () => {
+		const receipt = adaptReceipt({ type: 'Read' })
+		expect(receipt?.receiptType).toBe('read')
+		expect(receipt?.receiptTypeRaw).toBeUndefined()
+	})
+
+	it('maps { Other: value } to other and preserves the original value', () => {
+		const receipt = adaptReceipt({ Other: 'FutureType' })
+		expect(receipt?.receiptType).toBe('other')
+		expect(receipt?.receiptTypeRaw).toBe('FutureType')
+	})
+
+	it('normalizes a known value wrapped in { Other } without a raw residue', () => {
+		const receipt = adaptReceipt({ Other: 'Read' })
+		expect(receipt?.receiptType).toBe('read')
+		expect(receipt?.receiptTypeRaw).toBeUndefined()
+	})
+
+	it('maps an unknown bare string to other and preserves the original value', () => {
+		const receipt = adaptReceipt('FutureType')
+		expect(receipt?.receiptType).toBe('other')
+		expect(receipt?.receiptTypeRaw).toBe('FutureType')
+	})
+
+	it('leaves an absent receipt type absent', () => {
+		expect(adaptReceipt(undefined)?.receiptType).toBeUndefined()
+		expect(adaptReceipt(null)?.receiptType).toBeUndefined()
+	})
+
+	it('leaves a malformed receipt type absent instead of miscategorizing it', () => {
+		for (const malformed of [42, true, {}, { Other: 42 }, { type: 42 }, []]) {
+			const receipt = adaptReceipt(malformed)
+			expect(receipt?.receiptType).toBeUndefined()
+			expect(receipt?.receiptTypeRaw).toBeUndefined()
+		}
+	})
+
+	it('decodes an { Other } receipt through the packed batch without losing the value', () => {
+		const decoded = decodeReceiptWireBatch(
+			encodeReceiptWireBatch([
+				{
+					source: { chat: jid('5511'), sender: jid('5511'), is_group: false, is_from_me: false },
+					message_ids: ['M1'],
+					timestamp: 1_734_000_000,
+					type: { Other: 'FutureType' },
+					offline: false
+				}
+			])
+		)
+		expect(decoded.length).toBe(1)
+		const first = decoded[0]
+		if (!first) throw new Error('expected one decoded receipt')
+		expect(first.type).toEqual({ Other: 'FutureType' })
+	})
+
+	it('adapts the same logical receipt identically on the object and packed routes', () => {
+		for (const type of ['Read', { Other: 'FutureType' }, 'FutureType'] as const) {
+			const viaObject = adaptReceipt(type)
+			const [packed] = decodeReceiptWireBatch(
+				encodeReceiptWireBatch([
+					{
+						source: { chat: jid('5511'), sender: jid('5511'), is_group: false, is_from_me: false },
+						message_ids: ['M1'],
+						timestamp: 1_734_000_000,
+						type,
+						offline: false
+					}
+				])
+			)
+			const viaPacked = adaptBridgeEvent({ type: 'receipt', data: packed } as unknown as WhatsAppEvent)
+			if (viaPacked?.type !== 'receipt') throw new Error('expected canonical receipt on the packed route')
+			if (!viaObject) throw new Error('expected canonical receipt on the object route')
+			expect(viaPacked.receiptType).toBe(viaObject.receiptType)
+			expect(viaPacked.receiptTypeRaw).toBe(viaObject.receiptTypeRaw ?? undefined)
+			expect(viaPacked.timestamp).toBe(viaObject.timestamp)
+			expect(viaPacked.messageIds).toEqual(viaObject.messageIds)
+		}
+	})
+})
+
+describe('wire-event fidelity — required timestamps never silently become the epoch', () => {
+	it('accepts a valid RFC3339 timestamp on a receipt', () => {
+		const receipt = adaptReceipt('read', '2026-04-18T05:00:00Z')
+		expect(receipt?.timestamp).toBe(Math.floor(Date.parse('2026-04-18T05:00:00Z') / 1000))
+	})
+
+	it('preserves a valid zero timestamp instead of treating it as missing', () => {
+		expect(adaptReceipt('read', 0)?.timestamp).toBe(0)
+	})
+
+	it('drops a receipt with an absent timestamp instead of dating it at the epoch', () => {
+		expect(adaptReceipt('read', ABSENT)).toBe(null)
+	})
+
+	it('drops a receipt with an invalid timestamp string instead of dating it at the epoch', () => {
+		expect(adaptReceipt('read', 'not-a-date')).toBe(null)
+	})
+
+	it('drops a receipt with a non-finite numeric timestamp', () => {
+		expect(adaptReceipt('read', Number.NaN)).toBe(null)
+		expect(adaptReceipt('read', Number.POSITIVE_INFINITY)).toBe(null)
+	})
+
+	it('drops a message with an invalid timestamp string instead of dating it at the epoch', () => {
+		const result = adaptBridgeEvent({
+			type: 'message',
+			data: {
+				message: { conversation: 'hi' },
+				info: {
+					id: 'MSG1',
+					timestamp: 'not-a-date',
+					source: { chat: jid('5511'), sender: jid('5511'), is_from_me: false, is_group: false }
+				}
+			}
+		} as unknown as WhatsAppEvent)
+		expect(result).toBe(null)
+	})
+
+	it('drops a message with an absent timestamp', () => {
+		const result = adaptBridgeEvent({
+			type: 'message',
+			data: {
+				message: { conversation: 'hi' },
+				info: {
+					id: 'MSG1',
+					source: { chat: jid('5511'), sender: jid('5511'), is_from_me: false, is_group: false }
+				}
+			}
+		} as unknown as WhatsAppEvent)
+		expect(result).toBe(null)
+	})
+})
+
+describe('wire-event fidelity — optional timestamps stay absent when invalid', () => {
+	it('omits presence last_seen on invalid input instead of reporting the epoch', () => {
+		const invalid = adaptBridgeEvent({
+			type: 'presence',
+			data: { from: jid('5511'), unavailable: false, last_seen: 'not-a-date' }
+		} as unknown as WhatsAppEvent)
+		if (invalid?.type !== 'presence') throw new Error('expected canonical presence')
+		expect(invalid.lastSeen).toBeUndefined()
+
+		const valid = adaptBridgeEvent({
+			type: 'presence',
+			data: { from: jid('5511'), unavailable: false, last_seen: '2026-04-18T05:00:00Z' }
+		} as unknown as WhatsAppEvent)
+		if (valid?.type !== 'presence') throw new Error('expected canonical presence')
+		expect(valid.lastSeen).toBe(Math.floor(Date.parse('2026-04-18T05:00:00Z') / 1000))
+	})
+
+	it('omits a server-ack timestamp on invalid input instead of reporting the epoch', () => {
+		const result = adaptBridgeEvent({
+			type: 'server_ack',
+			data: { id: 'ACK-1', timestamp: 'not-a-date' }
+		} as unknown as WhatsAppEvent)
+		if (result?.type !== 'serverAck') throw new Error('expected canonical serverAck')
+		expect(result.timestamp).toBeUndefined()
+	})
+})

--- a/src/Bridge/__tests__/wire-event-fidelity.test.ts
+++ b/src/Bridge/__tests__/wire-event-fidelity.test.ts
@@ -89,6 +89,19 @@ describe('wire-event fidelity — receipt type across object and packed routes',
 		}
 	})
 
+	it('reads prototype-chain names as unknown wire values, not inherited members', () => {
+		// The lookup table is an ordinary object: without an own-property
+		// guard, 'constructor' would resolve to `Object` (truthy) and poison
+		// the canonical event instead of mapping to 'other'.
+		for (const name of ['constructor', 'toString', 'hasOwnProperty', '__proto__']) {
+			for (const shape of [name, { type: name }, { Other: name }]) {
+				const receipt = adaptReceipt(shape)
+				expect(receipt?.receiptType).toBe('other')
+				expect(receipt?.receiptTypeRaw).toBe(name)
+			}
+		}
+	})
+
 	it('decodes an { Other } receipt through the packed batch without losing the value', () => {
 		const mk = (type: string | { Other: string }) => ({
 			source: { chat: jid('5511'), sender: jid('5511'), is_group: false, is_from_me: false },

--- a/src/Bridge/index.ts
+++ b/src/Bridge/index.ts
@@ -19,5 +19,6 @@ export {
 	bridgeJidToString,
 	isBridgeJid,
 	isObject,
-	normalizeDiscriminator
+	normalizeDiscriminator,
+	toUnixSeconds
 } from './primitives.ts'

--- a/src/Bridge/index.ts
+++ b/src/Bridge/index.ts
@@ -15,9 +15,9 @@ export {
 	asJidString,
 	asNumber,
 	asString,
+	asUnixSeconds,
 	bridgeJidToString,
 	isBridgeJid,
 	isObject,
-	normalizeDiscriminator,
-	toUnixSeconds
+	normalizeDiscriminator
 } from './primitives.ts'

--- a/src/Bridge/primitives.ts
+++ b/src/Bridge/primitives.ts
@@ -114,19 +114,13 @@ const parseRfc3339Seconds = (raw: string): number | undefined => {
  * strings — the bridge serializes `DateTime<Utc>` as a string unless the field
  * names one of chrono's `ts_*` modules, so being lenient about which of the two
  * arrives insulates us from drift.
- */
-export const toUnixSeconds = (raw: unknown): number => {
-	if (typeof raw === 'number' && Number.isFinite(raw)) return raw
-	if (typeof raw === 'string') return parseRfc3339Seconds(raw) ?? 0
-	return 0
-}
-
-/**
- * Same as `toUnixSeconds`, but absence stays absent.
  *
- * The optional timestamps — `last_seen`, a server ack's `t`, an app-state
- * mutation's own time — mean "the server did not say" when missing, which is
- * not the same claim as the epoch.
+ * Absence and unparseable input stay absent (`undefined`): a missing,
+ * malformed, or non-finite timestamp must never become the epoch, which
+ * would place the event at 1970 and corrupt timeline ordering. Callers
+ * apply the per-field policy explicitly — required timestamps (message,
+ * receipt, call, group action) drop the event, optional ones (presence
+ * `last_seen`, server-ack time, pin/mute time) omit the field.
  */
 export const asUnixSeconds = (raw: unknown): number | undefined => {
 	if (typeof raw === 'number' && Number.isFinite(raw)) return raw

--- a/src/Bridge/primitives.ts
+++ b/src/Bridge/primitives.ts
@@ -129,6 +129,27 @@ export const asUnixSeconds = (raw: unknown): number | undefined => {
 }
 
 /**
+ * Validated coercion to unix seconds for external consumers that need a
+ * plain number (no `undefined` branch).
+ *
+ * Accepts the same inputs as `asUnixSeconds` — a finite number or an RFC
+ * 3339 string — and rejects everything else by throwing `RangeError`
+ * instead of fabricating the epoch: a missing, malformed, or non-finite
+ * timestamp must never become 1970-01-01 and corrupt timeline ordering.
+ * Internal adapters do not use this; they take `asUnixSeconds` with an
+ * explicit per-field policy (required timestamps drop the event, optional
+ * ones omit the field).
+ */
+export const toUnixSeconds = (raw: unknown): number => {
+	const parsed = asUnixSeconds(raw)
+	if (parsed === undefined) {
+		const preview = typeof raw === 'string' ? `: ${raw.slice(0, 80)}` : ''
+		throw new RangeError(`toUnixSeconds: cannot coerce ${typeof raw}${preview} to unix seconds`)
+	}
+	return parsed
+}
+
+/**
  * A 64-bit proto field, however the bridge chose to carry it.
  *
  * A protobuf `int64` reaches JavaScript as a protobufjs `Long`

--- a/src/Bridge/schema.ts
+++ b/src/Bridge/schema.ts
@@ -952,7 +952,10 @@ const parseReceiptType = (raw: unknown): { receiptType: CanonicalReceipt['receip
 	if (isObject(raw) && typeof raw.Other === 'string') return { receiptType: 'other', raw: raw.Other }
 	const norm = typeof raw === 'string' ? raw : isObject(raw) && typeof raw.type === 'string' ? raw.type : undefined
 	if (norm == null) return { receiptType: undefined }
-	const mapped = RECEIPT_TYPE_MAP[norm]
+	// Own-property lookup: the table is an ordinary object, so indexing an
+	// unknown bare name like 'constructor' or '__proto__' would otherwise
+	// return an inherited value instead of falling through to 'other'.
+	const mapped = Object.hasOwn(RECEIPT_TYPE_MAP, norm) ? RECEIPT_TYPE_MAP[norm] : undefined
 	return mapped ? { receiptType: mapped } : { receiptType: 'other', raw: norm }
 }
 

--- a/src/Bridge/schema.ts
+++ b/src/Bridge/schema.ts
@@ -50,8 +50,7 @@ import {
 	asString,
 	asUnixSeconds,
 	isObject,
-	normalizeDiscriminator,
-	toUnixSeconds
+	normalizeDiscriminator
 } from './primitives.ts'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -223,12 +222,14 @@ const ADAPTERS = {
 		const isFromMe = asBoolOr(src.is_from_me, false)
 		const senderAlt = asJidString(src.sender_alt)
 		const recipientAlt = asJidString(src.recipient_alt)
+		const timestamp = asUnixSeconds(info.timestamp)
+		if (timestamp === undefined) return null
 		return {
 			type: 'undecryptableMessage',
 			chatJid: chat,
 			senderJid: isGroup ? asJidString(src.sender) : undefined,
 			id,
-			timestamp: toUnixSeconds(info.timestamp),
+			timestamp,
 			isFromMe,
 			isGroup,
 			pushName: asString(info.push_name),
@@ -450,26 +451,36 @@ const ADAPTERS = {
 
 	// ── Calls ──
 	incoming_call: (data, logger) => adaptIncomingCall(data, logger),
-	missed_call: data => {
+	missed_call: (data, logger) => {
 		const from = asJidString(data?.from)
 		const callId = asString(data?.call_id)
 		if (!from || !callId) return null
+		const timestamp = asUnixSeconds(data?.timestamp)
+		if (timestamp === undefined) {
+			logger?.debug({ data }, 'missed_call adapter: missing or invalid timestamp')
+			return null
+		}
 		return {
 			type: 'incomingCall',
 			from,
-			timestamp: toUnixSeconds(data?.timestamp),
+			timestamp,
 			offline: data?.reason === 'offline',
 			action: { type: 'timeout', callId }
 		}
 	},
-	call_ended_elsewhere: data => {
+	call_ended_elsewhere: (data, logger) => {
 		const from = asJidString(data?.from)
 		const callId = asString(data?.call_id)
 		if (!from || !callId) return null
+		const timestamp = asUnixSeconds(data?.timestamp)
+		if (timestamp === undefined) {
+			logger?.debug({ data }, 'call_ended_elsewhere adapter: missing or invalid timestamp')
+			return null
+		}
 		return {
 			type: 'incomingCall',
 			from,
-			timestamp: toUnixSeconds(data?.timestamp),
+			timestamp,
 			offline: false,
 			action: { type: data?.outcome === 'accepted' ? 'accept' : 'reject', callId }
 		}
@@ -737,6 +748,15 @@ export const adaptBridgeMessageWire = (
 	const isFromMe = asBoolOr(info.isFromMe, false)
 	const senderAlt = asString(info.senderAlt)
 	const recipientAlt = asString(info.recipientAlt)
+	// The packed envelope carries the timestamp as a numeric record, so the
+	// only invalid shapes here are a missing or non-finite value. Like the
+	// object route below, those drop the message rather than dating it at
+	// the epoch.
+	const timestamp = asNumber(info.timestamp)
+	if (timestamp === undefined) {
+		logger?.debug({ info }, 'message wire adapter: missing or invalid timestamp')
+		return null
+	}
 	return {
 		type: 'message',
 		chatJid: chat,
@@ -744,7 +764,7 @@ export const adaptBridgeMessageWire = (
 		isGroup,
 		isFromMe,
 		id,
-		timestamp: asNumber(info.timestamp) ?? 0,
+		timestamp,
 		pushName: asString(info.pushName),
 		participantAlt: resolveParticipantAlt(senderAlt, isGroup),
 		remoteJidAlt: resolveRemoteJidAlt(senderAlt, recipientAlt, isGroup, isFromMe),
@@ -775,6 +795,11 @@ const adaptMessageParts = (
 	const senderJid = isGroup ? asJidString(senderRaw) : undefined
 	const senderAlt = asJidString(src.sender_alt)
 	const recipientAlt = asJidString(src.recipient_alt)
+	const timestamp = asUnixSeconds(info.timestamp)
+	if (timestamp === undefined) {
+		logger?.debug({ info }, 'message adapter: missing or invalid timestamp')
+		return null
+	}
 	return {
 		type: 'message',
 		chatJid: chat,
@@ -782,7 +807,7 @@ const adaptMessageParts = (
 		isGroup,
 		isFromMe,
 		id,
-		timestamp: toUnixSeconds(info.timestamp),
+		timestamp,
 		pushName: asString(info.push_name),
 		participantAlt: resolveParticipantAlt(senderAlt, isGroup),
 		remoteJidAlt: resolveRemoteJidAlt(senderAlt, recipientAlt, isGroup, isFromMe),
@@ -805,6 +830,16 @@ const adaptReceipt = (data: BridgeData<'receipt'>, logger?: ILogger): CanonicalE
 		return null
 	}
 	const isGroup = resolveIsGroup(src.is_group, chat)
+	// A receipt without a trustworthy timestamp cannot be placed on any
+	// timeline slot (`readTimestamp` / `playedTimestamp` /
+	// `receiptTimestamp`), so the event is dropped rather than dated at the
+	// epoch. Optional timestamps elsewhere stay absent via `asUnixSeconds`.
+	const timestamp = asUnixSeconds(data.timestamp)
+	if (timestamp === undefined) {
+		logger?.debug({ data }, 'receipt adapter: missing or invalid timestamp')
+		return null
+	}
+	const { receiptType, raw: receiptTypeRaw } = parseReceiptType(data.type)
 	return {
 		type: 'receipt',
 		chatJid: chat,
@@ -812,8 +847,9 @@ const adaptReceipt = (data: BridgeData<'receipt'>, logger?: ILogger): CanonicalE
 		isGroup,
 		isFromMe: asBoolOr(src.is_from_me, false),
 		messageIds: ids,
-		timestamp: toUnixSeconds(data.timestamp),
-		receiptType: parseReceiptType(data.type)
+		timestamp,
+		receiptType,
+		...(receiptTypeRaw !== undefined ? { receiptTypeRaw } : {})
 	}
 }
 
@@ -834,7 +870,8 @@ const adaptContactUpdate = (data: unknown): CanonicalEvent | null => {
 }
 
 /**
- * Bridge wire `ReceiptType` → canonical kebab-cased variant.
+ * Bridge wire `ReceiptType` → canonical kebab-cased variant, preserving the
+ * original value when it matches nothing known.
  *
  * The bridge's generated `.d.ts` advertises `ReceiptType` as
  * `{type: "delivered"} | …`, but `#[serde(from = "String")]` on the rust
@@ -842,6 +879,11 @@ const adaptContactUpdate = (data: unknown): CanonicalEvent | null => {
  * bare PascalCase variant name (`"Delivered"`, `"Read"`, `"PeerMsg"`).
  * Keep both spellings here so a future bridge bump that re-introduces
  * the snake_case wire form keeps working.
+ *
+ * Unrecognized wire values arrive wrapped as `{ Other: value }` (the packed
+ * `ReceiptWireData.type` contract) or, defensively, as a future bare
+ * string. Those map to `'other'` with the original value in `raw`; a known
+ * value wrapped in `{ Other }` normalizes to its category with no residue.
  */
 const RECEIPT_TYPE_MAP: Record<string, NonNullable<CanonicalReceipt['receiptType']>> = {
 	Delivered: 'delivered',
@@ -872,10 +914,18 @@ const RECEIPT_TYPE_MAP: Record<string, NonNullable<CanonicalReceipt['receiptType
 	server_error: 'server-error'
 }
 
-const parseReceiptType = (raw: unknown): CanonicalReceipt['receiptType'] => {
-	const norm = typeof raw === 'string' ? raw : isObject(raw) && typeof raw.type === 'string' ? raw.type : undefined
-	if (norm == null) return undefined
-	return RECEIPT_TYPE_MAP[norm] ?? 'other'
+const parseReceiptType = (raw: unknown): { receiptType: CanonicalReceipt['receiptType']; raw?: string } => {
+	const norm =
+		typeof raw === 'string'
+			? raw
+			: isObject(raw) && typeof raw.type === 'string'
+				? raw.type
+				: isObject(raw) && typeof raw.Other === 'string'
+					? raw.Other
+					: undefined
+	if (norm == null) return { receiptType: undefined }
+	const mapped = RECEIPT_TYPE_MAP[norm]
+	return mapped ? { receiptType: mapped } : { receiptType: 'other', raw: norm }
 }
 
 const adaptStarUpdate = (data: BridgeData<'star_update'>): CanonicalEvent | null => {
@@ -917,6 +967,14 @@ const adaptIncomingCall = (data: BridgeData<'incoming_call'>, logger?: ILogger):
 		return null
 	}
 
+	// The call offer is timeline-ordered by its timestamp downstream; an
+	// unparseable one drops the event rather than dating it at the epoch.
+	const timestamp = asUnixSeconds(data.timestamp)
+	if (timestamp === undefined) {
+		logger?.debug({ data }, 'incoming_call adapter: missing or invalid timestamp')
+		return null
+	}
+
 	const canonicalAction: CanonicalCallAction = {
 		type: actionType,
 		callId,
@@ -939,7 +997,7 @@ const adaptIncomingCall = (data: BridgeData<'incoming_call'>, logger?: ILogger):
 	return {
 		type: 'incomingCall',
 		from: asJidAddressString(data.from) ?? from,
-		timestamp: toUnixSeconds(data.timestamp),
+		timestamp,
 		offline: asBoolOr(data.offline, false),
 		stanzaId: asString(data.stanza_id),
 		notify: asString(data.notify),
@@ -1164,6 +1222,11 @@ const adaptGroupUpdate = (data: BridgeData<'group_update'>, logger?: ILogger): C
 		logger?.warn({ data }, 'group_update adapter: action shape rejected')
 		return null
 	}
+	const timestamp = asUnixSeconds(data.timestamp)
+	if (timestamp === undefined) {
+		logger?.debug({ data }, 'group_update adapter: missing or invalid timestamp')
+		return null
+	}
 	return {
 		type: 'groupUpdate',
 		groupJid,
@@ -1173,7 +1236,7 @@ const adaptGroupUpdate = (data: BridgeData<'group_update'>, logger?: ILogger): C
 		authorPn: asJidString(data.participant_pn),
 		authorUsername: asString(data.participant_username),
 		authorCountryCode: asString(data.participant_country_code),
-		timestamp: toUnixSeconds(data.timestamp),
+		timestamp,
 		isLidAddressingMode: asBoolOr(data.is_lid_addressing_mode, false),
 		action
 	}

--- a/src/Bridge/schema.ts
+++ b/src/Bridge/schema.ts
@@ -96,6 +96,18 @@ const resolveRemoteJidAlt = (
 	isFromMe: boolean
 ): string | undefined => (isGroup ? undefined : isFromMe ? recipientAlt : senderAlt)
 
+/**
+ * Rejection diagnostic for a required timestamp that is missing or
+ * unparseable. Metadata only — never the payload: these objects can carry
+ * message bodies and JIDs.
+ */
+const invalidTimestampDetail = (event: string, raw: unknown): Record<string, unknown> => ({
+	event,
+	field: 'timestamp',
+	reason: raw === undefined || raw === null ? 'missing' : 'invalid',
+	receivedType: typeof raw
+})
+
 const parseEditAttribute = (value: unknown): CanonicalMessage['editAttribute'] => {
 	switch (value) {
 		case '1':
@@ -205,7 +217,7 @@ const ADAPTERS = {
 			error: asString(data?.error)
 		}
 	},
-	undecryptable_message: data => {
+	undecryptable_message: (data, logger) => {
 		// Bridge ships `{ info: MessageInfo, is_unavailable, unavailable_type,
 		// decrypt_fail_mode }` — same MessageInfo shape as the regular
 		// `message` event. Extract the chat / sender / id so the dispatcher
@@ -223,7 +235,13 @@ const ADAPTERS = {
 		const senderAlt = asJidString(src.sender_alt)
 		const recipientAlt = asJidString(src.recipient_alt)
 		const timestamp = asUnixSeconds(info.timestamp)
-		if (timestamp === undefined) return null
+		if (timestamp === undefined) {
+			logger?.debug(
+				invalidTimestampDetail('undecryptable_message', info.timestamp),
+				'undecryptable_message adapter: missing or invalid timestamp'
+			)
+			return null
+		}
 		return {
 			type: 'undecryptableMessage',
 			chatJid: chat,
@@ -457,7 +475,10 @@ const ADAPTERS = {
 		if (!from || !callId) return null
 		const timestamp = asUnixSeconds(data?.timestamp)
 		if (timestamp === undefined) {
-			logger?.debug({ data }, 'missed_call adapter: missing or invalid timestamp')
+			logger?.debug(
+				invalidTimestampDetail('missed_call', data?.timestamp),
+				'missed_call adapter: missing or invalid timestamp'
+			)
 			return null
 		}
 		return {
@@ -474,7 +495,10 @@ const ADAPTERS = {
 		if (!from || !callId) return null
 		const timestamp = asUnixSeconds(data?.timestamp)
 		if (timestamp === undefined) {
-			logger?.debug({ data }, 'call_ended_elsewhere adapter: missing or invalid timestamp')
+			logger?.debug(
+				invalidTimestampDetail('call_ended_elsewhere', data?.timestamp),
+				'call_ended_elsewhere adapter: missing or invalid timestamp'
+			)
 			return null
 		}
 		return {
@@ -754,7 +778,10 @@ export const adaptBridgeMessageWire = (
 	// the epoch.
 	const timestamp = asNumber(info.timestamp)
 	if (timestamp === undefined) {
-		logger?.debug({ info }, 'message wire adapter: missing or invalid timestamp')
+		logger?.debug(
+			invalidTimestampDetail('message_wire', info.timestamp),
+			'message wire adapter: missing or invalid timestamp'
+		)
 		return null
 	}
 	return {
@@ -797,7 +824,7 @@ const adaptMessageParts = (
 	const recipientAlt = asJidString(src.recipient_alt)
 	const timestamp = asUnixSeconds(info.timestamp)
 	if (timestamp === undefined) {
-		logger?.debug({ info }, 'message adapter: missing or invalid timestamp')
+		logger?.debug(invalidTimestampDetail('message', info.timestamp), 'message adapter: missing or invalid timestamp')
 		return null
 	}
 	return {
@@ -836,7 +863,7 @@ const adaptReceipt = (data: BridgeData<'receipt'>, logger?: ILogger): CanonicalE
 	// epoch. Optional timestamps elsewhere stay absent via `asUnixSeconds`.
 	const timestamp = asUnixSeconds(data.timestamp)
 	if (timestamp === undefined) {
-		logger?.debug({ data }, 'receipt adapter: missing or invalid timestamp')
+		logger?.debug(invalidTimestampDetail('receipt', data.timestamp), 'receipt adapter: missing or invalid timestamp')
 		return null
 	}
 	const { receiptType, raw: receiptTypeRaw } = parseReceiptType(data.type)
@@ -882,8 +909,9 @@ const adaptContactUpdate = (data: unknown): CanonicalEvent | null => {
  *
  * Unrecognized wire values arrive wrapped as `{ Other: value }` (the packed
  * `ReceiptWireData.type` contract) or, defensively, as a future bare
- * string. Those map to `'other'` with the original value in `raw`; a known
- * value wrapped in `{ Other }` normalizes to its category with no residue.
+ * string. Those map to `'other'` with the original value in `raw`. The
+ * wrapper is trusted over spelling: `{ Other: 'Read' }` is `other`, not
+ * `read` (see `parseReceiptType`).
  */
 const RECEIPT_TYPE_MAP: Record<string, NonNullable<CanonicalReceipt['receiptType']>> = {
 	Delivered: 'delivered',
@@ -915,14 +943,14 @@ const RECEIPT_TYPE_MAP: Record<string, NonNullable<CanonicalReceipt['receiptType
 }
 
 const parseReceiptType = (raw: unknown): { receiptType: CanonicalReceipt['receiptType']; raw?: string } => {
-	const norm =
-		typeof raw === 'string'
-			? raw
-			: isObject(raw) && typeof raw.type === 'string'
-				? raw.type
-				: isObject(raw) && typeof raw.Other === 'string'
-					? raw.Other
-					: undefined
+	// The `Other` wrapper is authoritative: the packed codec round-trips
+	// `{ Other: value }` verbatim and never synthesizes it for a known
+	// variant, so even a payload whose spelling collides with a known
+	// variant name (e.g. `{ Other: 'Read' }`) stays category `other` with
+	// its exact payload preserved. Only bare strings and `{ type }` go
+	// through the known-variant lookup.
+	if (isObject(raw) && typeof raw.Other === 'string') return { receiptType: 'other', raw: raw.Other }
+	const norm = typeof raw === 'string' ? raw : isObject(raw) && typeof raw.type === 'string' ? raw.type : undefined
 	if (norm == null) return { receiptType: undefined }
 	const mapped = RECEIPT_TYPE_MAP[norm]
 	return mapped ? { receiptType: mapped } : { receiptType: 'other', raw: norm }
@@ -971,7 +999,10 @@ const adaptIncomingCall = (data: BridgeData<'incoming_call'>, logger?: ILogger):
 	// unparseable one drops the event rather than dating it at the epoch.
 	const timestamp = asUnixSeconds(data.timestamp)
 	if (timestamp === undefined) {
-		logger?.debug({ data }, 'incoming_call adapter: missing or invalid timestamp')
+		logger?.debug(
+			invalidTimestampDetail('incoming_call', data.timestamp),
+			'incoming_call adapter: missing or invalid timestamp'
+		)
 		return null
 	}
 
@@ -1224,7 +1255,10 @@ const adaptGroupUpdate = (data: BridgeData<'group_update'>, logger?: ILogger): C
 	}
 	const timestamp = asUnixSeconds(data.timestamp)
 	if (timestamp === undefined) {
-		logger?.debug({ data }, 'group_update adapter: missing or invalid timestamp')
+		logger?.debug(
+			invalidTimestampDetail('group_update', data.timestamp),
+			'group_update adapter: missing or invalid timestamp'
+		)
 		return null
 	}
 	return {

--- a/src/Bridge/types.ts
+++ b/src/Bridge/types.ts
@@ -207,6 +207,14 @@ export interface CanonicalReceipt {
 		| 'history-sync'
 		| 'server-error'
 		| 'other'
+	/**
+	 * Original wire value when `receiptType` is `'other'` — the bridge sends
+	 * unrecognized variants as `{ Other: value }` (or a future bare string),
+	 * and the category alone would lose which one it was. Absent whenever
+	 * the value matched a known variant (including a known value wrapped in
+	 * `{ Other }`) and whenever `receiptType` itself is absent.
+	 */
+	receiptTypeRaw?: string
 }
 
 // ── Contacts ──

--- a/src/Bridge/types.ts
+++ b/src/Bridge/types.ts
@@ -210,9 +210,12 @@ export interface CanonicalReceipt {
 	/**
 	 * Original wire value when `receiptType` is `'other'` — the bridge sends
 	 * unrecognized variants as `{ Other: value }` (or a future bare string),
-	 * and the category alone would lose which one it was. Absent whenever
-	 * the value matched a known variant (including a known value wrapped in
-	 * `{ Other }`) and whenever `receiptType` itself is absent.
+	 * and the category alone would lose which one it was. Always set for an
+	 * `Other`-wrapped payload, even when its spelling collides with a known
+	 * variant name: the wrapper means the producer did not recognize it.
+	 * Absent whenever the value matched a known variant through a bare
+	 * string or `{ type }` shape, and whenever `receiptType` itself is
+	 * absent.
 	 */
 	receiptTypeRaw?: string
 }

--- a/src/__fuzz__/bridge-events.fuzz.test.ts
+++ b/src/__fuzz__/bridge-events.fuzz.test.ts
@@ -449,10 +449,12 @@ describe('bridge event adaptation', () => {
 					}
 				}
 				// Dropping a payload is allowed only where the adapter says it is.
-				// `adaptBridgeMessageWire` returns null on exactly two conditions — a
-				// non-object message, or a `chat`/`id` that is not a non-empty string —
-				// and the generator produces plenty of those on purpose. Anything else
-				// is a *valid* message being dropped.
+				// `adaptBridgeMessageWire` returns null on exactly three conditions — a
+				// non-object message, a `chat`/`id` that is not a non-empty string, or a
+				// missing/non-finite timestamp (a message that cannot be placed on any
+				// timeline is dropped rather than dated at the epoch) — and the
+				// generator produces plenty of those on purpose. Anything else is a
+				// *valid* message being dropped.
 				//
 				// Skipping every null was too generous by a whole category. The
 				// `accepted > 0` floor below only catches total collapse, so an adapter
@@ -472,7 +474,9 @@ describe('bridge event adaptation', () => {
 					typeof info?.chat === 'string' &&
 					info.chat.length > 0 &&
 					typeof info.id === 'string' &&
-					info.id.length > 0
+					info.id.length > 0 &&
+					typeof info.timestamp === 'number' &&
+					Number.isFinite(info.timestamp)
 				if (canonical === null) {
 					if (!wellFormed) return []
 					return {


### PR DESCRIPTION
# BA-02: receipt and timestamp fidelity on both wire routes

Receipts and required timestamps now adapt identically on the object and
packed routes, unknown receipt values survive with their original payload,
and invalid timestamps can no longer silently become the epoch.

## Behavior changes (deliberate, not backwards-compatible in behavior)

- Events with a missing, malformed, or non-finite **required** timestamp
  (message, receipt, group update, incoming/missed/elsewhere call,
  undecryptable message, on both routes) are now **dropped** (`null` +
  metadata-only debug log) instead of being dated at the epoch (`0`).
  `0` remains a valid timestamp and still means 1970-01-01.
- `toUnixSeconds` is retained as an export but no longer fabricates the
  epoch: valid finite numbers and RFC3339 strings pass through, everything
  else throws `RangeError`. Internal adapters use `asUnixSeconds` with the
  per-field policy above; no in-tree caller uses `toUnixSeconds`.

## Changes by file

- `src/Bridge/schema.ts` — `parseReceiptType` accepts bare strings,
  `{ type }`, and `{ Other }`; the `Other` wrapper is authoritative (even
  on spelling collisions such as `{ Other: 'Read' }`); known-variant
  lookup uses an own-property guard so prototype names (`constructor`,
  `__proto__`, …) map to `other` instead of resolving to inherited
  members. All required-timestamp sites drop on invalid input with a
  metadata-only diagnostic (`{event, field, reason, receivedType}` — never
  the payload). Packed receipt batches reuse `adaptReceipt`, so both
  routes agree by construction.
- `src/Bridge/types.ts` — additive `CanonicalReceipt.receiptTypeRaw`:
  set only when `receiptType` is `'other'`, carrying the exact wire value.
- `src/Bridge/primitives.ts` — removed the epoch-fallback `toUnixSeconds`
  and reintroduced it as a validating helper that throws `RangeError` on
  invalid input; `asUnixSeconds` (absence stays absent) unchanged and
  documented with the required/optional policy.
- `src/Bridge/index.ts` — re-exports the retained `toUnixSeconds`.
- `src/Bridge/__tests__/wire-event-fidelity.test.ts` (new) — fidelity
  fixtures: known bare/snake/`{type}` variants, `Other` collisions
  (`'Read'`, `'read'`, `''`, unknown), absent/malformed types,
  prototype-chain names in all three shapes, packed-codec round-trip
  (`{Other}` preserved verbatim, known stays bare), object-vs-packed
  canonical equivalence, required-timestamp matrix (RFC3339, zero,
  absent, invalid string, NaN, Infinity), optional-timestamp omission,
  and the retained-export contract.
- `src/__fuzz__/bridge-events.fuzz.test.ts` — `bridge:message-wire`
  check documents the third null condition (missing/non-finite
  timestamp); liveness floor and envelope assertions unchanged.

## Validation (HEAD `e016e54`, bridge 0.20.0 pinned, no bump)

- New suite: 21 fidelity tests pass; each defect fixture failed before its
  fix and passes after (same scenarios).
- Focused: fidelity + `adapt` + `regressions` + `bridge-events` fuzz —
  231 tests, 231 pass, 0 fail.
- Full `npm test` on the prior commit of this branch: 1433 tests, 1432
  pass, 0 fail, 1 pre-existing skip (not rerun after the final 3-line
  lookup guard; the affected suites above all pass on HEAD).
- `npm run build`, `format:check`, `lint` (`tsc` + `oxlint`): pass.
- Audits on this branch: `compat:audit` exit 0, 97.83%, events 100%;
  `compat:audit:wire` exit 0 with 2 known `pollResultSnapshotMessageV3`
  divergences; `compat:audit:proto` exit 0 with known wire gaps (none in
  receipt/timestamp areas); `compat:audit:lifecycle` exit 0 (28 hold,
  0 violated). These are pre-existing baseline gaps, not regressions.
- `test:e2e` not run (requires dedicated infra; no login/session needed
  for this lot).

## Compatibility notes

- `receiptTypeRaw` is additive and optional; the dispatcher needs no
  change (`'other'` still routes to `receiptTimestamp`).
- Dropping corrupt-timestamp events instead of epoch-dating them changes
  observable behavior for malformed input only; well-formed events are
  byte-identical in outcome to before.
- Producer required/optional matrix with pinned-contract references is
  kept as local evidence (`agent_prompts/`, not in this PR); declaration
  inspection is called out there as contract evidence, not a runtime
  producer test — the runtime evidence is the packed-codec round-trip.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes receipt and timestamp fidelity on both object and packed wire routes: unknown receipt types now keep their original wire value, and events with invalid required timestamps are dropped instead of silently dated at the epoch.

- Events with a missing, malformed, or non-finite required timestamp (message, receipt, call, group update, undecryptable message) are dropped with a metadata-only debug log; `0` remains valid and still means 1970-01-01.
- Unrecognized receipt variants map to `'other'` and preserve the exact wire value in the new optional `receiptTypeRaw` field; the `{ Other }` wrapper is authoritative even on spelling collisions, and prototype-chain names like `constructor` map to `other`.
- Packed receipt batches reuse the same `adaptReceipt`, so both routes agree by construction.
- `toUnixSeconds` is retained as an export but now throws `RangeError` on invalid input instead of returning 0; internal adapters use `asUnixSeconds` with an explicit per-field policy.
- The behavior change affects only malformed input; well-formed events produce identical outcomes.

<sup>Written for commit e016e54d8254c3d27527a46fbaa64278dabf7ad1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or missing timestamps no longer default to the Unix epoch; affected events are dropped instead.
  * Valid zero timestamps remain supported, while optional invalid timestamps remain absent.
  * Receipt types are normalized more consistently across supported wire formats.
  * Unrecognized receipt values now preserve their original raw value.

* **Documentation**
  * Expanded timestamp handling documentation and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->