### PR TITLE
fix(socket): terminal close publishes exactly once per socket

### DIFF
--- a/src/Socket/terminal-close-reporter.ts
+++ b/src/Socket/terminal-close-reporter.ts
@@ -45,12 +45,20 @@ export interface TerminalCloseReporter {
 	 * Never rejects and never leaves `publish` uncalled: teardown failures are
 	 * logged, a throwing listener is contained, and a teardown that hangs is
 	 * cut short by the watchdog.
+	 *
+	 * Idempotent per socket: the first claim wins and every later call is a
+	 * no-op. A socket never gets a second generation — a terminal close means
+	 * "build a new socket" — so a second terminal event (a logout racing a
+	 * dispatcher close, a late duplicate dispatch) must not publish again.
 	 */
 	reportAfter: (teardown: () => Promise<void>, publish: () => void) => void
 	/**
 	 * Publish immediately, for a close nothing else will announce — a `logout()`
 	 * with no live client, or one whose `logout()` threw before the bridge
 	 * dispatched anything.
+	 *
+	 * Part of the same single claim as `reportAfter`: a no-op when a close
+	 * was already claimed.
 	 */
 	reportNow: (publish: () => void) => void
 	/**
@@ -66,11 +74,13 @@ export interface TerminalCloseReporter {
 	 */
 	hasReported: () => boolean
 	/**
-	 * Settles once the most recent report has been published — the moment the
+	 * Settles once the single report has been published — the moment the
 	 * consumer sees it, not the moment teardown finishes, so a waiter is not
 	 * left hanging when the watchdog is what released the event.
 	 *
-	 * Resolves immediately when nothing has been reported.
+	 * Resolves immediately when nothing has been reported. Every waiter
+	 * observes the same promise, so concurrent `logout()` and dispatcher
+	 * paths cannot split across generations.
 	 */
 	published: () => Promise<void>
 }
@@ -83,9 +93,23 @@ export const makeTerminalCloseReporter = (opts: {
 	const { logger } = opts
 	const publishTimeoutMs = opts.publishTimeoutMs ?? TERMINAL_CLOSE_PUBLISH_TIMEOUT_MS
 
-	/** Claims, not deliveries — see `hasReported`. */
+	/**
+	 * Claims, not deliveries — see `hasReported`. At most one: a socket has a
+	 * single terminal generation, so the first claim wins and later ones are
+	 * ignored rather than published.
+	 */
 	let claimed = 0
 	let publishedPromise: Promise<void> | undefined
+
+	/** True once the single terminal generation has been claimed. */
+	const claim = (): boolean => {
+		if (claimed > 0) {
+			logger.debug('terminal close already claimed; ignoring a duplicate terminal signal')
+			return false
+		}
+		claimed++
+		return true
+	}
 
 	/** One publish per claim, whatever gets there first, and never throwing. */
 	const makeOnce = (publish: () => void, settle: () => void) => {
@@ -107,7 +131,7 @@ export const makeTerminalCloseReporter = (opts: {
 
 	return {
 		reportAfter: (teardown, publish) => {
-			claimed++
+			if (!claim()) return
 			let settle!: () => void
 			publishedPromise = new Promise<void>(resolve => {
 				settle = resolve
@@ -143,7 +167,7 @@ export const makeTerminalCloseReporter = (opts: {
 		},
 
 		reportNow: publish => {
-			claimed++
+			if (!claim()) return
 			let settle!: () => void
 			publishedPromise = new Promise<void>(resolve => {
 				settle = resolve

--- a/src/Socket/terminal-close-reporter.ts
+++ b/src/Socket/terminal-close-reporter.ts
@@ -1,6 +1,13 @@
 /**
- * Reports the terminal `connection.update { close }` — exactly once, after
- * teardown, and never silently not at all.
+ * Reports the terminal `connection.update { close }` — exactly once, and
+ * never silently not at all.
+ *
+ * The accepted claim publishes after its teardown settles, so a consumer that
+ * answers the close with a replacement socket does not overlap the old one's
+ * release. The watchdog is the deliberate exception: past the timeout the
+ * close goes out with teardown still running (and logged), because losing the
+ * event entirely is the worse failure. Nothing here promises that every close
+ * lands after every resource is released — only that at most one close lands.
  *
  * That sentence is the whole contract this branch sells, and getting it wrong
  * has two opposite failure modes, both bad:
@@ -8,9 +15,8 @@
  *  - **Not reported.** The consumer's handler never runs, so it never builds a
  *    replacement socket. A bot offline with nothing in its logs — the original
  *    bug this branch exists to fix.
- *  - **Reported early, or twice.** The replacement socket overlaps the old
- *    one's auth-store flush and `free()`, or every listener sees two terminal
- *    notifications for one socket and a handler that cleans up on close loops.
+ *  - **Reported twice.** Every listener sees two terminal notifications for
+ *    one socket and a handler that cleans up on close loops.
  *
  * Keeping both away used to be inline logic split across the dispatcher hook
  * and `logout()`, sharing a counter and a promise. Nine separate bugs came out
@@ -44,12 +50,17 @@ export interface TerminalCloseReporter {
 	 *
 	 * Never rejects and never leaves `publish` uncalled: teardown failures are
 	 * logged, a throwing listener is contained, and a teardown that hangs is
-	 * cut short by the watchdog.
+	 * reported past by the watchdog.
 	 *
-	 * Idempotent per socket: the first claim wins and every later call is a
-	 * no-op. A socket never gets a second generation — a terminal close means
-	 * "build a new socket" — so a second terminal event (a logout racing a
-	 * dispatcher close, a late duplicate dispatch) must not publish again.
+	 * Idempotent per socket: the first claim wins and every later call is
+	 * ignored entirely — neither its teardown nor its publish is invoked. A
+	 * socket never gets a second generation — a terminal close means "build a
+	 * new socket" — so a second terminal event (a logout racing a dispatcher
+	 * close, a late duplicate dispatch) must not publish again.
+	 *
+	 * The watchdog bounds how long `published()` waits, not the teardown
+	 * itself: it neither cancels nor settles the underlying teardown, and a
+	 * teardown that finishes late publishes nothing further.
 	 */
 	reportAfter: (teardown: () => Promise<void>, publish: () => void) => void
 	/**
@@ -101,12 +112,13 @@ export const makeTerminalCloseReporter = (opts: {
 	let claimed = 0
 	let publishedPromise: Promise<void> | undefined
 
-	/** True once the single terminal generation has been claimed. */
+	/**
+	 * True once the single terminal generation has been claimed. Deliberately
+	 * log-free: a duplicate arrives on a path whose logger is
+	 * consumer-replaceable, and an ignored signal must never throw.
+	 */
 	const claim = (): boolean => {
-		if (claimed > 0) {
-			logger.debug('terminal close already claimed; ignoring a duplicate terminal signal')
-			return false
-		}
+		if (claimed > 0) return false
 		claimed++
 		return true
 	}

--- a/src/__tests__/socket-dispose-integration.test.ts
+++ b/src/__tests__/socket-dispose-integration.test.ts
@@ -348,6 +348,30 @@ describe('makeWASocket: disposing stops the bridge run loop', { timeout: 120_000
 		}
 	})
 
+	it('end() followed by logout() reports exactly one close through the real socket', async () => {
+		// A plain `end()` is not terminal and claims no close, so the logout
+		// fallback that follows is the first claim — and it must stay the
+		// only one. Full path: real owner, real reporter, real `logout()`.
+		const counter = await startConnectionCounter()
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const sock = makeWASocket({ auth: state, logger: silentLogger, waWebSocketUrl: counter.url })
+
+			let closes = 0
+			sock.ev.on('connection.update', update => {
+				if (update.connection === 'close') closes++
+			})
+
+			await sock.end(undefined)
+			expect(closes).toBe(0)
+
+			await sock.logout().catch(() => {})
+			expect(closes).toBe(1)
+		} finally {
+			await counter.close()
+		}
+	})
+
 	it('refuses socket operations once teardown owns the client', async () => {
 		// `peek()` keeps returning the client through `closing` so teardown can
 		// still close the transport with it — but handing it to an ordinary

--- a/src/__tests__/terminal-close-idempotence.test.ts
+++ b/src/__tests__/terminal-close-idempotence.test.ts
@@ -1,14 +1,25 @@
 /**
- * Terminal-close idempotence through the real composition: the dispatcher
- * learns about the close and hands publishing to the reporter, the way
- * `src/Socket/index.ts` wires `onTerminalClose` to
- * `terminalClose.reportAfter(() => owner.close(error)..., publish)`.
+ * Terminal-close idempotence through the dispatcher + reporter composition.
+ *
+ * The wiring mirrors `src/Socket/index.ts`: the dispatcher learns about the
+ * close and hands publishing to the reporter via `onTerminalClose`, which
+ * claims `reportAfter` with the socket teardown. These tests prove the
+ * duplicate-close failure and its fix at that composition — but they are NOT
+ * full socket tests: teardowns are gates, `logout()` is simulated by calling
+ * the same `reportNow` fallback the socket calls, and no bridge client ever
+ * exists. Full-socket coverage (real `end()`/`logout()` through the owner)
+ * lives in `socket-dispose-integration.test.ts`.
  *
  * The unit of idempotence is one reporter lifetime — one socket. A socket
  * never gets a second generation (a terminal close means "build a new
  * socket"), so any second terminal signal for the same socket must not
  * publish again: not a duplicate dispatch, not a logout racing the
  * dispatcher, not a late event after the first publish settled.
+ *
+ * Timing is barrier-based, never wall-clock: the first claim's teardown waits
+ * on a gate the test releases, and `flush()` drains the microtask/macrotask
+ * queue so an un-gated duplicate publish would already have happened. Each
+ * suppression test below fails against the old per-claim implementation.
  */
 
 import { EventEmitter } from 'node:events'
@@ -31,7 +42,15 @@ const noopLogger = {
 	}
 }
 
-const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+/**
+ * Drain pending microtasks and macrotask callbacks without sleeping: any
+ * teardown that was never gated has resolved by the time this returns, so an
+ * assertion on "nothing published yet" is deterministic.
+ */
+const flush = async () => {
+	await new Promise<void>(resolve => setImmediate(resolve))
+	await new Promise<void>(resolve => setImmediate(resolve))
+}
 
 interface Harness {
 	ev: EventEmitter
@@ -39,6 +58,7 @@ interface Harness {
 	reporter: ReturnType<typeof makeTerminalCloseReporter>
 	closes: Array<Partial<ConnectionState>>
 	teardowns: number
+	releaseTeardown: () => void
 }
 
 const makeHarness = (): Harness => {
@@ -57,10 +77,15 @@ const makeHarness = (): Harness => {
 			throw new Error('not used')
 		}
 	} as unknown as SocketContext
+	let releaseTeardown!: () => void
+	const teardownGate = new Promise<void>(resolve => {
+		releaseTeardown = resolve
+	})
 	const harness = {} as Harness
 	harness.ev = ev
 	harness.closes = []
 	harness.teardowns = 0
+	harness.releaseTeardown = () => releaseTeardown()
 	harness.reporter = makeTerminalCloseReporter({ logger: noopLogger as never, publishTimeoutMs: 1000 })
 	ev.on('connection.update', (update: Partial<ConnectionState>) => {
 		if (update.connection === 'close') harness.closes.push(update)
@@ -68,7 +93,10 @@ const makeHarness = (): Harness => {
 	const handlers = makeEventHandlers(ctx, {
 		onTerminalClose: (_error, publish) => {
 			harness.reporter.reportAfter(async () => {
+				// Runs synchronously up to the gate, so the count is exact
+				// the moment `onEvent` returns — no flush needed to observe it.
 				harness.teardowns++
+				await teardownGate
 			}, publish)
 		}
 	})
@@ -76,14 +104,23 @@ const makeHarness = (): Harness => {
 	return harness
 }
 
+const loggedOut = { type: 'logged_out', data: { reason: 'LoggedOut' } } as never
+const streamReplaced = { type: 'stream_replaced' } as never
+
 describe('terminal close idempotence: dispatcher + reporter', () => {
 	it('two sequential terminal events publish exactly one close', async () => {
 		const h = makeHarness()
 
-		h.onEvent({ type: 'logged_out', data: { reason: 'LoggedOut' } } as never)
-		h.onEvent({ type: 'stream_replaced' } as never)
+		h.onEvent(loggedOut)
+		h.onEvent(streamReplaced)
+		// The second claim must not even start its teardown, let alone publish.
+		expect(h.teardowns).toBe(1)
+
+		await flush()
+		expect(h.closes.length).toBe(0)
+
+		h.releaseTeardown()
 		await h.reporter.published()
-		await wait(20)
 
 		expect(h.closes.length).toBe(1)
 		expect(h.teardowns).toBe(1)
@@ -92,10 +129,13 @@ describe('terminal close idempotence: dispatcher + reporter', () => {
 	it('a duplicate of the same terminal event publishes once', async () => {
 		const h = makeHarness()
 
-		h.onEvent({ type: 'logged_out', data: { reason: 'LoggedOut' } } as never)
-		h.onEvent({ type: 'logged_out', data: { reason: 'LoggedOut' } } as never)
+		h.onEvent(loggedOut)
+		h.onEvent(loggedOut)
+		expect(h.teardowns).toBe(1)
+
+		h.releaseTeardown()
 		await h.reporter.published()
-		await wait(20)
+		await flush()
 
 		expect(h.closes.length).toBe(1)
 	})
@@ -103,35 +143,47 @@ describe('terminal close idempotence: dispatcher + reporter', () => {
 	it('a late terminal event after the first publish settled is ignored', async () => {
 		const h = makeHarness()
 
-		h.onEvent({ type: 'logged_out', data: { reason: 'LoggedOut' } } as never)
+		h.onEvent(loggedOut)
+		h.releaseTeardown()
 		await h.reporter.published()
-		h.onEvent({ type: 'stream_replaced' } as never)
-		await h.reporter.published()
-		await wait(20)
+		expect(h.closes.length).toBe(1)
+
+		h.onEvent(streamReplaced)
+		expect(h.teardowns).toBe(1)
+		await flush()
 
 		expect(h.closes.length).toBe(1)
 	})
 
-	it('logout fallback after a dispatcher close does not add a second close', async () => {
-		// `logout()` with a live client: the bridge dispatches `LoggedOut`
-		// (claimed), then the fallback rechecks `hasReported()` — and even if
-		// that recheck raced, `reportNow` itself is a no-op past the claim.
+	it('a reportNow fallback racing an in-flight reportAfter publishes nothing extra', async () => {
+		// Reporter-level simulation of the socket's `logout()` fallback: the
+		// bridge already dispatched `LoggedOut` (claim one, teardown gated),
+		// then the fallback's `reportNow` lands before teardown settles. It
+		// must be absorbed into the in-flight claim, not published alongside.
 		const h = makeHarness()
 
-		h.onEvent({ type: 'logged_out', data: { reason: 'LoggedOut' } } as never)
+		h.onEvent(loggedOut)
 		h.reporter.reportNow(() => {
 			h.ev.emit('connection.update', { connection: 'close' } as Partial<ConnectionState>)
 		})
+		await flush()
+		expect(h.closes.length).toBe(0)
+
+		h.releaseTeardown()
 		await h.reporter.published()
-		await wait(20)
+		await flush()
 
 		expect(h.closes.length).toBe(1)
 	})
 
-	it('logout with no live client still reports its one close', async () => {
-		// No dispatcher claim at all: the fallback is the first and only one.
+	it('reportNow as the first claim publishes the one close', async () => {
+		// Reporter-level simulation of the no-live-client logout fallback:
+		// nothing dispatched, so the fallback is the first and only claim.
+		// (Whether a real `sock.logout()` reaches this path is covered by
+		// the socket-dispose integration tests, not here.)
 		const h = makeHarness()
 
+		expect(h.reporter.hasReported()).toBe(false)
 		h.reporter.reportNow(() => {
 			h.ev.emit('connection.update', { connection: 'close' } as Partial<ConnectionState>)
 		})
@@ -141,7 +193,7 @@ describe('terminal close idempotence: dispatcher + reporter', () => {
 		expect(h.reporter.hasReported()).toBe(true)
 	})
 
-	it('a transient drop keeps reporting connecting and never claims the close', async () => {
+	it('a transient drop claims nothing, so the terminal close that follows is still the first', async () => {
 		const h = makeHarness()
 		const connections: Array<string | undefined> = []
 		h.ev.on('connection.update', (update: Partial<ConnectionState>) => {
@@ -149,23 +201,60 @@ describe('terminal close idempotence: dispatcher + reporter', () => {
 		})
 
 		h.onEvent({ type: 'disconnected' } as never)
-
 		expect(h.reporter.hasReported()).toBe(false)
 		expect(h.closes.length).toBe(0)
 		expect(connections).toEqual(['connecting'])
-	})
 
-	it('end without a terminal event claims nothing, so a later logout still closes once', async () => {
-		// A plain `end()` reports nothing through the reporter. The logout
-		// fallback that follows is therefore the first claim, not a duplicate.
-		const h = makeHarness()
-
-		expect(h.reporter.hasReported()).toBe(false)
-		h.reporter.reportNow(() => {
-			h.ev.emit('connection.update', { connection: 'close' } as Partial<ConnectionState>)
-		})
+		h.onEvent(loggedOut)
+		h.releaseTeardown()
 		await h.reporter.published()
 
 		expect(h.closes.length).toBe(1)
+	})
+
+	it('an ignored duplicate never touches the logger, even a throwing one', async () => {
+		// The duplicate path must be side-effect-free: no teardown, no
+		// publish, no log call a hostile logger could turn into a throw.
+		const throwingLogger = {
+			trace(): never {
+				throw new Error('logger threw')
+			},
+			debug(): never {
+				throw new Error('logger threw')
+			},
+			info(): never {
+				throw new Error('logger threw')
+			},
+			warn(): never {
+				throw new Error('logger threw')
+			},
+			error(): never {
+				throw new Error('logger threw')
+			},
+			child() {
+				return throwingLogger
+			}
+		} as never
+		const reporter = makeTerminalCloseReporter({ logger: throwingLogger, publishTimeoutMs: 1000 })
+		let publishes = 0
+
+		reporter.reportAfter(
+			async () => {},
+			() => {
+				publishes++
+			}
+		)
+		reporter.reportAfter(
+			async () => {},
+			() => {
+				publishes++
+			}
+		)
+		reporter.reportNow(() => {
+			publishes++
+		})
+		await reporter.published()
+
+		expect(publishes).toBe(1)
 	})
 })

--- a/src/__tests__/terminal-close-idempotence.test.ts
+++ b/src/__tests__/terminal-close-idempotence.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Terminal-close idempotence through the real composition: the dispatcher
+ * learns about the close and hands publishing to the reporter, the way
+ * `src/Socket/index.ts` wires `onTerminalClose` to
+ * `terminalClose.reportAfter(() => owner.close(error)..., publish)`.
+ *
+ * The unit of idempotence is one reporter lifetime — one socket. A socket
+ * never gets a second generation (a terminal close means "build a new
+ * socket"), so any second terminal signal for the same socket must not
+ * publish again: not a duplicate dispatch, not a logout racing the
+ * dispatcher, not a late event after the first publish settled.
+ */
+
+import { EventEmitter } from 'node:events'
+import { describe, it } from 'node:test'
+
+import { makeEventHandlers } from '../Socket/events.ts'
+import { makeTerminalCloseReporter } from '../Socket/terminal-close-reporter.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import type { ConnectionState } from '../Types/index.ts'
+import { expect } from './expect.ts'
+
+const noopLogger = {
+	trace() {},
+	debug() {},
+	info() {},
+	warn() {},
+	error() {},
+	child() {
+		return noopLogger
+	}
+}
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+interface Harness {
+	ev: EventEmitter
+	onEvent: (event: never) => void
+	reporter: ReturnType<typeof makeTerminalCloseReporter>
+	closes: Array<Partial<ConnectionState>>
+	teardowns: number
+}
+
+const makeHarness = (): Harness => {
+	const ev = new EventEmitter()
+	const ctx = {
+		ev,
+		logger: noopLogger,
+		fullConfig: {},
+		ws: new EventEmitter(),
+		getUser: () => undefined,
+		getMe: () => undefined,
+		setUser: () => {},
+		reportUnexpectedError: () => {},
+		getClient: () => Promise.reject(new Error('not used')),
+		getClientSync: () => {
+			throw new Error('not used')
+		}
+	} as unknown as SocketContext
+	const harness = {} as Harness
+	harness.ev = ev
+	harness.closes = []
+	harness.teardowns = 0
+	harness.reporter = makeTerminalCloseReporter({ logger: noopLogger as never, publishTimeoutMs: 1000 })
+	ev.on('connection.update', (update: Partial<ConnectionState>) => {
+		if (update.connection === 'close') harness.closes.push(update)
+	})
+	const handlers = makeEventHandlers(ctx, {
+		onTerminalClose: (_error, publish) => {
+			harness.reporter.reportAfter(async () => {
+				harness.teardowns++
+			}, publish)
+		}
+	})
+	harness.onEvent = handlers.onEvent as Harness['onEvent']
+	return harness
+}
+
+describe('terminal close idempotence: dispatcher + reporter', () => {
+	it('two sequential terminal events publish exactly one close', async () => {
+		const h = makeHarness()
+
+		h.onEvent({ type: 'logged_out', data: { reason: 'LoggedOut' } } as never)
+		h.onEvent({ type: 'stream_replaced' } as never)
+		await h.reporter.published()
+		await wait(20)
+
+		expect(h.closes.length).toBe(1)
+		expect(h.teardowns).toBe(1)
+	})
+
+	it('a duplicate of the same terminal event publishes once', async () => {
+		const h = makeHarness()
+
+		h.onEvent({ type: 'logged_out', data: { reason: 'LoggedOut' } } as never)
+		h.onEvent({ type: 'logged_out', data: { reason: 'LoggedOut' } } as never)
+		await h.reporter.published()
+		await wait(20)
+
+		expect(h.closes.length).toBe(1)
+	})
+
+	it('a late terminal event after the first publish settled is ignored', async () => {
+		const h = makeHarness()
+
+		h.onEvent({ type: 'logged_out', data: { reason: 'LoggedOut' } } as never)
+		await h.reporter.published()
+		h.onEvent({ type: 'stream_replaced' } as never)
+		await h.reporter.published()
+		await wait(20)
+
+		expect(h.closes.length).toBe(1)
+	})
+
+	it('logout fallback after a dispatcher close does not add a second close', async () => {
+		// `logout()` with a live client: the bridge dispatches `LoggedOut`
+		// (claimed), then the fallback rechecks `hasReported()` — and even if
+		// that recheck raced, `reportNow` itself is a no-op past the claim.
+		const h = makeHarness()
+
+		h.onEvent({ type: 'logged_out', data: { reason: 'LoggedOut' } } as never)
+		h.reporter.reportNow(() => {
+			h.ev.emit('connection.update', { connection: 'close' } as Partial<ConnectionState>)
+		})
+		await h.reporter.published()
+		await wait(20)
+
+		expect(h.closes.length).toBe(1)
+	})
+
+	it('logout with no live client still reports its one close', async () => {
+		// No dispatcher claim at all: the fallback is the first and only one.
+		const h = makeHarness()
+
+		h.reporter.reportNow(() => {
+			h.ev.emit('connection.update', { connection: 'close' } as Partial<ConnectionState>)
+		})
+		await h.reporter.published()
+
+		expect(h.closes.length).toBe(1)
+		expect(h.reporter.hasReported()).toBe(true)
+	})
+
+	it('a transient drop keeps reporting connecting and never claims the close', async () => {
+		const h = makeHarness()
+		const connections: Array<string | undefined> = []
+		h.ev.on('connection.update', (update: Partial<ConnectionState>) => {
+			connections.push(update.connection)
+		})
+
+		h.onEvent({ type: 'disconnected' } as never)
+
+		expect(h.reporter.hasReported()).toBe(false)
+		expect(h.closes.length).toBe(0)
+		expect(connections).toEqual(['connecting'])
+	})
+
+	it('end without a terminal event claims nothing, so a later logout still closes once', async () => {
+		// A plain `end()` reports nothing through the reporter. The logout
+		// fallback that follows is therefore the first claim, not a duplicate.
+		const h = makeHarness()
+
+		expect(h.reporter.hasReported()).toBe(false)
+		h.reporter.reportNow(() => {
+			h.ev.emit('connection.update', { connection: 'close' } as Partial<ConnectionState>)
+		})
+		await h.reporter.published()
+
+		expect(h.closes.length).toBe(1)
+	})
+})

--- a/src/__tests__/terminal-close-reporter.test.ts
+++ b/src/__tests__/terminal-close-reporter.test.ts
@@ -187,7 +187,10 @@ describe('terminal close: published', () => {
 		expect(published).toBe(true)
 	})
 
-	it('tracks the most recent report', async () => {
+	it('ignores a second claim: one socket has a single terminal generation', async () => {
+		// A terminal close means "build a new socket", so the same reporter
+		// must never publish twice — a logout racing a dispatcher close, or
+		// a late duplicate dispatch, is one generation, not two.
 		const reporter = makeReporter()
 		const seen: string[] = []
 
@@ -202,6 +205,73 @@ describe('terminal close: published', () => {
 		)
 		await reporter.published()
 
-		expect(seen).toEqual(['first', 'second'])
+		expect(seen).toEqual(['first'])
+	})
+
+	it('ignores a late duplicate after the first publish settled', async () => {
+		const reporter = makeReporter()
+		let publishes = 0
+
+		reporter.reportAfter(
+			async () => {},
+			() => {
+				publishes++
+			}
+		)
+		await reporter.published()
+
+		reporter.reportNow(() => {
+			publishes++
+		})
+		reporter.reportAfter(
+			async () => {},
+			() => {
+				publishes++
+			}
+		)
+		await reporter.published()
+		await wait(20)
+
+		expect(publishes).toBe(1)
+	})
+
+	it('a duplicate reportAfter never runs its teardown', async () => {
+		// The first teardown owns the release; a second terminal signal
+		// joining it would only re-enter work the owner already dedupes.
+		const reporter = makeReporter()
+		let teardowns = 0
+
+		reporter.reportAfter(
+			async () => {
+				teardowns++
+			},
+			() => {}
+		)
+		reporter.reportAfter(
+			async () => {
+				teardowns++
+			},
+			() => {}
+		)
+		await reporter.published()
+
+		expect(teardowns).toBe(1)
+	})
+
+	it('releases every waiter of published() on the single publish', async () => {
+		const reporter = makeReporter()
+		let publishes = 0
+
+		reporter.reportAfter(
+			async () => {
+				await wait(30)
+			},
+			() => {
+				publishes++
+			}
+		)
+		await Promise.all([reporter.published(), reporter.published(), reporter.published()])
+
+		expect(publishes).toBe(1)
 	})
 })


### PR DESCRIPTION
# fix(socket): terminal close publishes exactly once per socket

## Scope

Owns only `src/Socket/terminal-close-reporter.ts`, its unit tests, one new
dispatcher+reporter composition test file, and one real-socket
`end()`+`logout()` case in the existing dispose integration suite. No
dispatcher, schema, store, or bridge changes; bridge pin stays `0.20.0`.
This task does NOT adopt BR-04's future observation API and does not resolve
supervisor termination the old bridge never reports.

## Problem (reproduced, not assumed)

The reporter counted claims (`claimed++` per call) with a `makeOnce` per
claim, so every terminal signal published its own close. Proven through the
real dispatcher+reporter composition wired exactly like `index.ts`
(`onTerminalClose` → `reportAfter`): `logged_out` + `stream_replaced` and
duplicate `logged_out` each produced 2 closes / 2 teardowns for one socket
(repro commands and before/after counts kept in the task's local evidence
note; the ephemeral script itself was removed).

## Idempotence scope (exact)

One reporter lifetime = one socket = one terminal generation. The first
claim (`reportAfter` or `reportNow`) is accepted; every later call is ignored
entirely — neither its teardown nor its publish is invoked. A socket never
gets a second generation: a terminal close means "build a new socket".

## Watchdog exception (explicit)

The accepted claim publishes after its teardown settles, EXCEPT past
`TERMINAL_CLOSE_PUBLISH_TIMEOUT_MS`, when the close goes out with teardown
still running (and logged) rather than being lost. The watchdog bounds how
long `published()` waits — it neither cancels nor settles the underlying
teardown, and a late-finishing teardown publishes nothing further. This PR
does not promise that every close lands after all resources are released.

## Files

- `src/Socket/terminal-close-reporter.ts`: single-claim guard; duplicate
  path is side-effect-free (no teardown, no publish, no log call, so a
  throwing custom logger cannot disrupt it); contract docs updated for the
  watchdog exception. `src/Socket/index.ts` untouched — its `hasReported`
  rechecks are now belt-and-braces behind the reporter's own guard.
- `src/__tests__/terminal-close-reporter.test.ts`: the old "tracks the most
  recent report" case encoded the bug (two claims → two publishes) and now
  asserts single-generation suppression, plus no-teardown-on-duplicate and
  shared-`published()`-waiter cases.
- `src/__tests__/terminal-close-idempotence.test.ts` (new): dispatcher +
  reporter composition (gated teardowns, barrier-based timing, no sleeps).
  Helper-level by design: teardowns are gates and `logout()` is simulated via
  the same `reportNow` fallback the socket calls — no bridge client exists
  here. Covers duplicate/delayed/racing-terminal signals, first-claim
  `reportNow`, transient-drop-then-terminal, and throwing-logger duplicates.
- `src/__tests__/socket-dispose-integration.test.ts`: new real-socket case —
  `await sock.end()` (zero closes) then `await sock.logout()` (exactly one
  close) through the actual owner/reporter/logout path.

## Validation (final SHA `3e0563c`)

- Fail-before/pass-after: with the reporter restored to `8d99efa`, the 8
  new idempotence assertions fail; with the fix all pass (guards pass both).
- Focused: `terminal-close-reporter` + `terminal-close-idempotence` +
  `auto-reconnect-terminal-close` → 60/60 pass.
- Full `npm test` → 1424 pass, 0 fail, 1 skipped.
- `npm run build`, `format:check`, `lint` → pass.
- `compat:audit:lifecycle` → holds 28, violated 0 (LC-006 closes-at-most-once ok).
- Not run / N/A: `test:e2e` (no infra); release wasm-opt build is not
  applicable to this TypeScript-only change with the existing npm bridge pin.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal close reporting so each socket publishes its close exactly once, even when multiple terminal signals arrive (a logout racing a dispatcher close, or a duplicate dispatch). Previously, every terminal signal published its own close, producing two closes and two teardowns for one socket.

**Behavior**
- The first claim wins; every later `reportAfter` or `reportNow` call is ignored entirely — no teardown, no publish, no log call.
- Past the watchdog timeout, the close publishes with teardown still running rather than being lost; the watchdog bounds the wait but never cancels teardown.
- `end()` claims no close, so `end()` followed by `logout()` reports exactly one close through the real socket path.

<sup>Written for commit 3e0563cebb859ebf96efc526b3678a13f340d999. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

