### PR TITLE
fix(store): durable, serialized and error-honest bridge file store

### DIFF
--- a/src/Utils/__tests__/use-bridge-store-durability.test.ts
+++ b/src/Utils/__tests__/use-bridge-store-durability.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Durability contract for the file store:
+ *  - failure → identical retry re-attempts and persists (set, setMany, flush)
+ *  - setMany stays best-effort across keys with idempotent retry
+ *  - failed flushes keep pending work and propagate the error
+ *  - reads/deletes surface real errors; only absence is tolerated
+ *  - concurrent ops on one key serialize (set→delete, delete→set, flush)
+ *  - caller buffers and returned values are copies (no mutable aliasing)
+ *  - atomic replacement keeps the previous file intact across failures
+ *
+ * All faults go through the real `useBridgeStore` callbacks: filesystem
+ * states (ENOTDIR/ENOENT) for end-to-end failures and the
+ * `__testBridgeStoreIO` seam for write/rename-stage injection.
+ */
+
+import { strict as assert } from 'node:assert'
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+import { __testBridgeStoreIO, useBridgeStore } from '../use-bridge-store.ts'
+
+const enc = (s: string) => new TextEncoder().encode(s)
+const dec = (u: Uint8Array | null) => (u ? new TextDecoder().decode(u) : null)
+
+// `session` is a CRITICAL store (immediate durable write);
+// `msg_secret` is not (debounced, flush makes it durable).
+const CRITICAL = 'session'
+const NON_CRITICAL = 'msg_secret'
+
+const asFile = async (dir: string) => {
+	await rm(dir, { recursive: true, force: true })
+	await writeFile(dir, 'not a directory')
+}
+
+const asDir = async (dir: string) => {
+	await rm(dir, { force: true })
+	await mkdir(dir, { recursive: true })
+}
+
+const codedError = (message: string, code: string): NodeJS.ErrnoException => {
+	const err = new Error(message) as NodeJS.ErrnoException
+	err.code = code
+	return err
+}
+
+describe('useBridgeStore — durability', () => {
+	it('critical set failure → identical retry persists (no skip-after-failure)', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-set-'))
+		try {
+			const store = await useBridgeStore(dir)
+			const value = enc('ratchet-1')
+			await asFile(dir)
+			await assert.rejects(() => store.set(CRITICAL, 'addr', value), /ENOTDIR/)
+			// No torn file left behind by the failed write (ENOTDIR: the
+			// folder itself is a file here; ENOENT once it is removed).
+			await assert.rejects(() => access(join(dir, `${CRITICAL}-addr.bin`)), /ENO(TDIR|ENT)/)
+
+			await asDir(dir)
+			await store.set(CRITICAL, 'addr', value)
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-addr.bin`)), Buffer.from(value))
+
+			const reopened = await useBridgeStore(dir)
+			assert.equal(dec(await reopened.get(CRITICAL, 'addr')), 'ratchet-1')
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('critical setMany failure → identical retry persists', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-setmany-'))
+		try {
+			const store = await useBridgeStore(dir)
+			const entries: [string, Uint8Array][] = [
+				['a', enc('1')],
+				['b', enc('2')]
+			]
+			await asFile(dir)
+			await assert.rejects(() => store.setMany!(CRITICAL, entries), /ENOTDIR/)
+
+			await asDir(dir)
+			await store.setMany!(CRITICAL, entries)
+			assert.equal(dec(await store.get(CRITICAL, 'a')), '1')
+			assert.equal(dec(await store.get(CRITICAL, 'b')), '2')
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('setMany is best-effort across keys: one key fails, siblings persist, retry completes', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-besteffort-'))
+		const origWrite = __testBridgeStoreIO.writeTmp
+		try {
+			const store = await useBridgeStore(dir)
+			__testBridgeStoreIO.writeTmp = async (tmpPath, value) => {
+				if (tmpPath.includes(`${CRITICAL}-bad`)) throw codedError('injected write failure', 'EIO')
+				return origWrite(tmpPath, value)
+			}
+
+			const entries: [string, Uint8Array][] = [
+				['good', enc('g')],
+				['bad', enc('b')]
+			]
+			await assert.rejects(() => store.setMany!(CRITICAL, entries), /injected write failure/)
+			// Best-effort: the sibling was still applied.
+			assert.equal(dec(await store.get(CRITICAL, 'good')), 'g')
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-good.bin`)), Buffer.from(enc('g')))
+
+			__testBridgeStoreIO.writeTmp = origWrite
+			// Idempotent retry: `good` is already durable (skipped), `bad` is
+			// re-attempted and now persists.
+			await store.setMany!(CRITICAL, entries)
+			assert.equal(dec(await store.get(CRITICAL, 'bad')), 'b')
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-bad.bin`)), Buffer.from(enc('b')))
+		} finally {
+			__testBridgeStoreIO.writeTmp = origWrite
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('failed flush keeps pending work, throws again, and persists on retry', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-flush-'))
+		try {
+			const store = await useBridgeStore(dir)
+			await store.set(NON_CRITICAL, 'a', enc('v'))
+
+			await asFile(dir)
+			await assert.rejects(() => store.flush!(), /ENOTDIR/)
+			// Retained: a second flush re-attempts instead of resolving empty.
+			await assert.rejects(() => store.flush!(), /ENOTDIR/)
+
+			await asDir(dir)
+			await store.flush!()
+			assert.deepEqual(await readFile(join(dir, `${NON_CRITICAL}-a.bin`)), Buffer.from(enc('v')))
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('non-critical set while the folder is gone queues honestly: flush reports ENOENT, later flush persists', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-queued-'))
+		try {
+			const store = await useBridgeStore(dir)
+			await rm(dir, { recursive: true, force: true })
+
+			// Queueing is not durability: set resolves, flush must not claim
+			// the bytes reached disk.
+			await store.set(NON_CRITICAL, 'a', enc('v'))
+			assert.equal(dec(await store.get(NON_CRITICAL, 'a')), 'v')
+			await assert.rejects(() => store.flush!(), /ENOENT/)
+
+			await mkdir(dir, { recursive: true })
+			await store.flush!()
+			assert.deepEqual(await readFile(join(dir, `${NON_CRITICAL}-a.bin`)), Buffer.from(enc('v')))
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('reads surface real errors but return null for absent keys', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-read-'))
+		try {
+			const store = await useBridgeStore(dir)
+			assert.equal(await store.get(CRITICAL, 'missing'), null)
+			assert.deepEqual(await store.getMany!(CRITICAL, ['missing']), [])
+
+			await asFile(dir)
+			await assert.rejects(() => store.get(CRITICAL, 'k'), /ENOTDIR/)
+			await assert.rejects(() => store.getMany!(CRITICAL, ['k']), /ENOTDIR/)
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('deletes surface real errors but tolerate absent keys', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-del-'))
+		try {
+			const store = await useBridgeStore(dir)
+			await store.delete(CRITICAL, 'missing')
+			await store.deleteMany!(CRITICAL, [])
+
+			await asFile(dir)
+			await assert.rejects(() => store.delete(CRITICAL, 'k'), /ENOTDIR/)
+			await assert.rejects(() => store.deleteMany!(CRITICAL, ['k']), /ENOTDIR/)
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('set→delete serializes: delete waits for the in-flight write and the key stays gone', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-setdel-'))
+		const origWrite = __testBridgeStoreIO.writeTmp
+		let release!: () => void
+		try {
+			const store = await useBridgeStore(dir)
+			__testBridgeStoreIO.writeTmp = async (tmpPath, value) => {
+				await new Promise<void>(resolve => {
+					release = resolve
+				})
+				return origWrite(tmpPath, value)
+			}
+
+			const first = store.set(CRITICAL, 'k', enc('one'))
+			await new Promise(resolve => setTimeout(resolve, 50))
+			let deleteDone = false
+			const del = store.delete(CRITICAL, 'k').then(() => {
+				deleteDone = true
+			})
+			await new Promise(resolve => setTimeout(resolve, 100))
+			// The delete could not overtake the gated write.
+			assert.equal(deleteDone, false)
+			release()
+			await first
+			await del
+
+			assert.equal(await store.get(CRITICAL, 'k'), null)
+			await assert.rejects(() => access(join(dir, `${CRITICAL}-k.bin`)), /ENOENT/)
+		} finally {
+			__testBridgeStoreIO.writeTmp = origWrite
+			release?.()
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('delete→set serializes: the later write wins and is never resurrected over', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-delset-'))
+		try {
+			const store = await useBridgeStore(dir)
+			await store.set(CRITICAL, 'k', enc('seed'))
+			await store.delete(CRITICAL, 'k')
+			assert.equal(await store.get(CRITICAL, 'k'), null)
+
+			await store.set(CRITICAL, 'k', enc('new'))
+			assert.equal(dec(await store.get(CRITICAL, 'k')), 'new')
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('new')))
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('concurrent sets on one key serialize: the last scheduled value wins', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-conc-'))
+		const origWrite = __testBridgeStoreIO.writeTmp
+		let release!: () => void
+		try {
+			const store = await useBridgeStore(dir)
+			__testBridgeStoreIO.writeTmp = async (tmpPath, value) => {
+				await new Promise<void>(resolve => {
+					release = resolve
+				})
+				return origWrite(tmpPath, value)
+			}
+
+			const first = store.set(CRITICAL, 'k', enc('one'))
+			await new Promise(resolve => setTimeout(resolve, 50))
+			const second = store.set(CRITICAL, 'k', enc('two'))
+			await new Promise(resolve => setTimeout(resolve, 50))
+			release()
+			await first
+			__testBridgeStoreIO.writeTmp = origWrite
+			await second
+
+			assert.equal(dec(await store.get(CRITICAL, 'k')), 'two')
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('two')))
+		} finally {
+			__testBridgeStoreIO.writeTmp = origWrite
+			release?.()
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('mutating the caller buffer after set does not change persisted bytes', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-snap-'))
+		try {
+			const store = await useBridgeStore(dir)
+			const buf = enc('orig')
+			await store.set(CRITICAL, 'k', buf)
+			buf.fill(0)
+
+			const reopened = await useBridgeStore(dir)
+			assert.equal(dec(await reopened.get(CRITICAL, 'k')), 'orig')
+
+			// Same for debounced writes: the queued snapshot is immune too.
+			const buf2 = enc('queued')
+			await store.set(NON_CRITICAL, 'q', buf2)
+			buf2.fill(0)
+			await store.flush!()
+			assert.deepEqual(await readFile(join(dir, `${NON_CRITICAL}-q.bin`)), Buffer.from(enc('queued')))
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('get returns a copy: mutating it neither poisons the cache nor skips the next write', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-alias-'))
+		try {
+			const store = await useBridgeStore(dir)
+			await store.set(CRITICAL, 'k', enc('aaaa'))
+
+			const viewed = await store.get(CRITICAL, 'k')
+			assert.ok(viewed)
+			viewed.fill(0)
+			// Cache untouched — the next read still sees durable bytes.
+			assert.equal(dec(await store.get(CRITICAL, 'k')), 'aaaa')
+
+			// The mutated buffer is genuinely new data → the write happens.
+			await store.set(CRITICAL, 'k', viewed)
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(viewed))
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('rename-stage failure leaves the previous file intact and retryable', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-atomic-'))
+		const origPublish = __testBridgeStoreIO.publishTmp
+		try {
+			const store = await useBridgeStore(dir)
+			await store.set(CRITICAL, 'k', enc('old'))
+
+			let failOnce = true
+			__testBridgeStoreIO.publishTmp = async (tmpPath, finalPath) => {
+				if (failOnce) {
+					failOnce = false
+					throw codedError('injected rename failure', 'EIO')
+				}
+				return origPublish(tmpPath, finalPath)
+			}
+			await assert.rejects(() => store.set(CRITICAL, 'k', enc('new')), /injected rename failure/)
+			// Previous intact file still on disk — never torn.
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('old')))
+
+			__testBridgeStoreIO.publishTmp = origPublish
+			await store.set(CRITICAL, 'k', enc('new'))
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('new')))
+
+			const reopened = await useBridgeStore(dir)
+			assert.equal(dec(await reopened.get(CRITICAL, 'k')), 'new')
+		} finally {
+			__testBridgeStoreIO.publishTmp = origPublish
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('write-stage failure rejects, leaves no torn file, and retry persists', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-write-'))
+		const origWrite = __testBridgeStoreIO.writeTmp
+		try {
+			const store = await useBridgeStore(dir)
+			let failOnce = true
+			__testBridgeStoreIO.writeTmp = async (tmpPath, value) => {
+				if (failOnce) {
+					failOnce = false
+					throw codedError('injected sync failure', 'EIO')
+				}
+				return origWrite(tmpPath, value)
+			}
+
+			await assert.rejects(() => store.set(CRITICAL, 'k', enc('v')), /injected sync failure/)
+			await assert.rejects(() => access(join(dir, `${CRITICAL}-k.bin`)), /ENOENT/)
+
+			__testBridgeStoreIO.writeTmp = origWrite
+			await store.set(CRITICAL, 'k', enc('v'))
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('v')))
+		} finally {
+			__testBridgeStoreIO.writeTmp = origWrite
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('pending debounced values read back immediately but are not durable until flush', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-pending-'))
+		try {
+			const store = await useBridgeStore(dir)
+			await store.set(NON_CRITICAL, 'k', enc('pending'))
+			// Read-your-write before any flush.
+			assert.equal(dec(await store.get(NON_CRITICAL, 'k')), 'pending')
+
+			const reopened = await useBridgeStore(dir)
+			assert.equal(await reopened.get(NON_CRITICAL, 'k'), null)
+
+			await store.flush!()
+			const afterFlush = await useBridgeStore(dir)
+			assert.equal(dec(await afterFlush.get(NON_CRITICAL, 'k')), 'pending')
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('flush that never quiesces reports itself instead of dropping writes', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-quiesce-'))
+		const origWrite = __testBridgeStoreIO.writeTmp
+		try {
+			let store!: Awaited<ReturnType<typeof useBridgeStore>>
+			store = await useBridgeStore(dir)
+			let n = 0
+			__testBridgeStoreIO.writeTmp = async (tmpPath, value) => {
+				const i = n++
+				// Every flushed write is replaced by a fresh pending one, so
+				// no pass can drain the queue.
+				void store.set(NON_CRITICAL, `churn-${i}`, enc('x'))
+				return origWrite(tmpPath, value)
+			}
+
+			await store.set(NON_CRITICAL, 'churn-start', enc('x'))
+			await assert.rejects(() => store.flush!(), /did not quiesce/)
+		} finally {
+			__testBridgeStoreIO.writeTmp = origWrite
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+})

--- a/src/Utils/__tests__/use-bridge-store-durability.test.ts
+++ b/src/Utils/__tests__/use-bridge-store-durability.test.ts
@@ -25,7 +25,7 @@ import { access, mkdir, mkdtemp, open, readFile, rename, rm, writeFile } from 'n
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, it } from 'node:test'
-import { useBridgeStore } from '../use-bridge-store.ts'
+import { useBridgeStore, isUnsupportedDirSync } from '../use-bridge-store.ts'
 
 const enc = (s: string) => new TextEncoder().encode(s)
 const dec = (u: Uint8Array | null) => (u ? new TextDecoder().decode(u) : null)
@@ -65,6 +65,17 @@ const realWriteTmp = async (tmpPath: string, value: Uint8Array): Promise<void> =
 
 const realPublishTmp = async (tmpPath: string, finalPath: string): Promise<void> => {
 	await rename(tmpPath, finalPath)
+}
+
+// Production-faithful directory barrier for delegating stubs (Linux path:
+// open + sync; platform fallback lives in the module under test).
+const realSyncDir = async (dir: string): Promise<void> => {
+	const handle = await open(dir, 'r')
+	try {
+		await handle.sync()
+	} finally {
+		await handle.close().catch(() => {})
+	}
 }
 
 // A gate: `hold()` blocks until `release()` is called. `hits` counts
@@ -146,7 +157,8 @@ describe('useBridgeStore — durability', () => {
 					if (tmpPath.includes(`${CRITICAL}-bad`)) throw codedError('injected write failure', 'EIO')
 					return realWriteTmp(tmpPath, value)
 				},
-				publishTmp: realPublishTmp
+				publishTmp: realPublishTmp,
+				syncDir: realSyncDir
 			}
 			const store = await useBridgeStore(dir, { io: failBad })
 
@@ -181,7 +193,8 @@ describe('useBridgeStore — durability', () => {
 						await gate.gate
 						return realWriteTmp(tmpPath, value)
 					},
-					publishTmp: realPublishTmp
+					publishTmp: realPublishTmp,
+					syncDir: realSyncDir
 				}
 			})
 
@@ -216,7 +229,8 @@ describe('useBridgeStore — durability', () => {
 						await gate.gate
 						return realWriteTmp(tmpPath, value)
 					},
-					publishTmp: realPublishTmp
+					publishTmp: realPublishTmp,
+					syncDir: realSyncDir
 				}
 			})
 
@@ -247,7 +261,8 @@ describe('useBridgeStore — durability', () => {
 						await gate.gate
 						return realWriteTmp(tmpPath, value)
 					},
-					publishTmp: realPublishTmp
+					publishTmp: realPublishTmp,
+					syncDir: realSyncDir
 				}
 			})
 
@@ -284,7 +299,8 @@ describe('useBridgeStore — durability', () => {
 						await gate.gate
 						return realWriteTmp(tmpPath, value)
 					},
-					publishTmp: realPublishTmp
+					publishTmp: realPublishTmp,
+					syncDir: realSyncDir
 				}
 			})
 
@@ -456,7 +472,8 @@ describe('useBridgeStore — durability', () => {
 						await gate.gate
 						return realWriteTmp(tmpPath, value)
 					},
-					publishTmp: realPublishTmp
+					publishTmp: realPublishTmp,
+					syncDir: realSyncDir
 				}
 			})
 
@@ -507,7 +524,8 @@ describe('useBridgeStore — durability', () => {
 						await gate.gate
 						return realWriteTmp(tmpPath, value)
 					},
-					publishTmp: realPublishTmp
+					publishTmp: realPublishTmp,
+					syncDir: realSyncDir
 				}
 			})
 
@@ -584,7 +602,8 @@ describe('useBridgeStore — durability', () => {
 							throw codedError('injected rename failure', 'EIO')
 						}
 						return realPublishTmp(tmpPath, finalPath)
-					}
+					},
+					syncDir: realSyncDir
 				}
 			})
 			await assert.rejects(() => store.set(CRITICAL, 'k', enc('new')), /injected rename failure/)
@@ -614,7 +633,8 @@ describe('useBridgeStore — durability', () => {
 						}
 						return realWriteTmp(tmpPath, value)
 					},
-					publishTmp: realPublishTmp
+					publishTmp: realPublishTmp,
+					syncDir: realSyncDir
 				}
 			})
 
@@ -646,7 +666,8 @@ describe('useBridgeStore — durability', () => {
 							throw codedError('injected publish failure', 'EIO')
 						}
 						return realPublishTmp(tmpPath, finalPath)
-					}
+					},
+					syncDir: realSyncDir
 				}
 			})
 
@@ -698,7 +719,8 @@ describe('useBridgeStore — durability', () => {
 						void store.set(NON_CRITICAL, `churn-${i}`, enc('x'))
 						return realWriteTmp(tmpPath, value)
 					},
-					publishTmp: realPublishTmp
+					publishTmp: realPublishTmp,
+					syncDir: realSyncDir
 				}
 			})
 
@@ -707,5 +729,214 @@ describe('useBridgeStore — durability', () => {
 		} finally {
 			await rm(dir, { recursive: true, force: true })
 		}
+	})
+
+	it('flush propagates a barrier-observed critical-write failure; later flushes are clean', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-barrier-err-'))
+		try {
+			const gate = makeGate()
+			let failWrite = true
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: async (tmpPath, value) => {
+						gate.hit()
+						await gate.gate
+						if (failWrite) throw codedError('injected gated failure', 'EIO')
+						return realWriteTmp(tmpPath, value)
+					},
+					publishTmp: realPublishTmp,
+					syncDir: realSyncDir
+				}
+			})
+
+			let setSettled = false
+			let setError: unknown
+			const pending = store.set(CRITICAL, 'k', enc('v')).then(
+				() => {
+					setSettled = true
+				},
+				e => {
+					setSettled = true
+					setError = e
+				}
+			)
+			await waitFor(() => gate.hits >= 1, 'write to reach the gate')
+
+			let flushSettled = false
+			let flushError: unknown
+			const flushing = store.flush!().then(
+				() => {
+					flushSettled = true
+				},
+				e => {
+					flushSettled = true
+					flushError = e
+				}
+			)
+			await new Promise(resolve => setTimeout(resolve, 100))
+			// The admitted write is blocked: neither call may settle yet.
+			assert.equal(setSettled, false)
+			assert.equal(flushSettled, false)
+
+			gate.release()
+			await pending
+			await flushing
+			assert.match(String(setError), /injected gated failure/)
+			// The barrier observed the failure: flush rejects instead of
+			// resolving successfully.
+			assert.match(String(flushError), /injected gated failure/)
+
+			// Settled history never poisons later flushes.
+			failWrite = false
+			await store.flush!()
+
+			// A healthy retry certifies the key.
+			const healthy = await useBridgeStore(dir)
+			await healthy.set(CRITICAL, 'k', enc('v'))
+			await healthy.flush!()
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('v')))
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('post-rename barrier failure invalidates certification; identical sets re-attempt', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-uncertain-'))
+		try {
+			let failBarrier = false
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: realWriteTmp,
+					// Real rename-then-error boundary: the bytes reach the
+					// target, but the barrier never certifies them.
+					publishTmp: async (tmpPath, finalPath) => {
+						await rename(tmpPath, finalPath)
+						if (failBarrier) throw codedError('injected post-rename barrier failure', 'EIO')
+					},
+					syncDir: realSyncDir
+				}
+			})
+
+			await store.set(CRITICAL, 'k', enc('A'))
+			failBarrier = true
+			await assert.rejects(() => store.set(CRITICAL, 'k', enc('B')), /post-rename barrier failure/)
+			// The rename really happened: disk holds B while the cache must
+			// no longer claim A for the key.
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('B')))
+
+			// Reads serve best-available B without re-certifying it: retry B
+			// still runs its still-required barrier.
+			assert.equal(dec(await store.get(CRITICAL, 'k')), 'B')
+			await assert.rejects(() => store.set(CRITICAL, 'k', enc('B')), /post-rename barrier failure/)
+			// Identical set of A must re-attempt, not skip on stale cache.
+			// Its rename lands A on disk before the barrier fails again.
+			await assert.rejects(() => store.set(CRITICAL, 'k', enc('A')), /post-rename barrier failure/)
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('A')))
+			assert.equal(dec(await store.get(CRITICAL, 'k')), 'A')
+
+			failBarrier = false
+			await store.set(CRITICAL, 'k', enc('B'))
+			assert.equal(dec(await store.get(CRITICAL, 'k')), 'B')
+			await store.set(CRITICAL, 'k', enc('A'))
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('A')))
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('failed post-unlink barrier is retried, not swallowed as idempotent absence', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-delbarrier-'))
+		try {
+			let failSync = false
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: realWriteTmp,
+					publishTmp: realPublishTmp,
+					syncDir: async (d: string) => {
+						if (failSync) throw codedError('injected post-unlink barrier failure', 'EIO')
+						return realSyncDir(d)
+					}
+				}
+			})
+
+			await store.set(CRITICAL, 'k', enc('v'))
+			failSync = true
+			await assert.rejects(() => store.delete(CRITICAL, 'k'), /post-unlink barrier failure/)
+			// The unlink really happened.
+			await assert.rejects(() => access(join(dir, `${CRITICAL}-k.bin`)), /ENOENT/)
+			assert.equal(await store.get(CRITICAL, 'k'), null)
+			// Retry while still failing rejects again — never swallowed.
+			await assert.rejects(() => store.delete(CRITICAL, 'k'), /post-unlink barrier failure/)
+
+			failSync = false
+			// ENOENT on disk, but the prior barrier was uncertified: the
+			// retry re-runs the barrier and then resolves.
+			await store.delete(CRITICAL, 'k')
+			assert.equal(await store.get(CRITICAL, 'k'), null)
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('uncertain delete with the directory removed externally surfaces ENOENT', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-delgone-'))
+		try {
+			let failSync = false
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: realWriteTmp,
+					publishTmp: realPublishTmp,
+					syncDir: async (d: string) => {
+						if (failSync) throw codedError('injected post-unlink barrier failure', 'EIO')
+						return realSyncDir(d)
+					}
+				}
+			})
+
+			await store.set(CRITICAL, 'k', enc('v'))
+			failSync = true
+			await assert.rejects(() => store.delete(CRITICAL, 'k'), /post-unlink barrier failure/)
+
+			// Explicit scoped policy: an externally removed directory is not
+			// silently treated as certified absence while uncertain.
+			failSync = false
+			await rm(dir, { recursive: true, force: true })
+			await assert.rejects(() => store.delete(CRITICAL, 'k'), /ENOENT/)
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('isUnsupportedDirSync classifies directory-barrier errors per platform', () => {
+		const cases: [code: string, platform: NodeJS.Platform, expected: boolean][] = [
+			['ENOSYS', 'linux', true],
+			['ENOSYS', 'win32', true],
+			['ENOSYS', 'darwin', true],
+			['ENOTSUP', 'linux', true],
+			['ENOTSUP', 'win32', true],
+			['EINVAL', 'win32', true],
+			['EINVAL', 'linux', false],
+			['EINVAL', 'darwin', false],
+			['EPERM', 'win32', true],
+			['EPERM', 'linux', false],
+			['EISDIR', 'win32', true],
+			['EISDIR', 'linux', false],
+			['EIO', 'linux', false],
+			['EIO', 'win32', false],
+			['ENOSPC', 'linux', false],
+			['ENOSPC', 'win32', false],
+			['EACCES', 'linux', false],
+			['EACCES', 'win32', false],
+			['ENOENT', 'linux', false],
+			['ENOENT', 'win32', false],
+			['EBADF', 'linux', false],
+			['EBADF', 'win32', false]
+		]
+		for (const [code, platform, expected] of cases) {
+			assert.equal(isUnsupportedDirSync(codedError('x', code), platform), expected, `${code}/${platform}`)
+		}
+		// Default platform binding works without an explicit argument.
+		assert.equal(isUnsupportedDirSync(codedError('x', 'ENOSYS')), true)
+		assert.equal(isUnsupportedDirSync(codedError('x', 'EIO')), false)
 	})
 })

--- a/src/Utils/__tests__/use-bridge-store-durability.test.ts
+++ b/src/Utils/__tests__/use-bridge-store-durability.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { strict as assert } from 'node:assert'
-import { access, mkdir, mkdtemp, open, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, open, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, it } from 'node:test'
@@ -153,11 +153,13 @@ describe('useBridgeStore — durability', () => {
 		const dir = await mkdtemp(join(tmpdir(), 'dur-besteffort-'))
 		try {
 			const failBad = {
-				writeTmp: async (tmpPath: string, value: Uint8Array) => {
-					if (tmpPath.includes(`${CRITICAL}-bad`)) throw codedError('injected write failure', 'EIO')
-					return realWriteTmp(tmpPath, value)
+				writeTmp: realWriteTmp,
+				// Temp basenames are decoupled from keys by design, so the
+				// fault targets the final path (which carries the key).
+				publishTmp: async (tmpPath: string, finalPath: string) => {
+					if (finalPath.includes(`${CRITICAL}-bad`)) throw codedError('injected write failure', 'EIO')
+					return realPublishTmp(tmpPath, finalPath)
 				},
-				publishTmp: realPublishTmp,
 				syncDir: realSyncDir
 			}
 			const store = await useBridgeStore(dir, { io: failBad })
@@ -938,5 +940,145 @@ describe('useBridgeStore — durability', () => {
 		// Default platform binding works without an explicit argument.
 		assert.equal(isUnsupportedDirSync(codedError('x', 'ENOSYS')), true)
 		assert.equal(isUnsupportedDirSync(codedError('x', 'EIO')), false)
+	})
+
+	it('uncertain delete retry with failing barrier preserves admitted pending data (Greptile 3939491652)', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-delpending-'))
+		try {
+			let failSync = false
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: realWriteTmp,
+					publishTmp: realPublishTmp,
+					syncDir: async (d: string) => {
+						if (failSync) throw codedError('injected barrier failure', 'EIO')
+						return realSyncDir(d)
+					}
+				}
+			})
+
+			await store.set(NON_CRITICAL, 'k', enc('v1'))
+			await store.flush!()
+			failSync = true
+			// Unlink succeeds, barrier fails: uncertainty with an absent file.
+			await assert.rejects(() => store.delete(NON_CRITICAL, 'k'), /barrier failure/)
+
+			// Admit a debounced value on the uncertain absent key.
+			await store.set(NON_CRITICAL, 'k', enc('v2'))
+			assert.equal(dec(await store.get(NON_CRITICAL, 'k')), 'v2')
+
+			// Retry delete: unlink hits ENOENT while uncertain, barrier fails
+			// again — the admitted pending value must survive the failure.
+			await assert.rejects(() => store.delete(NON_CRITICAL, 'k'), /barrier failure/)
+			assert.equal(dec(await store.get(NON_CRITICAL, 'k')), 'v2')
+			// Uncertainty is kept, not resolved: a further retry still fails.
+			await assert.rejects(() => store.delete(NON_CRITICAL, 'k'), /barrier failure/)
+			// And the pending work is still flushable, not silently dropped.
+			await assert.rejects(() => store.flush!(), /barrier failure/)
+
+			failSync = false
+			await store.flush!()
+			const reopened = await useBridgeStore(dir)
+			assert.equal(dec(await reopened.get(NON_CRITICAL, 'k')), 'v2')
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('writes a key whose encoded filename is long but valid (Greptile 3939501789)', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-longname-'))
+		try {
+			const store = await useBridgeStore(dir)
+			// `session-` (8) + 228 + `.bin` (4) = 240 bytes: valid under the
+			// 255-byte component limit, but any temp name derived by
+			// extending it exceeds the limit.
+			const key = 'a'.repeat(228)
+			assert.ok(Buffer.byteLength(`${CRITICAL}-${key}.bin`) < 255)
+			await store.set(CRITICAL, key, enc('long'))
+			assert.equal(dec(await store.get(CRITICAL, key)), 'long')
+			assert.deepEqual(await store.listKeys!(CRITICAL), [key])
+			const reopened = await useBridgeStore(dir)
+			assert.equal(dec(await reopened.get(CRITICAL, key)), 'long')
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('creates and replaces auth files with restrictive modes under a typical umask (Greptile 3939501791)', async () => {
+		// POSIX mode semantics only; on Windows modes are largely ignored,
+		// so only the round-trip is asserted there.
+		const posix = process.platform !== 'win32'
+		const dir = await mkdtemp(join(tmpdir(), 'dur-modes-'))
+		const prevUmask = process.umask(0o022)
+		try {
+			const store = await useBridgeStore(dir)
+			await store.set(CRITICAL, 'k', enc('v'))
+			if (posix) {
+				assert.equal((await stat(join(dir, `${CRITICAL}-k.bin`))).mode & 0o777, 0o600)
+			}
+			assert.equal(dec(await store.get(CRITICAL, 'k')), 'v')
+
+			// A hardened pre-existing file must never be widened by replace.
+			const hardened = join(dir, `${CRITICAL}-h.bin`)
+			await writeFile(hardened, enc('seed'), { mode: 0o600 })
+			await store.set(CRITICAL, 'h', enc('new'))
+			if (posix) {
+				assert.equal((await stat(hardened)).mode & 0o777, 0o600)
+			}
+			assert.equal(dec(await store.get(CRITICAL, 'h')), 'new')
+		} finally {
+			process.umask(prevUmask)
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('default-writer close failure cleans its owned temp and surfaces the original error (Greptile 3939501793)', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-closefail-'))
+		try {
+			let failClose = true
+			let removeBeforeThrow = false
+			const store = await useBridgeStore(dir, {
+				// Only the temp-creation step is replaced; write, sync,
+				// close-cleanup and publish run the real default code.
+				io: {
+					openTmp: async (tmpPath: string) => {
+						const handle = await open(tmpPath, 'wx')
+						let closed = false
+						return {
+							writeFile: (value: Uint8Array) => handle.writeFile(value),
+							sync: () => handle.sync(),
+							close: async () => {
+								if (closed) return
+								closed = true
+								if (failClose) {
+									if (removeBeforeThrow) await rm(tmpPath, { force: true })
+									throw codedError('injected close failure', 'EIO')
+								}
+								await handle.close()
+							}
+						}
+					}
+				}
+			})
+
+			await assert.rejects(() => store.set(CRITICAL, 'k', enc('v')), /injected close failure/)
+			// Owned temp cleaned: no secret-carrying leftovers remain.
+			assert.deepEqual(
+				(await readdir(dir)).filter(f => f.endsWith('.tmp')),
+				[]
+			)
+
+			// A cleanup racing a vanished temp still reports the original.
+			removeBeforeThrow = true
+			await assert.rejects(() => store.set(CRITICAL, 'k', enc('v')), /injected close failure/)
+
+			// Retries accumulate nothing: exactly the target file remains.
+			failClose = false
+			await store.set(CRITICAL, 'k', enc('v'))
+			assert.deepEqual(await readdir(dir), [`${CRITICAL}-k.bin`])
+			assert.equal(dec(await store.get(CRITICAL, 'k')), 'v')
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
 	})
 })

--- a/src/Utils/__tests__/use-bridge-store-durability.test.ts
+++ b/src/Utils/__tests__/use-bridge-store-durability.test.ts
@@ -1032,6 +1032,41 @@ describe('useBridgeStore — durability', () => {
 		}
 	})
 
+	it('failed drain pass stops and leaves work for the next flush (Greptile 3939542163)', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-staleerr-'))
+		try {
+			let failWrites = 1
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: async (tmpPath: string, value: Uint8Array) => {
+						if (failWrites > 0) {
+							failWrites--
+							throw codedError('injected transient failure', 'EIO')
+						}
+						return realWriteTmp(tmpPath, value)
+					},
+					publishTmp: realPublishTmp,
+					syncDir: realSyncDir
+				}
+			})
+
+			await store.set(NON_CRITICAL, 'a', enc('A'))
+			await store.set(NON_CRITICAL, 'b', enc('B'))
+			await assert.rejects(() => store.flush!(), /injected transient failure/)
+			// `b` succeeded in the same pass; `a` must still be pending —
+			// not silently retried inside the failed call.
+			assert.deepEqual(await readFile(join(dir, `${NON_CRITICAL}-b.bin`)), Buffer.from(enc('B')))
+			await assert.rejects(() => access(join(dir, `${NON_CRITICAL}-a.bin`)), /ENOENT/)
+			assert.equal(dec(await store.get(NON_CRITICAL, 'a')), 'A')
+
+			// A subsequent explicit flush recovers the failed key.
+			await store.flush!()
+			assert.deepEqual(await readFile(join(dir, `${NON_CRITICAL}-a.bin`)), Buffer.from(enc('A')))
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
 	it('default-writer close failure cleans its owned temp and surfaces the original error (Greptile 3939501793)', async () => {
 		const dir = await mkdtemp(join(tmpdir(), 'dur-closefail-'))
 		try {
@@ -1052,6 +1087,10 @@ describe('useBridgeStore — durability', () => {
 								closed = true
 								if (failClose) {
 									if (removeBeforeThrow) await rm(tmpPath, { force: true })
+									// Release the real fd so the harness does not
+									// flag a GC leak; the injected error is what
+									// the implementation under test observes.
+									await handle.close().catch(() => {})
 									throw codedError('injected close failure', 'EIO')
 								}
 								await handle.close()

--- a/src/Utils/__tests__/use-bridge-store-durability.test.ts
+++ b/src/Utils/__tests__/use-bridge-store-durability.test.ts
@@ -1,24 +1,31 @@
 /**
  * Durability contract for the file store:
+ *  - caller buffers are copied at admission (Buffer and Uint8Array), even
+ *    when mutated synchronously after the call behind a held prior op
  *  - failure → identical retry re-attempts and persists (set, setMany, flush)
  *  - setMany stays best-effort across keys with idempotent retry
  *  - failed flushes keep pending work and propagate the error
+ *  - flush() waits for operations admitted before it (barrier) and never
+ *    reports quiescence while prior admitted work is still running
  *  - reads/deletes surface real errors; only absence is tolerated
+ *  - a failed delete restores preceding pending/durable state
  *  - concurrent ops on one key serialize (set→delete, delete→set, flush)
- *  - caller buffers and returned values are copies (no mutable aliasing)
- *  - atomic replacement keeps the previous file intact across failures
+ *  - returned values are copies (no mutable aliasing)
+ *  - atomic replacement keeps the previous file intact across failures and
+ *    never removes a temp file it did not create
  *
- * All faults go through the real `useBridgeStore` callbacks: filesystem
- * states (ENOTDIR/ENOENT) for end-to-end failures and the
- * `__testBridgeStoreIO` seam for write/rename-stage injection.
+ * All faults go through the real `useBridgeStore` callbacks with per-store
+ * scoped I/O steps (`{ io }` option) or real filesystem states
+ * (ENOTDIR/ENOENT). No shared mutable seam: each store under test owns its
+ * injection, so gates and failures cannot leak across stores or tests.
  */
 
 import { strict as assert } from 'node:assert'
-import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, open, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, it } from 'node:test'
-import { __testBridgeStoreIO, useBridgeStore } from '../use-bridge-store.ts'
+import { useBridgeStore } from '../use-bridge-store.ts'
 
 const enc = (s: string) => new TextEncoder().encode(s)
 const dec = (u: Uint8Array | null) => (u ? new TextDecoder().decode(u) : null)
@@ -42,6 +49,50 @@ const codedError = (message: string, code: string): NodeJS.ErrnoException => {
 	const err = new Error(message) as NodeJS.ErrnoException
 	err.code = code
 	return err
+}
+
+// Production-faithful temp write used to delegate after a gate/fault:
+// exclusive create, payload, file sync.
+const realWriteTmp = async (tmpPath: string, value: Uint8Array): Promise<void> => {
+	const handle = await open(tmpPath, 'wx')
+	try {
+		await handle.writeFile(value)
+		await handle.sync()
+	} finally {
+		await handle.close().catch(() => {})
+	}
+}
+
+const realPublishTmp = async (tmpPath: string, finalPath: string): Promise<void> => {
+	await rename(tmpPath, finalPath)
+}
+
+// A gate: `hold()` blocks until `release()` is called. `hits` counts
+// arrivals so tests can wait for an operation to be provably blocked
+// instead of racing a sleep.
+const makeGate = () => {
+	let release!: () => void
+	let hits = 0
+	const gate = new Promise<void>(resolve => {
+		release = resolve
+	})
+	return {
+		gate,
+		release,
+		hit() {
+			hits++
+		},
+		get hits() {
+			return hits
+		}
+	}
+}
+
+const waitFor = async (cond: () => boolean, what: string): Promise<void> => {
+	for (let i = 0; i < 200 && !cond(); i++) {
+		await new Promise(resolve => setTimeout(resolve, 10))
+	}
+	assert.ok(cond(), `timed out waiting for ${what}`)
 }
 
 describe('useBridgeStore — durability', () => {
@@ -89,13 +140,15 @@ describe('useBridgeStore — durability', () => {
 
 	it('setMany is best-effort across keys: one key fails, siblings persist, retry completes', async () => {
 		const dir = await mkdtemp(join(tmpdir(), 'dur-besteffort-'))
-		const origWrite = __testBridgeStoreIO.writeTmp
 		try {
-			const store = await useBridgeStore(dir)
-			__testBridgeStoreIO.writeTmp = async (tmpPath, value) => {
-				if (tmpPath.includes(`${CRITICAL}-bad`)) throw codedError('injected write failure', 'EIO')
-				return origWrite(tmpPath, value)
+			const failBad = {
+				writeTmp: async (tmpPath: string, value: Uint8Array) => {
+					if (tmpPath.includes(`${CRITICAL}-bad`)) throw codedError('injected write failure', 'EIO')
+					return realWriteTmp(tmpPath, value)
+				},
+				publishTmp: realPublishTmp
 			}
+			const store = await useBridgeStore(dir, { io: failBad })
 
 			const entries: [string, Uint8Array][] = [
 				['good', enc('g')],
@@ -106,14 +159,174 @@ describe('useBridgeStore — durability', () => {
 			assert.equal(dec(await store.get(CRITICAL, 'good')), 'g')
 			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-good.bin`)), Buffer.from(enc('g')))
 
-			__testBridgeStoreIO.writeTmp = origWrite
-			// Idempotent retry: `good` is already durable (skipped), `bad` is
-			// re-attempted and now persists.
-			await store.setMany!(CRITICAL, entries)
-			assert.equal(dec(await store.get(CRITICAL, 'bad')), 'b')
+			// Idempotent retry on a healthy store: `good` is already durable
+			// (skipped), `bad` is re-attempted and now persists.
+			const healthy = await useBridgeStore(dir)
+			await healthy.setMany!(CRITICAL, entries)
+			assert.equal(dec(await healthy.get(CRITICAL, 'bad')), 'b')
 			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-bad.bin`)), Buffer.from(enc('b')))
 		} finally {
-			__testBridgeStoreIO.writeTmp = origWrite
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('admission copies Buffer input: synchronous mutation behind a held op cannot change it', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-admit-buf-'))
+		try {
+			const gate = makeGate()
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: async (tmpPath, value) => {
+						gate.hit()
+						await gate.gate
+						return realWriteTmp(tmpPath, value)
+					},
+					publishTmp: realPublishTmp
+				}
+			})
+
+			const first = store.set(CRITICAL, 'k', enc('first'))
+			await waitFor(() => gate.hits >= 1, 'first write to reach the gate')
+
+			// Admitted while the prior op holds the key lock; mutated in the
+			// same tick, before any await. Only an admission-time copy of a
+			// Buffer (whose .slice() would alias!) persists 'second-secret'.
+			const buf = Buffer.from('second-secret')
+			const second = store.set(CRITICAL, 'k', buf)
+			buf.fill(0)
+			gate.release()
+			await first
+			await second
+
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from('second-secret'))
+			assert.equal(dec(await store.get(CRITICAL, 'k')), 'second-secret')
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('admission copies Uint8Array input: synchronous mutation behind a held op cannot change it', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-admit-u8-'))
+		try {
+			const gate = makeGate()
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: async (tmpPath, value) => {
+						gate.hit()
+						await gate.gate
+						return realWriteTmp(tmpPath, value)
+					},
+					publishTmp: realPublishTmp
+				}
+			})
+
+			const first = store.set(CRITICAL, 'k', enc('first'))
+			await waitFor(() => gate.hits >= 1, 'first write to reach the gate')
+
+			const buf: Uint8Array = enc('second-secret')
+			const second = store.set(CRITICAL, 'k', buf)
+			buf.fill(0)
+			gate.release()
+			await first
+			await second
+
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from('second-secret'))
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('setMany admission-copies every entry: caller mutation before await cannot change them', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-admit-many-'))
+		try {
+			const gate = makeGate()
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: async (tmpPath, value) => {
+						gate.hit()
+						await gate.gate
+						return realWriteTmp(tmpPath, value)
+					},
+					publishTmp: realPublishTmp
+				}
+			})
+
+			const first = store.set(CRITICAL, 'blocker', enc('first'))
+			await waitFor(() => gate.hits >= 1, 'blocker write to reach the gate')
+
+			const bufA = Buffer.from('alpha')
+			const bufB: Uint8Array = enc('beta')
+			const batch = store.setMany!(CRITICAL, [
+				['a', bufA],
+				['b', bufB]
+			])
+			bufA.fill(0)
+			bufB.fill(0)
+			gate.release()
+			await first
+			await batch
+
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-a.bin`)), Buffer.from('alpha'))
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-b.bin`)), Buffer.from('beta'))
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('flush waits for an admitted in-flight critical write instead of reporting quiescence', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-barrier-'))
+		try {
+			const gate = makeGate()
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: async (tmpPath, value) => {
+						gate.hit()
+						await gate.gate
+						return realWriteTmp(tmpPath, value)
+					},
+					publishTmp: realPublishTmp
+				}
+			})
+
+			const pending = store.set(CRITICAL, 'k', enc('v'))
+			await waitFor(() => gate.hits >= 1, 'write to reach the gate')
+
+			let flushed = false
+			let flushError: unknown
+			const flushing = store.flush!()
+				.then(() => {
+					flushed = true
+				})
+				.catch(e => {
+					flushError = e
+				})
+			await new Promise(resolve => setTimeout(resolve, 100))
+			// The admitted write is blocked: flush must neither resolve nor
+			// falsely claim success while prior work is outstanding.
+			assert.equal(flushed, false)
+			assert.equal(flushError, undefined)
+
+			gate.release()
+			await pending
+			await flushing
+			assert.equal(flushed, true)
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('v')))
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('flush observes a set queued just before it, even before the set reaches the queue', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-barrier-q-'))
+		try {
+			const store = await useBridgeStore(dir)
+			// Deliberately not awaited: flush() is called in the same tick,
+			// before the set's key-lock callback can run.
+			const queued = store.set(NON_CRITICAL, 'k', enc('v'))
+			await store.flush!()
+			await queued
+			assert.deepEqual(await readFile(join(dir, `${NON_CRITICAL}-k.bin`)), Buffer.from(enc('v')))
+		} finally {
 			await rm(dir, { recursive: true, force: true })
 		}
 	})
@@ -157,6 +370,51 @@ describe('useBridgeStore — durability', () => {
 		}
 	})
 
+	it('failed delete keeps the acknowledged debounced value readable and flushable', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-delfail-'))
+		try {
+			const store = await useBridgeStore(dir)
+			await store.set(NON_CRITICAL, 'k', enc('v'))
+
+			await asFile(dir)
+			await assert.rejects(() => store.delete(NON_CRITICAL, 'k'), /ENOTDIR/)
+
+			// Preceding pending state recovered: still readable, still queued.
+			assert.equal(dec(await store.get(NON_CRITICAL, 'k')), 'v')
+			await assert.rejects(() => store.flush!(), /ENOTDIR/)
+
+			await asDir(dir)
+			await store.flush!()
+			assert.deepEqual(await readFile(join(dir, `${NON_CRITICAL}-k.bin`)), Buffer.from(enc('v')))
+
+			// A later delete on a healthy folder succeeds at its own point.
+			await store.delete(NON_CRITICAL, 'k')
+			assert.equal(await store.get(NON_CRITICAL, 'k'), null)
+			await assert.rejects(() => access(join(dir, `${NON_CRITICAL}-k.bin`)), /ENOENT/)
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('failed delete keeps the acknowledged durable value; interleaved writes still win', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-delfail2-'))
+		try {
+			const store = await useBridgeStore(dir)
+			await store.set(CRITICAL, 'k', enc('old'))
+
+			await asFile(dir)
+			await assert.rejects(() => store.delete(CRITICAL, 'k'), /ENOTDIR/)
+			assert.equal(dec(await store.get(CRITICAL, 'k')), 'old')
+
+			await asDir(dir)
+			// Interleaved write after the failed delete persists normally.
+			await store.set(CRITICAL, 'k', enc('new'))
+			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('new')))
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
 	it('reads surface real errors but return null for absent keys', async () => {
 		const dir = await mkdtemp(join(tmpdir(), 'dur-read-'))
 		try {
@@ -189,19 +447,21 @@ describe('useBridgeStore — durability', () => {
 
 	it('set→delete serializes: delete waits for the in-flight write and the key stays gone', async () => {
 		const dir = await mkdtemp(join(tmpdir(), 'dur-setdel-'))
-		const origWrite = __testBridgeStoreIO.writeTmp
-		let release!: () => void
 		try {
-			const store = await useBridgeStore(dir)
-			__testBridgeStoreIO.writeTmp = async (tmpPath, value) => {
-				await new Promise<void>(resolve => {
-					release = resolve
-				})
-				return origWrite(tmpPath, value)
-			}
+			const gate = makeGate()
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: async (tmpPath, value) => {
+						gate.hit()
+						await gate.gate
+						return realWriteTmp(tmpPath, value)
+					},
+					publishTmp: realPublishTmp
+				}
+			})
 
 			const first = store.set(CRITICAL, 'k', enc('one'))
-			await new Promise(resolve => setTimeout(resolve, 50))
+			await waitFor(() => gate.hits >= 1, 'write to reach the gate')
 			let deleteDone = false
 			const del = store.delete(CRITICAL, 'k').then(() => {
 				deleteDone = true
@@ -209,15 +469,13 @@ describe('useBridgeStore — durability', () => {
 			await new Promise(resolve => setTimeout(resolve, 100))
 			// The delete could not overtake the gated write.
 			assert.equal(deleteDone, false)
-			release()
+			gate.release()
 			await first
 			await del
 
 			assert.equal(await store.get(CRITICAL, 'k'), null)
 			await assert.rejects(() => access(join(dir, `${CRITICAL}-k.bin`)), /ENOENT/)
 		} finally {
-			__testBridgeStoreIO.writeTmp = origWrite
-			release?.()
 			await rm(dir, { recursive: true, force: true })
 		}
 	})
@@ -240,36 +498,35 @@ describe('useBridgeStore — durability', () => {
 
 	it('concurrent sets on one key serialize: the last scheduled value wins', async () => {
 		const dir = await mkdtemp(join(tmpdir(), 'dur-conc-'))
-		const origWrite = __testBridgeStoreIO.writeTmp
-		let release!: () => void
 		try {
-			const store = await useBridgeStore(dir)
-			__testBridgeStoreIO.writeTmp = async (tmpPath, value) => {
-				await new Promise<void>(resolve => {
-					release = resolve
-				})
-				return origWrite(tmpPath, value)
-			}
+			const gate = makeGate()
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: async (tmpPath, value) => {
+						gate.hit()
+						await gate.gate
+						return realWriteTmp(tmpPath, value)
+					},
+					publishTmp: realPublishTmp
+				}
+			})
 
 			const first = store.set(CRITICAL, 'k', enc('one'))
-			await new Promise(resolve => setTimeout(resolve, 50))
+			await waitFor(() => gate.hits >= 1, 'first write to reach the gate')
 			const second = store.set(CRITICAL, 'k', enc('two'))
 			await new Promise(resolve => setTimeout(resolve, 50))
-			release()
+			gate.release()
 			await first
-			__testBridgeStoreIO.writeTmp = origWrite
 			await second
 
 			assert.equal(dec(await store.get(CRITICAL, 'k')), 'two')
 			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('two')))
 		} finally {
-			__testBridgeStoreIO.writeTmp = origWrite
-			release?.()
 			await rm(dir, { recursive: true, force: true })
 		}
 	})
 
-	it('mutating the caller buffer after set does not change persisted bytes', async () => {
+	it('mutating the caller buffer after an awaited set does not change persisted bytes', async () => {
 		const dir = await mkdtemp(join(tmpdir(), 'dur-snap-'))
 		try {
 			const store = await useBridgeStore(dir)
@@ -280,7 +537,7 @@ describe('useBridgeStore — durability', () => {
 			const reopened = await useBridgeStore(dir)
 			assert.equal(dec(await reopened.get(CRITICAL, 'k')), 'orig')
 
-			// Same for debounced writes: the queued snapshot is immune too.
+			// Same for debounced writes: the queued copy is immune too.
 			const buf2 = enc('queued')
 			await store.set(NON_CRITICAL, 'q', buf2)
 			buf2.fill(0)
@@ -313,57 +570,97 @@ describe('useBridgeStore — durability', () => {
 
 	it('rename-stage failure leaves the previous file intact and retryable', async () => {
 		const dir = await mkdtemp(join(tmpdir(), 'dur-atomic-'))
-		const origPublish = __testBridgeStoreIO.publishTmp
 		try {
-			const store = await useBridgeStore(dir)
-			await store.set(CRITICAL, 'k', enc('old'))
+			const healthy = await useBridgeStore(dir)
+			await healthy.set(CRITICAL, 'k', enc('old'))
 
 			let failOnce = true
-			__testBridgeStoreIO.publishTmp = async (tmpPath, finalPath) => {
-				if (failOnce) {
-					failOnce = false
-					throw codedError('injected rename failure', 'EIO')
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: realWriteTmp,
+					publishTmp: async (tmpPath, finalPath) => {
+						if (failOnce) {
+							failOnce = false
+							throw codedError('injected rename failure', 'EIO')
+						}
+						return realPublishTmp(tmpPath, finalPath)
+					}
 				}
-				return origPublish(tmpPath, finalPath)
-			}
+			})
 			await assert.rejects(() => store.set(CRITICAL, 'k', enc('new')), /injected rename failure/)
 			// Previous intact file still on disk — never torn.
 			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('old')))
 
-			__testBridgeStoreIO.publishTmp = origPublish
-			await store.set(CRITICAL, 'k', enc('new'))
+			await healthy.set(CRITICAL, 'k', enc('new'))
 			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('new')))
 
 			const reopened = await useBridgeStore(dir)
 			assert.equal(dec(await reopened.get(CRITICAL, 'k')), 'new')
 		} finally {
-			__testBridgeStoreIO.publishTmp = origPublish
 			await rm(dir, { recursive: true, force: true })
 		}
 	})
 
 	it('write-stage failure rejects, leaves no torn file, and retry persists', async () => {
 		const dir = await mkdtemp(join(tmpdir(), 'dur-write-'))
-		const origWrite = __testBridgeStoreIO.writeTmp
 		try {
-			const store = await useBridgeStore(dir)
 			let failOnce = true
-			__testBridgeStoreIO.writeTmp = async (tmpPath, value) => {
-				if (failOnce) {
-					failOnce = false
-					throw codedError('injected sync failure', 'EIO')
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: async (tmpPath, value) => {
+						if (failOnce) {
+							failOnce = false
+							throw codedError('injected sync failure', 'EIO')
+						}
+						return realWriteTmp(tmpPath, value)
+					},
+					publishTmp: realPublishTmp
 				}
-				return origWrite(tmpPath, value)
-			}
+			})
 
 			await assert.rejects(() => store.set(CRITICAL, 'k', enc('v')), /injected sync failure/)
 			await assert.rejects(() => access(join(dir, `${CRITICAL}-k.bin`)), /ENOENT/)
 
-			__testBridgeStoreIO.writeTmp = origWrite
-			await store.set(CRITICAL, 'k', enc('v'))
+			const healthy = await useBridgeStore(dir)
+			await healthy.set(CRITICAL, 'k', enc('v'))
 			assert.deepEqual(await readFile(join(dir, `${CRITICAL}-k.bin`)), Buffer.from(enc('v')))
 		} finally {
-			__testBridgeStoreIO.writeTmp = origWrite
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('concurrent writes claim distinct temps and a failed publish never removes a foreign temp', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'dur-tmp-'))
+		try {
+			const seen = new Set<string>()
+			let failPublish = true
+			const store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: async (tmpPath, value) => {
+						seen.add(tmpPath)
+						return realWriteTmp(tmpPath, value)
+					},
+					publishTmp: async (tmpPath, finalPath) => {
+						if (failPublish) {
+							failPublish = false
+							throw codedError('injected publish failure', 'EIO')
+						}
+						return realPublishTmp(tmpPath, finalPath)
+					}
+				}
+			})
+
+			// A foreign temp-looking file this operation did not create.
+			const foreign = join(dir, `${CRITICAL}-k.bin.99999.0.deadbeef.tmp`)
+			await writeFile(foreign, enc('foreign'))
+
+			await assert.rejects(() => store.set(CRITICAL, 'k', enc('v')), /injected publish failure/)
+			await store.set(CRITICAL, 'a', enc('1'))
+			await store.set(CRITICAL, 'b', enc('2'))
+
+			assert.ok(seen.size >= 3, `expected distinct temps per attempt, saw ${seen.size}`)
+			assert.deepEqual(await readFile(foreign), Buffer.from(enc('foreign')))
+		} finally {
 			await rm(dir, { recursive: true, force: true })
 		}
 	})
@@ -389,23 +686,25 @@ describe('useBridgeStore — durability', () => {
 
 	it('flush that never quiesces reports itself instead of dropping writes', async () => {
 		const dir = await mkdtemp(join(tmpdir(), 'dur-quiesce-'))
-		const origWrite = __testBridgeStoreIO.writeTmp
 		try {
 			let store!: Awaited<ReturnType<typeof useBridgeStore>>
-			store = await useBridgeStore(dir)
 			let n = 0
-			__testBridgeStoreIO.writeTmp = async (tmpPath, value) => {
-				const i = n++
-				// Every flushed write is replaced by a fresh pending one, so
-				// no pass can drain the queue.
-				void store.set(NON_CRITICAL, `churn-${i}`, enc('x'))
-				return origWrite(tmpPath, value)
-			}
+			store = await useBridgeStore(dir, {
+				io: {
+					writeTmp: async (tmpPath, value) => {
+						const i = n++
+						// Every flushed write is replaced by a fresh pending
+						// one, so no pass can drain the queue.
+						void store.set(NON_CRITICAL, `churn-${i}`, enc('x'))
+						return realWriteTmp(tmpPath, value)
+					},
+					publishTmp: realPublishTmp
+				}
+			})
 
 			await store.set(NON_CRITICAL, 'churn-start', enc('x'))
 			await assert.rejects(() => store.flush!(), /did not quiesce/)
 		} finally {
-			__testBridgeStoreIO.writeTmp = origWrite
 			await rm(dir, { recursive: true, force: true })
 		}
 	})

--- a/src/Utils/__tests__/use-bridge-store-errors.test.ts
+++ b/src/Utils/__tests__/use-bridge-store-errors.test.ts
@@ -1,9 +1,11 @@
 /**
- * Error-propagation contract for the file store (Codex review fixes):
- *  - A critical-store write that fails for a REAL reason (not the folder being
- *    gone) MUST reject — swallowing it silently loses Signal session state.
- *  - The folder genuinely being gone (ENOENT, shutdown race) is tolerated.
+ * Error-propagation contract for the file store:
+ *  - A critical-store write that fails for ANY reason (ENOTDIR, ENOENT,
+ *    ENOSPC, EACCES, EIO) MUST reject — resolving without durable bytes
+ *    would silently lose Signal session state while the caller believes
+ *    the write succeeded.
  *  - listKeys must not turn a real readdir failure into an empty namespace.
+ *    Only ENOENT on readdir (folder genuinely gone) reads as empty.
  *
  * We force deterministic, portable failures by replacing the store folder with
  * a regular FILE: then any path under it fails with ENOTDIR (≠ ENOENT), and
@@ -11,13 +13,14 @@
  */
 
 import { strict as assert } from 'node:assert'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, it } from 'node:test'
 import { useBridgeStore } from '../use-bridge-store.ts'
 
 const enc = (s: string) => new TextEncoder().encode(s)
+const dec = (u: Uint8Array | null) => (u ? new TextDecoder().decode(u) : null)
 
 // `session` is a CRITICAL store (immediate write); `msg_secret` is not.
 const CRITICAL = 'session'
@@ -51,13 +54,31 @@ describe('useBridgeStore — error propagation', () => {
 		await rm(dir, { force: true })
 	})
 
-	it('critical set TOLERATES the folder being gone (ENOENT, shutdown race)', async () => {
+	it('critical set REJECTS when the folder is gone (ENOENT): no bytes, no success claim', async () => {
 		const dir = await mkdtemp(join(tmpdir(), 'err-enoent-'))
 		const store = await useBridgeStore(dir)
 		await rm(dir, { recursive: true, force: true })
 
-		// Folder removed entirely → ENOENT → must resolve, not throw.
-		await store.set(CRITICAL, 'addr', enc('x'))
+		// Folder removed entirely → ENOENT → must reject, not resolve.
+		// Resolving here would tell the core a Signal ratchet step is
+		// durable when nothing reached disk.
+		await assert.rejects(() => store.set(CRITICAL, 'addr', enc('x')), /ENOENT/)
+		await rm(dir, { recursive: true, force: true })
+	})
+
+	it('critical set retry after ENOENT persists once the folder exists again', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'err-enoent-retry-'))
+		const store = await useBridgeStore(dir)
+		await rm(dir, { recursive: true, force: true })
+
+		const value = enc('x')
+		await assert.rejects(() => store.set(CRITICAL, 'addr', value), /ENOENT/)
+		// Identical retry must NOT be skipped: the failure never reached
+		// the durable map, so the retry re-attempts and persists.
+		await mkdir(dir, { recursive: true })
+		await store.set(CRITICAL, 'addr', value)
+		assert.equal(dec(await store.get(CRITICAL, 'addr')), 'x')
+		await rm(dir, { recursive: true, force: true })
 	})
 
 	it('listKeys PROPAGATES a real readdir failure (ENOTDIR), not empty', async () => {

--- a/src/Utils/use-bridge-store.ts
+++ b/src/Utils/use-bridge-store.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'node:buffer'
 import { mkdir, open, readdir, readFile, rename, unlink } from 'node:fs/promises'
+import { randomBytes } from 'node:crypto'
 import { dirname, join } from 'node:path'
 import type { AuthenticationState } from '../Types/index.ts'
 
@@ -51,84 +52,83 @@ const CRITICAL_STORES: ReadonlySet<string> = new Set([
  */
 const isEnoent = (e: unknown): boolean => (e as NodeJS.ErrnoException)?.code === 'ENOENT'
 
+const errnoOf = (e: unknown): string | undefined => (e as NodeJS.ErrnoException)?.code
+
 const bytesEqual = (a: Uint8Array, b: Uint8Array): boolean => a.length === b.length && Buffer.compare(a, b) === 0
 
-const snapshot = (value: Uint8Array): Uint8Array => value.slice()
+// Real copy for both Uint8Array and Buffer. `Buffer.prototype.slice`
+// deliberately returns a view over the same memory, so `.slice()` is NOT
+// a valid snapshot for caller-owned buffers.
+const copyBytes = (value: Uint8Array): Uint8Array => Uint8Array.from(value)
 
-/**
- * Test-only fault-injection seam for the atomic-write steps. Production
- * code always uses the real implementations. Tests replace one step at a
- * time with a rejecting stub to prove that a failure before the rename
- * leaves the previous file intact, that a failure anywhere keeps the work
- * retryable, and that the retry then persists. Not part of the public
- * store contract — the bridge never touches this object.
- */
-export const __testBridgeStoreIO: {
+// File-creation steps behind one durable write. Scoped per store via the
+// `options` parameter of `useBridgeStore` — never a shared global — so
+// tests can hold, fail, or observe a single store's I/O without affecting
+// any other store instance. When omitted, the production implementation
+// below is used.
+type BridgeStoreFileIO = {
 	writeTmp(tmpPath: string, value: Uint8Array): Promise<void>
 	publishTmp(tmpPath: string, finalPath: string): Promise<void>
-} = {
+}
+
+type BridgeStoreOptions = {
+	io?: BridgeStoreFileIO
+}
+
+/**
+ * Directory fsync failures that mean "this platform cannot sync directory
+ * handles" rather than "your data is at risk". ENOSYS/ENOTSUP: the syscall
+ * is not implemented. EINVAL/EBADF: the handle kind does not support
+ * syncing (e.g. directory handles on some platforms). EPERM: the sandbox
+ * forbids handle sync even though the data path succeeded. Everything
+ * else — EIO, ENOSPC, EROFS, EACCES on open — is a real I/O failure and
+ * propagates so the caller learns the durability barrier did not hold.
+ */
+const isUnsupportedDirSync = (e: unknown): boolean => {
+	const code = errnoOf(e)
+	return code === 'ENOSYS' || code === 'ENOTSUP' || code === 'EINVAL' || code === 'EBADF' || code === 'EPERM'
+}
+
+// Persist a directory entry update (rename/unlink) toward power-loss
+// durability. `open` failures propagate untouched; only the narrow
+// "unsupported" class of `sync` failures is swallowed, documented above.
+const syncDir = async (dir: string): Promise<void> => {
+	const handle = await open(dir, 'r')
+	try {
+		await handle.sync()
+	} catch (e) {
+		if (!isUnsupportedDirSync(e)) throw e
+	} finally {
+		await handle.close().catch(() => {})
+	}
+}
+
+const defaultFileIO: BridgeStoreFileIO = {
 	async writeTmp(tmpPath: string, value: Uint8Array): Promise<void> {
-		const handle = await open(tmpPath, 'w')
+		// Exclusive create: never truncate a temp file this operation did
+		// not create. Temp names are unique per attempt (see durableWrite),
+		// so EEXIST is not expected — but if it ever happens the caller
+		// retries with a fresh name instead of touching foreign bytes.
+		const handle = await open(tmpPath, 'wx')
 		try {
 			await handle.writeFile(value)
 			await handle.sync()
-		} finally {
-			await handle.close()
+		} catch (e) {
+			// Owned (we just created it exclusively): remove our own
+			// partial temp, never anyone else's.
+			await handle.close().catch(() => {})
+			await unlink(tmpPath).catch(() => {})
+			throw e
 		}
+		await handle.close()
 	},
 	async publishTmp(tmpPath: string, finalPath: string): Promise<void> {
 		await rename(tmpPath, finalPath)
-		// Best-effort directory sync so the rename itself survives a power
-		// loss, not just a process crash. Platforms that cannot sync a
-		// directory keep the rename either way — atomicity against a dead
-		// process never depended on this call.
-		try {
-			const dirHandle = await open(dirname(finalPath), 'r')
-			try {
-				await dirHandle.sync()
-			} finally {
-				await dirHandle.close()
-			}
-		} catch {
-			// ignore — durability degrades to process-crash atomicity
-		}
+		await syncDir(dirname(finalPath))
 	}
 }
 
 let tmpSeq = 0
-
-/**
- * Durable file replacement: write + fsync a uniquely-named temp file in
- * the same directory, then atomically rename it over the target. The
- * previous file (or its absence) is untouched until the rename succeeds,
- * so a crash or a failed write can never leave a torn target behind —
- * readers always see the old intact file or the new intact file.
- *
- * Guarantees are scoped honestly: the rename is atomic against a dead
- * process, and the file + directory syncs raise the bar toward power-loss
- * durability on platforms that honor them. No file-level test can prove
- * power-loss survival — that would need a physical harness — so tests
- * assert the mockable half (failure atomicity, retryability) and the code
- * does not claim more.
- *
- * Every error propagates, including ENOENT: resolving a write whose bytes
- * never reached disk would let the caller believe state is durable.
- */
-const durableWrite = async (finalPath: string, value: Uint8Array): Promise<void> => {
-	const tmpPath = `${finalPath}.${process.pid}.${tmpSeq++}.tmp`
-	try {
-		await __testBridgeStoreIO.writeTmp(tmpPath, value)
-	} catch (e) {
-		await unlink(tmpPath).catch(() => {})
-		throw e
-	}
-	try {
-		await __testBridgeStoreIO.publishTmp(tmpPath, finalPath)
-	} catch (e) {
-		await unlink(tmpPath).catch(() => {})
-		throw e
-	}
-}
 
 /**
  * Creates a file-based store for the WASM bridge.
@@ -136,6 +136,9 @@ const durableWrite = async (finalPath: string, value: Uint8Array): Promise<void>
  * Each (store, key) pair maps to a file: `<folder>/<store>-<key>.bin`
  *
  * Durability model:
+ * - Caller buffers are copied synchronously at admission (`set`/`setMany`
+ *   copy before queueing), so mutating a buffer after the call — even
+ *   before awaiting it — can never change what gets persisted.
  * - Critical stores write through `durableWrite` before `set`/`setMany`
  *   resolve. The in-memory map only records bytes AFTER they are on disk,
  *   so an identical retry following a failure is never skipped and always
@@ -144,21 +147,81 @@ const durableWrite = async (finalPath: string, value: Uint8Array): Promise<void>
  *   immediately (read-your-write), but such reads are NOT durable until
  *   `flush()` succeeds. A failed flush keeps the pending entry and throws,
  *   so the next `flush()` retries the same bytes.
- * - All mutations of one key (set, delete, flush, concurrent batches) run
+ * - `flush()` first waits for every operation admitted before it (barrier),
+ *   then drains the pending writes those operations produced. It never
+ *   reports quiescence while prior admitted work is still running.
+ * - All operations on one key (set, delete, flush, concurrent batches) run
  *   through a per-key chain, so a stale failure can never erase newer
  *   state and an in-flight write can never resurrect a deleted key.
- * - Every byte array crossing the boundary is copied: caller buffers
- *   cannot mutate cached or in-flight data, and returned buffers cannot
- *   mutate the cache either.
+ * - A failed delete restores the preceding pending/durable state, so an
+ *   acknowledged value stays readable and flushable; only a successful
+ *   delete clears it, at its linearization point under the key lock.
+ * - Every byte array handed back to callers is a copy.
  *
  * @param folder Directory to store bridge state files
+ * @param options Optional per-store file-I/O steps (scoped test seam)
  */
-export async function useBridgeStore(folder: string): Promise<NonNullable<AuthenticationState['store']>> {
+export async function useBridgeStore(
+	folder: string,
+	options?: BridgeStoreOptions
+): Promise<NonNullable<AuthenticationState['store']>> {
 	await mkdir(folder, { recursive: true })
 
+	const io = options?.io ?? defaultFileIO
+
+	/**
+	 * Durable file replacement: write + fsync an exclusively-created,
+	 * uniquely-named temp file in the same directory, then atomically
+	 * rename it over the target. The previous file (or its absence) is
+	 * untouched until the rename succeeds, so a crash or a failed write can
+	 * never leave a torn target behind — readers always see the old intact
+	 * file or the new intact file. Cleanup only ever removes a temp this
+	 * operation created; a temp that already existed is left alone.
+	 *
+	 * Guarantees are scoped honestly: the rename is atomic against a dead
+	 * process, and the file + directory syncs raise the bar toward
+	 * power-loss durability on platforms that honor them. No file-level
+	 * test can prove power-loss survival — that would need a physical
+	 * harness — so tests assert the checkable half (failure atomicity,
+	 * retryability) and the code does not claim more.
+	 *
+	 * Every error propagates, including ENOENT: resolving a write whose
+	 * bytes never reached disk would let the caller believe state is
+	 * durable.
+	 */
+	const durableWrite = async (finalPath: string, value: Uint8Array): Promise<void> => {
+		const MAX_TMP_ATTEMPTS = 5
+		for (let attempt = 0; attempt < MAX_TMP_ATTEMPTS; attempt++) {
+			const tmpPath = `${finalPath}.${process.pid}.${tmpSeq++}.${randomBytes(4).toString('hex')}.tmp`
+			try {
+				await io.writeTmp(tmpPath, value)
+			} catch (e) {
+				// EEXIST means a foreign temp owns this name (we create
+				// exclusively and never overwrite): retry with a fresh name
+				// instead of deleting or reusing it. Any other failure is
+				// ours to report; `writeTmp` already cleaned up its own temp.
+				if (errnoOf(e) === 'EEXIST') continue
+				throw e
+			}
+			try {
+				await io.publishTmp(tmpPath, finalPath)
+			} catch (e) {
+				// Publish of our own temp failed before (or atomically
+				// without) replacing the target: remove only our temp. If
+				// the rename itself succeeded, the temp is already gone and
+				// this unlink is a tolerated no-op.
+				await unlink(tmpPath).catch(() => {})
+				throw e
+			}
+			return
+		}
+		throw new Error(`use-bridge-store durableWrite could not claim a unique temp name for ${finalPath}`)
+	}
+
 	// Last bytes known to be durable per key (written, flushed, or read
-	// from disk). Snapshots only — never a caller-owned reference. Bounded
-	// by LRU eviction; eviction only drops knowledge, disk stays canonical.
+	// from disk). Private copies only — never a caller-owned reference.
+	// Bounded by LRU eviction; eviction only drops knowledge, disk stays
+	// canonical.
 	const MAX_CACHE_ENTRIES = 5000
 	const durable = new Map<string, Uint8Array>()
 	const rememberDurable = (key: string, value: Uint8Array) => {
@@ -173,12 +236,76 @@ export async function useBridgeStore(folder: string): Promise<NonNullable<Authen
 
 	const filePath = (store: string, key: string) => join(folder, `${store}-${encodeURIComponent(key)}.bin`)
 
-	// Per-key serialization chain. Every mutation or read of one key runs
-	// inside `withKeyLock` for that key; different keys never block each
-	// other. The tail swallows rejections so one failed op cannot wedge
-	// later ops for the same key.
+	// Per-key serialization chain. Every key operation runs inside
+	// `withKeyLock` for that key; different keys never block each other.
+	// The tail swallows rejections so one failed op cannot wedge later ops
+	// for the same key. Every admitted op is also tracked in `admitted`
+	// until it settles so `flush()` can wait for work admitted before it.
 	const chains = new Map<string, Promise<void>>()
+	const admitted = new Set<Promise<unknown>>()
 	const withKeyLock = <T>(cacheKey: string, fn: () => Promise<T>): Promise<T> => {
+		const prev = chains.get(cacheKey) ?? Promise.resolve()
+		const next = prev.then(fn, fn)
+		const tail = next.then(
+			() => undefined,
+			() => undefined
+		)
+		chains.set(cacheKey, tail)
+		tail.then(() => {
+			if (chains.get(cacheKey) === tail) chains.delete(cacheKey)
+		})
+		admitted.add(next)
+		next.then(
+			() => {
+				admitted.delete(next)
+			},
+			() => {
+				admitted.delete(next)
+			}
+		)
+		return next
+	}
+
+	// Debounced non-critical writes not yet flushed to disk.
+	const pendingWrites = new Map<
+		string,
+		{ store: string; key: string; path: string; value: Uint8Array; timer?: ReturnType<typeof setTimeout> }
+	>()
+	const WRITE_DELAY_MS = 50
+
+	const armTimer = (cacheKey: string, entry: { value: Uint8Array; timer?: ReturnType<typeof setTimeout> }): void => {
+		if (entry.timer) clearTimeout(entry.timer)
+		entry.timer = setTimeout(() => {
+			void flushOne(cacheKey).catch(() => {
+				// No caller to report to; the entry stays pending and the
+				// next explicit flush() retries it and surfaces the error.
+			})
+		}, WRITE_DELAY_MS)
+		entry.timer.unref() // Don't keep the process alive for debounced writes
+	}
+
+	// Flush one pending key. Runs under the key lock (not tracked in
+	// `admitted`: the drain loop drives it, so tracking it would make
+	// `flush()` wait on itself). On failure the entry is RETAINED (timer
+	// cleared) so an explicit `flush()` retries the same bytes, and the
+	// error propagates to that caller.
+	const flushOne = (cacheKey: string): Promise<void> =>
+		withKeyLockInternal(cacheKey, async () => {
+			const pending = pendingWrites.get(cacheKey)
+			if (!pending) return
+			if (pending.timer) {
+				clearTimeout(pending.timer)
+				pending.timer = undefined
+			}
+			await durableWrite(pending.path, pending.value)
+			if (pendingWrites.get(cacheKey) === pending) pendingWrites.delete(cacheKey)
+			rememberDurable(cacheKey, copyBytes(pending.value))
+		})
+
+	// Same as `withKeyLock` but invisible to the flush admission barrier.
+	// Only the flush drain loop may use this; key operations use
+	// `withKeyLock` so `flush()` observes them.
+	const withKeyLockInternal = <T>(cacheKey: string, fn: () => Promise<T>): Promise<T> => {
 		const prev = chains.get(cacheKey) ?? Promise.resolve()
 		const next = prev.then(fn, fn)
 		const tail = next.then(
@@ -192,41 +319,29 @@ export async function useBridgeStore(folder: string): Promise<NonNullable<Authen
 		return next
 	}
 
-	// Debounced non-critical writes not yet flushed to disk.
-	const pendingWrites = new Map<
-		string,
-		{ store: string; key: string; path: string; value: Uint8Array; timer?: ReturnType<typeof setTimeout> }
-	>()
-	const WRITE_DELAY_MS = 50
-
-	// Flush one pending key. Runs under the key lock. On failure the entry
-	// is RETAINED (timer cleared) so an explicit `flush()` retries the same
-	// bytes, and the error propagates to that caller. The debounce timer
-	// swallows its own failure — it has no caller to report to — but the
-	// entry stays pending, so the work is never lost silently.
-	const flushOne = (cacheKey: string): Promise<void> =>
-		withKeyLock(cacheKey, async () => {
-			const pending = pendingWrites.get(cacheKey)
-			if (!pending) return
-			if (pending.timer) {
-				clearTimeout(pending.timer)
-				pending.timer = undefined
-			}
-			await durableWrite(pending.path, pending.value)
-			if (pendingWrites.get(cacheKey) === pending) pendingWrites.delete(cacheKey)
-			rememberDurable(cacheKey, snapshot(pending.value))
-		})
-
 	const FLUSH_MAX_PASSES = 32
 	const flushAll = async () => {
-		// Drain in passes because new sets can land while a batch's writes
-		// are awaited. A pass with zero successes cannot make progress by
-		// immediate retry (persistent failure), so stop and report the
-		// first error with the entries still pending for the next flush.
-		// The pass cap only guards a caller emitting writes in a tight
-		// loop — `Socket/index.ts.end()` waits on this and must return.
+		// Each pass first waits for every operation admitted so far
+		// (barrier), then drains the pending writes those operations
+		// produced. A `set()` queued just before `flush()` is therefore
+		// observed even if it had not reached `pendingWrites` yet, and an
+		// already-running critical write completes before quiescence is
+		// declared. `flushOne` internals are not admitted, so the barrier
+		// never waits on the drain loop itself (no self-deadlock).
+		// A pass with zero successes and nothing newly admitted cannot make
+		// progress by immediate retry (persistent failure), so stop and
+		// report the first error with the entries still pending for the
+		// next flush. The pass cap only guards a caller emitting writes in
+		// a tight loop — `Socket/index.ts.end()` waits on this and must
+		// return.
 		const errors: unknown[] = []
-		for (let i = 0; i < FLUSH_MAX_PASSES && pendingWrites.size > 0; i++) {
+		for (let i = 0; i < FLUSH_MAX_PASSES; i++) {
+			const outstanding = [...admitted]
+			if (outstanding.length > 0) await Promise.allSettled(outstanding)
+			if (pendingWrites.size === 0) {
+				if (admitted.size === 0) break
+				continue
+			}
 			const keys = [...pendingWrites.keys()]
 			let progressed = false
 			await Promise.all(
@@ -241,21 +356,20 @@ export async function useBridgeStore(folder: string): Promise<NonNullable<Authen
 					)
 				)
 			)
-			if (!progressed) break
+			if (!progressed && admitted.size === 0) break
 		}
 		if (errors.length > 0) throw errors[0]
-		if (pendingWrites.size > 0) {
+		if (pendingWrites.size > 0 || admitted.size > 0) {
 			throw new Error(
-				`use-bridge-store flushAll did not quiesce after ${FLUSH_MAX_PASSES} passes (${pendingWrites.size} pending writes remain)`
+				`use-bridge-store flushAll did not quiesce after ${FLUSH_MAX_PASSES} passes (${pendingWrites.size} pending writes, ${admitted.size} in-flight operations remain)`
 			)
 		}
 	}
 
-	// Write path shared by `set` and `setMany`. Must run under the key
-	// lock — callers wrap it via `withKeyLock`.
-	const doSetLocked = async (store: string, key: string, cacheKey: string, value: Uint8Array): Promise<void> => {
-		const incoming = snapshot(value)
-
+	// Write path shared by `set` and `setMany`. `incoming` is already a
+	// private admission-time copy. Must run under the key lock — callers
+	// wrap it via `withKeyLock`.
+	const doSetLocked = async (store: string, key: string, cacheKey: string, incoming: Uint8Array): Promise<void> => {
 		// Skip only when the identical bytes are already durable or already
 		// queued. A failed write never reaches `durable`/`pendingWrites`,
 		// so an identical retry always re-attempts instead of resolving
@@ -277,7 +391,7 @@ export async function useBridgeStore(folder: string): Promise<NonNullable<Authen
 			// Propagate every failure (ENOSPC/EACCES/EIO/ENOTDIR/ENOENT) —
 			// losing a critical Signal write silently corrupts next decrypt.
 			await durableWrite(filePath(store, key), incoming)
-			rememberDurable(cacheKey, snapshot(incoming))
+			rememberDurable(cacheKey, copyBytes(incoming))
 			return
 		}
 
@@ -290,19 +404,18 @@ export async function useBridgeStore(folder: string): Promise<NonNullable<Authen
 			value: incoming,
 			timer: undefined as ReturnType<typeof setTimeout> | undefined
 		}
-		entry.timer = setTimeout(() => {
-			void flushOne(cacheKey).catch(() => {
-				// No caller to report to; the entry stays pending and the
-				// next explicit flush() retries it and surfaces the error.
-			})
-		}, WRITE_DELAY_MS)
-		entry.timer.unref() // Don't keep the process alive for debounced writes
+		armTimer(cacheKey, entry)
 		pendingWrites.set(cacheKey, entry)
 	}
 
 	const doSet = (store: string, key: string, value: Uint8Array): Promise<void> => {
+		// Admission-time copy, synchronous with the call: a caller mutating
+		// its buffer immediately after (even before awaiting) cannot change
+		// what this operation persists. `Uint8Array.from` copies Buffer
+		// inputs too — `Buffer.slice` would only create a shared view.
+		const incoming = copyBytes(value)
 		const cacheKey = `${store}\0${key}`
-		return withKeyLock(cacheKey, () => doSetLocked(store, key, cacheKey, value))
+		return withKeyLock(cacheKey, () => doSetLocked(store, key, cacheKey, incoming))
 	}
 
 	// Read path shared by `get` and `getMany`. Runs under the key lock so
@@ -313,10 +426,10 @@ export async function useBridgeStore(folder: string): Promise<NonNullable<Authen
 	// makes it durable.
 	const doGetLocked = async (store: string, key: string, cacheKey: string): Promise<Uint8Array | null> => {
 		const pending = pendingWrites.get(cacheKey)
-		if (pending) return snapshot(pending.value)
+		if (pending) return copyBytes(pending.value)
 
 		const known = durable.get(cacheKey)
-		if (known) return snapshot(known)
+		if (known) return copyBytes(known)
 
 		let data: Awaited<ReturnType<typeof readFile>>
 		try {
@@ -328,8 +441,8 @@ export async function useBridgeStore(folder: string): Promise<NonNullable<Authen
 			if (isEnoent(e)) return null
 			throw e
 		}
-		const arr = snapshot(new Uint8Array(data.buffer, data.byteOffset, data.byteLength))
-		rememberDurable(cacheKey, snapshot(arr))
+		const arr = copyBytes(new Uint8Array(data.buffer, data.byteOffset, data.byteLength))
+		rememberDurable(cacheKey, copyBytes(arr))
 		return arr
 	}
 
@@ -339,25 +452,34 @@ export async function useBridgeStore(folder: string): Promise<NonNullable<Authen
 	}
 
 	// Delete path shared by `delete`, `deleteMany` and `deletePrefix`.
-	// Runs under the key lock: cancels queued writes first so a flush in
-	// flight can never resurrect the key, and drops durable knowledge so a
-	// later read goes back to disk. Only ENOENT (already absent) is
-	// tolerated; real unlink failures propagate.
+	// Runs under the key lock. The preceding pending/durable state is only
+	// cleared once the unlink succeeds (its linearization point); if the
+	// unlink fails with a real error, that state is restored — timer
+	// re-armed — so an acknowledged value stays readable and flushable, and
+	// the error propagates. Only ENOENT (already absent) is tolerated. A
+	// successful unlink is followed by a directory sync with the same
+	// scoped fallback as the write path, so the deletion itself is durable.
 	const doDeleteOne = (store: string, key: string): Promise<void> => {
 		const cacheKey = `${store}\0${key}`
 		return withKeyLock(cacheKey, async () => {
+			const prevPending = pendingWrites.get(cacheKey)
+			const prevDurable = durable.get(cacheKey)
+			if (prevPending?.timer) clearTimeout(prevPending.timer)
+			pendingWrites.delete(cacheKey)
 			durable.delete(cacheKey)
-			const pending = pendingWrites.get(cacheKey)
-			if (pending) {
-				if (pending.timer) clearTimeout(pending.timer)
-				pendingWrites.delete(cacheKey)
-			}
 
 			try {
 				await unlink(filePath(store, key))
 			} catch (e) {
-				if (!isEnoent(e)) throw e
+				if (isEnoent(e)) return
+				if (prevDurable) rememberDurable(cacheKey, prevDurable)
+				if (prevPending) {
+					armTimer(cacheKey, prevPending)
+					pendingWrites.set(cacheKey, prevPending)
+				}
+				throw e
 			}
+			await syncDir(folder)
 		})
 	}
 
@@ -375,10 +497,10 @@ export async function useBridgeStore(folder: string): Promise<NonNullable<Authen
 	// `deletePrefix`). Closure, not a method, so it never depends on `this`.
 	// Files are `<store>-<encodeURIComponent(key)>.bin`; store names never
 	// contain a hyphen, so split on the FIRST hyphen and decode the remainder.
-	// A flush is awaited first so debounced writes are durable before the
-	// readdir; its failure propagates rather than enumerating a stale view.
-	// Pending deletes both cancel their `pendingWrites` entry AND unlink
-	// immediately, so they never appear here.
+	// A flush is awaited first so admitted and debounced writes are durable
+	// before the readdir; its failure propagates rather than enumerating a
+	// stale view. Pending deletes both cancel their `pendingWrites` entry
+	// AND unlink immediately, so they never appear here.
 	const doListKeys = async (store: string, prefix?: string): Promise<string[]> => {
 		await flushAll()
 
@@ -432,7 +554,8 @@ export async function useBridgeStore(folder: string): Promise<NonNullable<Authen
 		// Batched variant of `set`. The bridge calls this (when present) to
 		// persist a burst of entries in a single FFI crossing instead of N
 		// round-trips (e.g. ~20k messageSecrets from a history sync).
-		// Per-entry semantics are identical to `set`. Best-effort across
+		// Per-entry semantics are identical to `set` — admission copies are
+		// taken synchronously for every entry, in order. Best-effort across
 		// keys per the bridge contract: every entry is attempted even when
 		// a sibling fails (writes are idempotent by key, so the core can
 		// retry the batch), and the first error propagates. No multi-key

--- a/src/Utils/use-bridge-store.ts
+++ b/src/Utils/use-bridge-store.ts
@@ -90,14 +90,23 @@ export const isUnsupportedDirSync = (e: unknown, platform: NodeJS.Platform = pro
 // File-creation steps behind one durable write plus the directory barrier.
 // Scoped per store via the `options` parameter of `useBridgeStore` — never
 // a shared global — so tests can hold, fail, or observe a single store's
-// I/O without affecting any other store instance. Only the default
-// implementation below provides the durability contract documented on
-// `useBridgeStore`; a custom implementation is a test/fault-injection seam
-// and carries no durability guarantees of its own.
+// I/O without affecting any other store instance. Every member is optional
+// and falls back to its default below, so a test can replace one low-level
+// step (e.g. temp-file creation) while exercising the real default
+// implementation of the rest. Only the defaults provide the durability
+// contract documented on `useBridgeStore`; a custom implementation is a
+// test/fault-injection seam and carries no durability guarantees of its own.
+type BridgeStoreFileHandle = {
+	writeFile(value: Uint8Array): Promise<void>
+	sync(): Promise<void>
+	close(): Promise<void>
+}
+
 type BridgeStoreFileIO = {
-	writeTmp(tmpPath: string, value: Uint8Array): Promise<void>
-	publishTmp(tmpPath: string, finalPath: string): Promise<void>
-	syncDir(dir: string): Promise<void>
+	writeTmp?(tmpPath: string, value: Uint8Array): Promise<void>
+	publishTmp?(tmpPath: string, finalPath: string): Promise<void>
+	syncDir?(dir: string): Promise<void>
+	openTmp?(tmpPath: string): Promise<BridgeStoreFileHandle>
 }
 
 type BridgeStoreOptions = {
@@ -137,29 +146,39 @@ const defaultSyncDir = async (dir: string): Promise<void> => {
 	}
 }
 
-const defaultFileIO: BridgeStoreFileIO = {
-	async writeTmp(tmpPath: string, value: Uint8Array): Promise<void> {
-		// Exclusive create: never truncate a temp file this operation did
-		// not create. Temp names are unique per attempt (see durableWrite),
-		// so EEXIST is not expected — but if it ever happens the caller
-		// retries with a fresh name instead of touching foreign bytes.
-		const handle = await open(tmpPath, 'wx')
-		try {
-			await handle.writeFile(value)
-			await handle.sync()
-		} catch (e) {
-			// Owned (we just created it exclusively): remove our own
-			// partial temp, never anyone else's.
-			await handle.close().catch(() => {})
-			await unlink(tmpPath).catch(() => {})
-			throw e
-		}
+// Exclusive temp creation with a restrictive mode for sensitive auth
+// bytes. `0o600` regardless of umask: replacement renames this inode over
+// the target, so an existing `0600` file can never be widened (a previously
+// wider file narrows to `0600`, the safe direction for session secrets;
+// POSIX only — Windows ignores mode bits).
+const realOpenTmp = async (tmpPath: string): Promise<BridgeStoreFileHandle> => open(tmpPath, 'wx', 0o600)
+
+const defaultWriteTmp = async (
+	tmpPath: string,
+	value: Uint8Array,
+	openTmp: (tmpPath: string) => Promise<BridgeStoreFileHandle>
+): Promise<void> => {
+	// Exclusive create: never truncate a temp file this operation did
+	// not create. Temp names are unique per attempt (see durableWrite),
+	// so EEXIST is not expected — but if it ever happens the caller
+	// retries with a fresh name instead of touching foreign bytes.
+	const handle = await openTmp(tmpPath)
+	try {
+		await handle.writeFile(value)
+		await handle.sync()
 		await handle.close()
-	},
-	async publishTmp(tmpPath: string, finalPath: string): Promise<void> {
-		await rename(tmpPath, finalPath)
-	},
-	syncDir: defaultSyncDir
+	} catch (e) {
+		// Owned (we just created it exclusively): close best-effort and
+		// remove our own temp, never anyone else's. Cleanup failures
+		// cannot mask the original error — it always propagates.
+		await handle.close().catch(() => {})
+		await unlink(tmpPath).catch(() => {})
+		throw e
+	}
+}
+
+const defaultPublishTmp = async (tmpPath: string, finalPath: string): Promise<void> => {
+	await rename(tmpPath, finalPath)
 }
 
 let tmpSeq = 0
@@ -214,13 +233,21 @@ export async function useBridgeStore(
 ): Promise<NonNullable<AuthenticationState['store']>> {
 	await mkdir(folder, { recursive: true })
 
-	const io = options?.io ?? defaultFileIO
+	const openTmp = options?.io?.openTmp ?? realOpenTmp
+	const io = {
+		writeTmp: options?.io?.writeTmp ?? ((tmpPath, value) => defaultWriteTmp(tmpPath, value, openTmp)),
+		publishTmp: options?.io?.publishTmp ?? defaultPublishTmp,
+		syncDir: options?.io?.syncDir ?? defaultSyncDir
+	}
 
 	/**
-	 * Durable file replacement: write + fsync an exclusively-created,
-	 * uniquely-named temp file in the same directory, then atomically
-	 * rename it over the target and sync the directory. The previous file
-	 * (or its absence) is untouched until the rename succeeds, so a crash
+	 * Durable file replacement: write + fsync an exclusively-created temp
+	 * file in the same directory, then atomically rename it over the
+	 * target and sync the directory. The temp uses a short fixed-shape
+	 * basename (independent of key length, so long-but-valid final names
+	 * still fit NAME_MAX) created with mode `0600` (POSIX; Windows ignores
+	 * mode bits), so replacing a hardened auth file never widens its
+	 * permissions. The previous file (or its absence) is untouched until the rename succeeds, so a crash
 	 * or a failed write can never leave a torn target behind — readers
 	 * always see the old intact file or the new intact file. Cleanup only
 	 * ever removes a temp this operation created; a temp that already
@@ -241,7 +268,14 @@ export async function useBridgeStore(
 	const durableWrite = async (finalPath: string, value: Uint8Array): Promise<void> => {
 		const MAX_TMP_ATTEMPTS = 5
 		for (let attempt = 0; attempt < MAX_TMP_ATTEMPTS; attempt++) {
-			const tmpPath = `${finalPath}.${process.pid}.${tmpSeq++}.${randomBytes(4).toString('hex')}.tmp`
+			// Short fixed-shape basename in the same directory (rename stays
+			// atomic): independent of the target key length so keys whose
+			// valid final names approach NAME_MAX still fit. Uniqueness from
+			// pid + sequence + randomness; the final stored name is untouched.
+			const tmpPath = join(
+				dirname(finalPath),
+				`.bstore-${process.pid.toString(36)}-${(tmpSeq++).toString(36)}-${randomBytes(4).toString('hex')}.tmp`
+			)
 			try {
 				await io.writeTmp(tmpPath, value)
 			} catch (e) {
@@ -559,6 +593,19 @@ export async function useBridgeStore(
 			pendingWrites.delete(cacheKey)
 			durable.delete(cacheKey)
 
+			// Reinstate the state captured above after any delete failure
+			// that leaves the key's fate undecided, so an acknowledged
+			// value stays readable and flushable. Not used when absence is
+			// certified (the delete won) or when the unlink itself succeeded
+			// (the file is genuinely gone; only the barrier is uncertain).
+			const restoreDeleteState = () => {
+				if (prevDurable) rememberDurable(cacheKey, prevDurable)
+				if (prevPending) {
+					armTimer(cacheKey, prevPending)
+					pendingWrites.set(cacheKey, prevPending)
+				}
+			}
+
 			try {
 				await unlink(filePath(store, key))
 			} catch (e) {
@@ -567,15 +614,16 @@ export async function useBridgeStore(
 					// Absent on disk, but a prior barrier was never
 					// certified: certify the absence now instead of
 					// swallowing the uncertainty.
-					await io.syncDir(folder)
+					try {
+						await io.syncDir(folder)
+					} catch (syncError) {
+						restoreDeleteState()
+						throw syncError
+					}
 					uncertain.delete(cacheKey)
 					return
 				}
-				if (prevDurable) rememberDurable(cacheKey, prevDurable)
-				if (prevPending) {
-					armTimer(cacheKey, prevPending)
-					pendingWrites.set(cacheKey, prevPending)
-				}
+				restoreDeleteState()
 				throw e
 			}
 			try {

--- a/src/Utils/use-bridge-store.ts
+++ b/src/Utils/use-bridge-store.ts
@@ -1,13 +1,14 @@
 import { Buffer } from 'node:buffer'
-import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { mkdir, open, readdir, readFile, rename, unlink } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 import type { AuthenticationState } from '../Types/index.ts'
 
 /**
  * Stores whose loss on SIGKILL produces undecryptable messages or
  * permanent app-state divergence. Each entry below carries a reason —
- * promoting a store to "critical" doubles disk I/O, so don't add
- * anything here that can be re-derived from the network.
+ * promoting a store to "critical" multiplies disk I/O (write + fsync +
+ * atomic rename per key), so don't add anything here that can be
+ * re-derived from the network.
  *
  *   `session` / `identity` — Signal session ratchet steps. Lose
  *      one step → next inbound message from peer undecryptable.
@@ -40,106 +41,209 @@ const CRITICAL_STORES: ReadonlySet<string> = new Set([
 ])
 
 /**
- * `ENOENT` is the only error tolerated on a write/readdir: it means the auth
- * folder was removed (e.g. during shutdown/cleanup). Any other error (ENOSPC,
- * EACCES, EIO, ENOTDIR) is a real persistence failure that MUST propagate —
- * swallowing it would silently lose Signal session state or message secrets
- * while the caller believes the write succeeded.
+ * `ENOENT` is legitimate only where absence is a valid answer: reading a
+ * key that was never written (or was deleted), deleting a key that is
+ * already gone, and enumerating a folder that was removed. Everywhere
+ * else — writes, flushes, non-ENOENT read/delete failures (ENOTDIR,
+ * EACCES, EIO, ENOSPC) — the error MUST propagate. A write that resolves
+ * without durable bytes while the caller believes it persisted silently
+ * loses Signal session state or message secrets.
  */
 const isEnoent = (e: unknown): boolean => (e as NodeJS.ErrnoException)?.code === 'ENOENT'
+
+const bytesEqual = (a: Uint8Array, b: Uint8Array): boolean => a.length === b.length && Buffer.compare(a, b) === 0
+
+const snapshot = (value: Uint8Array): Uint8Array => value.slice()
+
+/**
+ * Test-only fault-injection seam for the atomic-write steps. Production
+ * code always uses the real implementations. Tests replace one step at a
+ * time with a rejecting stub to prove that a failure before the rename
+ * leaves the previous file intact, that a failure anywhere keeps the work
+ * retryable, and that the retry then persists. Not part of the public
+ * store contract — the bridge never touches this object.
+ */
+export const __testBridgeStoreIO: {
+	writeTmp(tmpPath: string, value: Uint8Array): Promise<void>
+	publishTmp(tmpPath: string, finalPath: string): Promise<void>
+} = {
+	async writeTmp(tmpPath: string, value: Uint8Array): Promise<void> {
+		const handle = await open(tmpPath, 'w')
+		try {
+			await handle.writeFile(value)
+			await handle.sync()
+		} finally {
+			await handle.close()
+		}
+	},
+	async publishTmp(tmpPath: string, finalPath: string): Promise<void> {
+		await rename(tmpPath, finalPath)
+		// Best-effort directory sync so the rename itself survives a power
+		// loss, not just a process crash. Platforms that cannot sync a
+		// directory keep the rename either way — atomicity against a dead
+		// process never depended on this call.
+		try {
+			const dirHandle = await open(dirname(finalPath), 'r')
+			try {
+				await dirHandle.sync()
+			} finally {
+				await dirHandle.close()
+			}
+		} catch {
+			// ignore — durability degrades to process-crash atomicity
+		}
+	}
+}
+
+let tmpSeq = 0
+
+/**
+ * Durable file replacement: write + fsync a uniquely-named temp file in
+ * the same directory, then atomically rename it over the target. The
+ * previous file (or its absence) is untouched until the rename succeeds,
+ * so a crash or a failed write can never leave a torn target behind —
+ * readers always see the old intact file or the new intact file.
+ *
+ * Guarantees are scoped honestly: the rename is atomic against a dead
+ * process, and the file + directory syncs raise the bar toward power-loss
+ * durability on platforms that honor them. No file-level test can prove
+ * power-loss survival — that would need a physical harness — so tests
+ * assert the mockable half (failure atomicity, retryability) and the code
+ * does not claim more.
+ *
+ * Every error propagates, including ENOENT: resolving a write whose bytes
+ * never reached disk would let the caller believe state is durable.
+ */
+const durableWrite = async (finalPath: string, value: Uint8Array): Promise<void> => {
+	const tmpPath = `${finalPath}.${process.pid}.${tmpSeq++}.tmp`
+	try {
+		await __testBridgeStoreIO.writeTmp(tmpPath, value)
+	} catch (e) {
+		await unlink(tmpPath).catch(() => {})
+		throw e
+	}
+	try {
+		await __testBridgeStoreIO.publishTmp(tmpPath, finalPath)
+	} catch (e) {
+		await unlink(tmpPath).catch(() => {})
+		throw e
+	}
+}
 
 /**
  * Creates a file-based store for the WASM bridge.
  *
  * Each (store, key) pair maps to a file: `<folder>/<store>-<key>.bin`
  *
- * Uses a write-through in-memory cache to avoid redundant disk reads.
- * Writes go to both cache and disk. Reads hit cache first, disk on miss.
+ * Durability model:
+ * - Critical stores write through `durableWrite` before `set`/`setMany`
+ *   resolve. The in-memory map only records bytes AFTER they are on disk,
+ *   so an identical retry following a failure is never skipped and always
+ *   re-attempts the write.
+ * - Non-critical stores are debounced (50ms coalescing) and readable
+ *   immediately (read-your-write), but such reads are NOT durable until
+ *   `flush()` succeeds. A failed flush keeps the pending entry and throws,
+ *   so the next `flush()` retries the same bytes.
+ * - All mutations of one key (set, delete, flush, concurrent batches) run
+ *   through a per-key chain, so a stale failure can never erase newer
+ *   state and an in-flight write can never resurrect a deleted key.
+ * - Every byte array crossing the boundary is copied: caller buffers
+ *   cannot mutate cached or in-flight data, and returned buffers cannot
+ *   mutate the cache either.
  *
  * @param folder Directory to store bridge state files
  */
 export async function useBridgeStore(folder: string): Promise<NonNullable<AuthenticationState['store']>> {
 	await mkdir(folder, { recursive: true })
 
-	// Write-through cache with LRU eviction to bound memory
+	// Last bytes known to be durable per key (written, flushed, or read
+	// from disk). Snapshots only — never a caller-owned reference. Bounded
+	// by LRU eviction; eviction only drops knowledge, disk stays canonical.
 	const MAX_CACHE_ENTRIES = 5000
-	const cache = new Map<string, Uint8Array>()
-	const touchCache = (key: string, value: Uint8Array) => {
+	const durable = new Map<string, Uint8Array>()
+	const rememberDurable = (key: string, value: Uint8Array) => {
 		// LRU: delete + re-insert moves to end of insertion order
-		cache.delete(key)
-		cache.set(key, value)
-		// Evict oldest entries if over limit
-		if (cache.size > MAX_CACHE_ENTRIES) {
-			const first = cache.keys().next().value!
-			cache.delete(first)
+		durable.delete(key)
+		durable.set(key, value)
+		if (durable.size > MAX_CACHE_ENTRIES) {
+			const first = durable.keys().next().value!
+			durable.delete(first)
 		}
 	}
 
 	const filePath = (store: string, key: string) => join(folder, `${store}-${encodeURIComponent(key)}.bin`)
 
-	// Durable write that propagates real failures but tolerates the folder
-	// having been removed (shutdown race). Used by both `set` and `setMany`.
-	const writeCritical = async (store: string, key: string, value: Uint8Array): Promise<void> => {
-		try {
-			await writeFile(filePath(store, key), value)
-		} catch (e) {
-			if (!isEnoent(e)) throw e
-			// folder removed during shutdown — nothing to persist into
-		}
+	// Per-key serialization chain. Every mutation or read of one key runs
+	// inside `withKeyLock` for that key; different keys never block each
+	// other. The tail swallows rejections so one failed op cannot wedge
+	// later ops for the same key.
+	const chains = new Map<string, Promise<void>>()
+	const withKeyLock = <T>(cacheKey: string, fn: () => Promise<T>): Promise<T> => {
+		const prev = chains.get(cacheKey) ?? Promise.resolve()
+		const next = prev.then(fn, fn)
+		const tail = next.then(
+			() => undefined,
+			() => undefined
+		)
+		chains.set(cacheKey, tail)
+		tail.then(() => {
+			if (chains.get(cacheKey) === tail) chains.delete(cacheKey)
+		})
+		return next
 	}
 
-	// Batch write queue: coalesces rapid writes to the same key
-	const pendingWrites = new Map<string, { path: string; value: Uint8Array; timer: ReturnType<typeof setTimeout> }>()
+	// Debounced non-critical writes not yet flushed to disk.
+	const pendingWrites = new Map<
+		string,
+		{ store: string; key: string; path: string; value: Uint8Array; timer?: ReturnType<typeof setTimeout> }
+	>()
 	const WRITE_DELAY_MS = 50
 
-	const flushWrite = async (cacheKey: string) => {
-		const pending = pendingWrites.get(cacheKey)
-		if (!pending) return
-		clearTimeout(pending.timer)
-		pendingWrites.delete(cacheKey)
-		try {
-			await writeFile(pending.path, pending.value)
-		} catch {
-			// Ignore — folder may have been deleted during cleanup
-		}
-	}
-
-	// Delete many keys concurrently (shared by `deleteMany` and `deletePrefix`).
-	// Defined as a closure rather than a method so callers don't depend on
-	// `this` — the bridge invokes every store callback with `this = null`.
-	const doDeleteMany = async (store: string, keys: string[]): Promise<void> => {
-		if (keys.length === 0) return
-		await Promise.all(
-			keys.map(async key => {
-				const cacheKey = `${store}\0${key}`
-				cache.delete(cacheKey)
-				const existing = pendingWrites.get(cacheKey)
-				if (existing) {
-					clearTimeout(existing.timer)
-					pendingWrites.delete(cacheKey)
-				}
-
-				try {
-					await unlink(filePath(store, key))
-				} catch {
-					// ignore if file doesn't exist
-				}
-			})
-		)
-	}
+	// Flush one pending key. Runs under the key lock. On failure the entry
+	// is RETAINED (timer cleared) so an explicit `flush()` retries the same
+	// bytes, and the error propagates to that caller. The debounce timer
+	// swallows its own failure — it has no caller to report to — but the
+	// entry stays pending, so the work is never lost silently.
+	const flushOne = (cacheKey: string): Promise<void> =>
+		withKeyLock(cacheKey, async () => {
+			const pending = pendingWrites.get(cacheKey)
+			if (!pending) return
+			if (pending.timer) {
+				clearTimeout(pending.timer)
+				pending.timer = undefined
+			}
+			await durableWrite(pending.path, pending.value)
+			if (pendingWrites.get(cacheKey) === pending) pendingWrites.delete(cacheKey)
+			rememberDurable(cacheKey, snapshot(pending.value))
+		})
 
 	const FLUSH_MAX_PASSES = 32
 	const flushAll = async () => {
-		// Drain in a loop because new sets can land while we're awaiting the
-		// previous batch's writeFile. Bounded so a caller emitting writes in
-		// a tight loop can't lock us forever — `Socket/index.ts.end()` waits
-		// on this and must always return. If the cap is hit with writes
-		// still pending, surface that to the caller — silently dropping
-		// them would lose Signal session steps and corrupt next decrypt.
+		// Drain in passes because new sets can land while a batch's writes
+		// are awaited. A pass with zero successes cannot make progress by
+		// immediate retry (persistent failure), so stop and report the
+		// first error with the entries still pending for the next flush.
+		// The pass cap only guards a caller emitting writes in a tight
+		// loop — `Socket/index.ts.end()` waits on this and must return.
+		const errors: unknown[] = []
 		for (let i = 0; i < FLUSH_MAX_PASSES && pendingWrites.size > 0; i++) {
 			const keys = [...pendingWrites.keys()]
-			await Promise.all(keys.map(flushWrite))
+			let progressed = false
+			await Promise.all(
+				keys.map(key =>
+					flushOne(key).then(
+						() => {
+							progressed = true
+						},
+						e => {
+							errors.push(e)
+						}
+					)
+				)
+			)
+			if (!progressed) break
 		}
+		if (errors.length > 0) throw errors[0]
 		if (pendingWrites.size > 0) {
 			throw new Error(
 				`use-bridge-store flushAll did not quiesce after ${FLUSH_MAX_PASSES} passes (${pendingWrites.size} pending writes remain)`
@@ -147,14 +251,134 @@ export async function useBridgeStore(folder: string): Promise<NonNullable<Authen
 		}
 	}
 
+	// Write path shared by `set` and `setMany`. Must run under the key
+	// lock — callers wrap it via `withKeyLock`.
+	const doSetLocked = async (store: string, key: string, cacheKey: string, value: Uint8Array): Promise<void> => {
+		const incoming = snapshot(value)
+
+		// Skip only when the identical bytes are already durable or already
+		// queued. A failed write never reaches `durable`/`pendingWrites`,
+		// so an identical retry always re-attempts instead of resolving
+		// without persisting.
+		const pending = pendingWrites.get(cacheKey)
+		if (pending) {
+			if (bytesEqual(pending.value, incoming)) return
+		} else {
+			const known = durable.get(cacheKey)
+			if (known && bytesEqual(known, incoming)) return
+		}
+
+		if (CRITICAL_STORES.has(store)) {
+			if (pending) {
+				if (pending.timer) clearTimeout(pending.timer)
+				pendingWrites.delete(cacheKey)
+			}
+
+			// Propagate every failure (ENOSPC/EACCES/EIO/ENOTDIR/ENOENT) —
+			// losing a critical Signal write silently corrupts next decrypt.
+			await durableWrite(filePath(store, key), incoming)
+			rememberDurable(cacheKey, snapshot(incoming))
+			return
+		}
+
+		// Non-critical writes: coalesce rapid writes to the same key
+		if (pending?.timer) clearTimeout(pending.timer)
+		const entry = {
+			store,
+			key,
+			path: filePath(store, key),
+			value: incoming,
+			timer: undefined as ReturnType<typeof setTimeout> | undefined
+		}
+		entry.timer = setTimeout(() => {
+			void flushOne(cacheKey).catch(() => {
+				// No caller to report to; the entry stays pending and the
+				// next explicit flush() retries it and surfaces the error.
+			})
+		}, WRITE_DELAY_MS)
+		entry.timer.unref() // Don't keep the process alive for debounced writes
+		pendingWrites.set(cacheKey, entry)
+	}
+
+	const doSet = (store: string, key: string, value: Uint8Array): Promise<void> => {
+		const cacheKey = `${store}\0${key}`
+		return withKeyLock(cacheKey, () => doSetLocked(store, key, cacheKey, value))
+	}
+
+	// Read path shared by `get` and `getMany`. Runs under the key lock so
+	// a concurrent delete cannot leave stale bytes resurrected in `durable`.
+	// Returns a copy — callers can never mutate the cache or in-flight data.
+	// A pending (debounced, not yet durable) value satisfies read-your-write
+	// immediately; it is exposed as pending, and `flush()` is the call that
+	// makes it durable.
+	const doGetLocked = async (store: string, key: string, cacheKey: string): Promise<Uint8Array | null> => {
+		const pending = pendingWrites.get(cacheKey)
+		if (pending) return snapshot(pending.value)
+
+		const known = durable.get(cacheKey)
+		if (known) return snapshot(known)
+
+		let data: Awaited<ReturnType<typeof readFile>>
+		try {
+			data = await readFile(filePath(store, key))
+		} catch (e) {
+			// Absent key is a legitimate null. Any other read failure
+			// (EACCES/EIO/ENOTDIR) must NOT masquerade as "no value", or the
+			// core would treat persisted state as gone.
+			if (isEnoent(e)) return null
+			throw e
+		}
+		const arr = snapshot(new Uint8Array(data.buffer, data.byteOffset, data.byteLength))
+		rememberDurable(cacheKey, snapshot(arr))
+		return arr
+	}
+
+	const doGet = (store: string, key: string): Promise<Uint8Array | null> => {
+		const cacheKey = `${store}\0${key}`
+		return withKeyLock(cacheKey, () => doGetLocked(store, key, cacheKey))
+	}
+
+	// Delete path shared by `delete`, `deleteMany` and `deletePrefix`.
+	// Runs under the key lock: cancels queued writes first so a flush in
+	// flight can never resurrect the key, and drops durable knowledge so a
+	// later read goes back to disk. Only ENOENT (already absent) is
+	// tolerated; real unlink failures propagate.
+	const doDeleteOne = (store: string, key: string): Promise<void> => {
+		const cacheKey = `${store}\0${key}`
+		return withKeyLock(cacheKey, async () => {
+			durable.delete(cacheKey)
+			const pending = pendingWrites.get(cacheKey)
+			if (pending) {
+				if (pending.timer) clearTimeout(pending.timer)
+				pendingWrites.delete(cacheKey)
+			}
+
+			try {
+				await unlink(filePath(store, key))
+			} catch (e) {
+				if (!isEnoent(e)) throw e
+			}
+		})
+	}
+
+	// Delete many keys concurrently (shared by `deleteMany` and
+	// `deletePrefix`). Defined as a closure rather than a method so callers
+	// don't depend on `this` — the bridge invokes every store callback with
+	// `this = null`. Best-effort across keys: every key is attempted even
+	// when a sibling fails, and the first error propagates.
+	const doDeleteMany = async (store: string, keys: string[]): Promise<void> => {
+		if (keys.length === 0) return
+		await Promise.all(keys.map(key => doDeleteOne(store, key)))
+	}
+
 	// Enumerate live keys in a namespace (shared by `listKeys` and
 	// `deletePrefix`). Closure, not a method, so it never depends on `this`.
 	// Files are `<store>-<encodeURIComponent(key)>.bin`; store names never
 	// contain a hyphen, so split on the FIRST hyphen and decode the remainder.
-	// readdir (durable view) is unioned with not-yet-flushed debounced writes
-	// so a key written <50ms ago isn't missed; a flush is awaited first so a
-	// torn debounce window can't drop a key. Pending deletes both cancel their
-	// `pendingWrites` entry AND unlink immediately, so they never appear here.
+	// A flush is awaited first so debounced writes are durable before the
+	// readdir; its failure propagates rather than enumerating a stale view.
+	// Pending deletes both cancel their `pendingWrites` entry AND unlink
+	// immediately, so they never appear here.
 	const doListKeys = async (store: string, prefix?: string): Promise<string[]> => {
 		await flushAll()
 
@@ -199,143 +423,28 @@ export async function useBridgeStore(folder: string): Promise<NonNullable<Authen
 	}
 
 	return {
-		async get(store: string, key: string): Promise<Uint8Array | null> {
-			const cacheKey = `${store}\0${key}`
+		get: doGet,
 
-			// Check cache first
-			const cached = cache.get(cacheKey)
-			if (cached) return cached
+		set: doSet,
 
-			const pending = pendingWrites.get(cacheKey)
-			if (pending) return pending.value
-
-			try {
-				const data = await readFile(filePath(store, key))
-				const arr = new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
-				touchCache(cacheKey, arr)
-				return arr
-			} catch {
-				return null
-			}
-		},
-
-		async set(store: string, key: string, value: Uint8Array): Promise<void> {
-			const cacheKey = `${store}\0${key}`
-
-			// Skip write if value is identical to cached version
-			const prev = cache.get(cacheKey)
-			if (prev && Buffer.from(prev).equals(Buffer.from(value))) {
-				return
-			}
-
-			touchCache(cacheKey, value)
-
-			if (CRITICAL_STORES.has(store)) {
-				const existing = pendingWrites.get(cacheKey)
-				if (existing) {
-					clearTimeout(existing.timer)
-					pendingWrites.delete(cacheKey)
-				}
-
-				// Propagate real failures (ENOSPC/EACCES/…) — losing a critical
-				// Signal write silently corrupts the next decrypt.
-				await writeCritical(store, key, value)
-
-				return
-			}
-
-			// Non-critical writes: coalesce rapid writes to the same key
-			const existing = pendingWrites.get(cacheKey)
-			if (existing) {
-				clearTimeout(existing.timer)
-			}
-
-			const path = filePath(store, key)
-			const timer = setTimeout(() => void flushWrite(cacheKey), WRITE_DELAY_MS)
-			timer.unref() // Don't keep the process alive for debounced writes
-			pendingWrites.set(cacheKey, { path, value, timer })
-		},
-
-		async delete(store: string, key: string): Promise<void> {
-			const cacheKey = `${store}\0${key}`
-			cache.delete(cacheKey)
-
-			// Cancel pending write
-			const existing = pendingWrites.get(cacheKey)
-			if (existing) {
-				clearTimeout(existing.timer)
-				pendingWrites.delete(cacheKey)
-			}
-
-			try {
-				await unlink(filePath(store, key))
-			} catch {
-				// ignore if file doesn't exist
-			}
-		},
+		delete: doDeleteOne,
 
 		// Batched variant of `set`. The bridge calls this (when present) to
 		// persist a burst of entries in a single FFI crossing instead of N
-		// round-trips (e.g. ~20k messageSecrets from a history sync). Per-entry
-		// semantics are identical to `set` — same skip-if-equal, same cache
-		// touch, same critical-vs-debounced write policy.
+		// round-trips (e.g. ~20k messageSecrets from a history sync).
+		// Per-entry semantics are identical to `set`. Best-effort across
+		// keys per the bridge contract: every entry is attempted even when
+		// a sibling fails (writes are idempotent by key, so the core can
+		// retry the batch), and the first error propagates. No multi-key
+		// transaction is attempted — the filesystem does not provide one.
 		async setMany(store: string, entries: [key: string, value: Uint8Array][]): Promise<void> {
 			// Empty batch is a valid no-op.
 			if (entries.length === 0) return
 
-			const critical = CRITICAL_STORES.has(store)
-			// Collect critical writes so we can run them concurrently with
-			// Promise.all instead of awaiting each writeFile serially in a loop.
-			const criticalWrites: Promise<void>[] = []
-
-			for (const [key, value] of entries) {
-				const cacheKey = `${store}\0${key}`
-
-				// Skip write if value is identical to cached version.
-				// Buffer.compare accepts Uint8Array directly (no copy), unlike
-				// Buffer.from(prev).equals(Buffer.from(value)) which copied both.
-				const prev = cache.get(cacheKey)
-				if (prev && prev.length === value.length && Buffer.compare(prev, value) === 0) {
-					continue
-				}
-
-				touchCache(cacheKey, value)
-
-				if (critical) {
-					// Cancel any pending debounced write for this key first,
-					// exactly like `set` does, then write immediately.
-					const existing = pendingWrites.get(cacheKey)
-					if (existing) {
-						clearTimeout(existing.timer)
-						pendingWrites.delete(cacheKey)
-					}
-
-					// Propagate real failures: if a critical write in the batch
-					// fails, setMany rejects, and the Rust core skips the
-					// follow-up self-index rewrite (so the index can't claim a
-					// value exists that was never persisted).
-					criticalWrites.push(writeCritical(store, key, value))
-					continue
-				}
-
-				// Non-critical writes: coalesce rapid writes to the same key.
-				// The debounce already coalesces a burst, so scheduling each
-				// entry is fine — no immediate flush needed.
-				const existing = pendingWrites.get(cacheKey)
-				if (existing) {
-					clearTimeout(existing.timer)
-				}
-
-				const path = filePath(store, key)
-				const timer = setTimeout(() => void flushWrite(cacheKey), WRITE_DELAY_MS)
-				timer.unref() // Don't keep the process alive for debounced writes
-				pendingWrites.set(cacheKey, { path, value, timer })
-			}
-
-			// Run all critical writes concurrently.
-			if (criticalWrites.length > 0) {
-				await Promise.all(criticalWrites)
-			}
+			// Schedule every entry synchronously so same-key duplicates chain
+			// in batch order; per-key locks serialize against concurrent
+			// sets, deletes and flushes.
+			await Promise.all(entries.map(([key, value]) => doSet(store, key, value)))
 		},
 
 		// Batched variant of `delete`. Per-key semantics are identical to
@@ -343,25 +452,15 @@ export async function useBridgeStore(folder: string): Promise<NonNullable<Authen
 		deleteMany: doDeleteMany,
 
 		// Read many keys at once. Cache-aside per key (like `get`), so a hit
-		// never touches disk; misses read the file. Missing keys are omitted.
+		// never touches disk; misses read the file. Missing keys are omitted;
+		// real read failures propagate rather than silently dropping keys.
 		async getMany(store: string, keys: string[]): Promise<[key: string, value: Uint8Array][]> {
 			if (keys.length === 0) return []
 
 			const results = await Promise.all(
 				keys.map(async (key): Promise<[string, Uint8Array] | null> => {
-					const cacheKey = `${store}\0${key}`
-					const cached = cache.get(cacheKey)
-					if (cached) return [key, cached]
-					const pending = pendingWrites.get(cacheKey)
-					if (pending) return [key, pending.value]
-					try {
-						const data = await readFile(filePath(store, key))
-						const arr = new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
-						touchCache(cacheKey, arr)
-						return [key, arr]
-					} catch {
-						return null
-					}
+					const value = await doGet(store, key)
+					return value === null ? null : [key, value]
 				})
 			)
 

--- a/src/Utils/use-bridge-store.ts
+++ b/src/Utils/use-bridge-store.ts
@@ -61,39 +61,73 @@ const bytesEqual = (a: Uint8Array, b: Uint8Array): boolean => a.length === b.len
 // a valid snapshot for caller-owned buffers.
 const copyBytes = (value: Uint8Array): Uint8Array => Uint8Array.from(value)
 
-// File-creation steps behind one durable write. Scoped per store via the
-// `options` parameter of `useBridgeStore` — never a shared global — so
-// tests can hold, fail, or observe a single store's I/O without affecting
-// any other store instance. When omitted, the production implementation
-// below is used.
+/**
+ * Pure classifier for directory-barrier failures: does this error mean
+ * "this platform cannot sync directory handles" (degrade to process-crash
+ * atomicity) or "the durability barrier did not hold" (propagate)?
+ *
+ * - `ENOSYS` / `ENOTSUP` on any platform: the operation is not
+ *   implemented — genuinely unsupported, safe to degrade.
+ * - `EINVAL` / `EPERM` / `EISDIR` on `win32` only: Windows directory
+ *   handles reject open-for-read and FlushFileBuffers with these codes,
+ *   so they are the documented platform fallback there. On Linux/macOS
+ *   the same codes from a freshly opened directory handle mean something
+ *   is genuinely wrong and they propagate.
+ * - Everything else propagates everywhere: `EIO`, `ENOSPC`, `EROFS`,
+ *   `EACCES`, `ENOENT`, and notably `EBADF` (a bad handle is a real bug,
+ *   never evidence of an unsupported platform).
+ *
+ * `platform` defaults to the running platform; tests pass explicit values
+ * to cover the matrix deterministically on any OS.
+ */
+export const isUnsupportedDirSync = (e: unknown, platform: NodeJS.Platform = process.platform): boolean => {
+	const code = errnoOf(e)
+	if (code === 'ENOSYS' || code === 'ENOTSUP') return true
+	if (platform === 'win32' && (code === 'EINVAL' || code === 'EPERM' || code === 'EISDIR')) return true
+	return false
+}
+
+// File-creation steps behind one durable write plus the directory barrier.
+// Scoped per store via the `options` parameter of `useBridgeStore` — never
+// a shared global — so tests can hold, fail, or observe a single store's
+// I/O without affecting any other store instance. Only the default
+// implementation below provides the durability contract documented on
+// `useBridgeStore`; a custom implementation is a test/fault-injection seam
+// and carries no durability guarantees of its own.
 type BridgeStoreFileIO = {
 	writeTmp(tmpPath: string, value: Uint8Array): Promise<void>
 	publishTmp(tmpPath: string, finalPath: string): Promise<void>
+	syncDir(dir: string): Promise<void>
 }
 
 type BridgeStoreOptions = {
 	io?: BridgeStoreFileIO
 }
 
-/**
- * Directory fsync failures that mean "this platform cannot sync directory
- * handles" rather than "your data is at risk". ENOSYS/ENOTSUP: the syscall
- * is not implemented. EINVAL/EBADF: the handle kind does not support
- * syncing (e.g. directory handles on some platforms). EPERM: the sandbox
- * forbids handle sync even though the data path succeeded. Everything
- * else — EIO, ENOSPC, EROFS, EACCES on open — is a real I/O failure and
- * propagates so the caller learns the durability barrier did not hold.
- */
-const isUnsupportedDirSync = (e: unknown): boolean => {
-	const code = errnoOf(e)
-	return code === 'ENOSYS' || code === 'ENOTSUP' || code === 'EINVAL' || code === 'EBADF' || code === 'EPERM'
+// Thrown by `durableWrite` when the temp file was published (rename
+// attempted) but the post-rename barrier did not certify. At that point
+// the target may or may not hold the new bytes, so prior durable
+// knowledge for the key is invalid. Carries the original failure.
+class BarrierUncertainty extends Error {
+	readonly detail: unknown
+	constructor(detail: unknown) {
+		super('use-bridge-store: post-rename barrier uncertified; prior durable knowledge invalidated')
+		this.name = 'BarrierUncertainty'
+		this.detail = detail
+	}
 }
 
-// Persist a directory entry update (rename/unlink) toward power-loss
-// durability. `open` failures propagate untouched; only the narrow
-// "unsupported" class of `sync` failures is swallowed, documented above.
-const syncDir = async (dir: string): Promise<void> => {
-	const handle = await open(dir, 'r')
+const defaultSyncDir = async (dir: string): Promise<void> => {
+	let handle: Awaited<ReturnType<typeof open>> | undefined
+	try {
+		handle = await open(dir, 'r')
+	} catch (e) {
+		// A store folder that cannot even be opened is not a platform
+		// quirk, except where the platform cannot open directory handles
+		// at all (classified above).
+		if (!isUnsupportedDirSync(e)) throw e
+		return
+	}
 	try {
 		await handle.sync()
 	} catch (e) {
@@ -124,8 +158,8 @@ const defaultFileIO: BridgeStoreFileIO = {
 	},
 	async publishTmp(tmpPath: string, finalPath: string): Promise<void> {
 		await rename(tmpPath, finalPath)
-		await syncDir(dirname(finalPath))
-	}
+	},
+	syncDir: defaultSyncDir
 }
 
 let tmpSeq = 0
@@ -140,26 +174,39 @@ let tmpSeq = 0
  *   copy before queueing), so mutating a buffer after the call — even
  *   before awaiting it — can never change what gets persisted.
  * - Critical stores write through `durableWrite` before `set`/`setMany`
- *   resolve. The in-memory map only records bytes AFTER they are on disk,
- *   so an identical retry following a failure is never skipped and always
+ *   resolve. The in-memory map only records bytes AFTER the full barrier
+ *   (write + fsync + atomic rename + directory sync) succeeds, so an
+ *   identical retry following a failure is never skipped and always
  *   re-attempts the write.
+ * - If the post-rename barrier fails, the key is marked uncertain: prior
+ *   durable knowledge is discarded, reads serve best-available bytes
+ *   without re-certifying them, and no identical set is skipped until a
+ *   later operation completes the full barrier for that key.
  * - Non-critical stores are debounced (50ms coalescing) and readable
  *   immediately (read-your-write), but such reads are NOT durable until
  *   `flush()` succeeds. A failed flush keeps the pending entry and throws,
  *   so the next `flush()` retries the same bytes.
- * - `flush()` first waits for every operation admitted before it (barrier),
- *   then drains the pending writes those operations produced. It never
+ * - `flush()` first waits for every operation admitted before it
+ *   (barrier), then drains the pending writes those operations produced.
+ *   Failures observed by the barrier propagate — a failed admitted write
+ *   fails the flush — but only operations outstanding during that flush
+ *   are reported, so history never poisons later flushes. `flush()` never
  *   reports quiescence while prior admitted work is still running.
  * - All operations on one key (set, delete, flush, concurrent batches) run
  *   through a per-key chain, so a stale failure can never erase newer
  *   state and an in-flight write can never resurrect a deleted key.
  * - A failed delete restores the preceding pending/durable state, so an
  *   acknowledged value stays readable and flushable; only a successful
- *   delete clears it, at its linearization point under the key lock.
+ *   delete (unlink + directory barrier) clears it. A delete retried while
+ *   the key is uncertain re-runs the directory barrier instead of
+ *   swallowing the uncertainty as idempotent absence — except that a
+ *   directory removed externally surfaces ENOENT rather than success.
  * - Every byte array handed back to callers is a copy.
  *
  * @param folder Directory to store bridge state files
- * @param options Optional per-store file-I/O steps (scoped test seam)
+ * @param options Optional per-store file-I/O steps. Test/fault-injection
+ *   seam only: the default implementation is the sole provider of the
+ *   durability contract above.
  */
 export async function useBridgeStore(
 	folder: string,
@@ -172,11 +219,12 @@ export async function useBridgeStore(
 	/**
 	 * Durable file replacement: write + fsync an exclusively-created,
 	 * uniquely-named temp file in the same directory, then atomically
-	 * rename it over the target. The previous file (or its absence) is
-	 * untouched until the rename succeeds, so a crash or a failed write can
-	 * never leave a torn target behind — readers always see the old intact
-	 * file or the new intact file. Cleanup only ever removes a temp this
-	 * operation created; a temp that already existed is left alone.
+	 * rename it over the target and sync the directory. The previous file
+	 * (or its absence) is untouched until the rename succeeds, so a crash
+	 * or a failed write can never leave a torn target behind — readers
+	 * always see the old intact file or the new intact file. Cleanup only
+	 * ever removes a temp this operation created; a temp that already
+	 * existed is left alone.
 	 *
 	 * Guarantees are scoped honestly: the rename is atomic against a dead
 	 * process, and the file + directory syncs raise the bar toward
@@ -187,7 +235,8 @@ export async function useBridgeStore(
 	 *
 	 * Every error propagates, including ENOENT: resolving a write whose
 	 * bytes never reached disk would let the caller believe state is
-	 * durable.
+	 * durable. A failure at or after the rename throws BarrierUncertainty
+	 * so the caller invalidates prior durable knowledge for the key.
 	 */
 	const durableWrite = async (finalPath: string, value: Uint8Array): Promise<void> => {
 		const MAX_TMP_ATTEMPTS = 5
@@ -198,30 +247,32 @@ export async function useBridgeStore(
 			} catch (e) {
 				// EEXIST means a foreign temp owns this name (we create
 				// exclusively and never overwrite): retry with a fresh name
-				// instead of deleting or reusing it. Any other failure is
-				// ours to report; `writeTmp` already cleaned up its own temp.
+				// instead of deleting or reusing it. Any earlier failure
+				// left the target untouched; `writeTmp` already cleaned up
+				// its own temp.
 				if (errnoOf(e) === 'EEXIST') continue
 				throw e
 			}
 			try {
 				await io.publishTmp(tmpPath, finalPath)
+				await io.syncDir(dirname(finalPath))
 			} catch (e) {
-				// Publish of our own temp failed before (or atomically
-				// without) replacing the target: remove only our temp. If
-				// the rename itself succeeded, the temp is already gone and
-				// this unlink is a tolerated no-op.
+				// Our own temp failed to publish or certify: remove only our
+				// temp. If the rename itself succeeded, the temp is already
+				// gone and this unlink is a tolerated no-op — but the
+				// barrier is uncertified either way.
 				await unlink(tmpPath).catch(() => {})
-				throw e
+				throw new BarrierUncertainty(e)
 			}
 			return
 		}
 		throw new Error(`use-bridge-store durableWrite could not claim a unique temp name for ${finalPath}`)
 	}
 
-	// Last bytes known to be durable per key (written, flushed, or read
-	// from disk). Private copies only — never a caller-owned reference.
-	// Bounded by LRU eviction; eviction only drops knowledge, disk stays
-	// canonical.
+	// Last bytes known to have passed the FULL barrier per key (written,
+	// flushed, or read from disk outside uncertainty). Private copies only
+	// — never a caller-owned reference. Bounded by LRU eviction; eviction
+	// only drops knowledge, disk stays canonical.
 	const MAX_CACHE_ENTRIES = 5000
 	const durable = new Map<string, Uint8Array>()
 	const rememberDurable = (key: string, value: Uint8Array) => {
@@ -233,6 +284,13 @@ export async function useBridgeStore(
 			durable.delete(first)
 		}
 	}
+
+	// Keys whose last mutation never completed the full barrier (post-rename
+	// or post-unlink failure). Durable knowledge is discarded; reads serve
+	// best-available bytes without re-certifying them; identical sets are
+	// never skipped. Cleared only by a later operation that completes the
+	// full barrier for the key (write, flush, or certified delete).
+	const uncertain = new Set<string>()
 
 	const filePath = (store: string, key: string) => join(folder, `${store}-${encodeURIComponent(key)}.bin`)
 
@@ -284,6 +342,24 @@ export async function useBridgeStore(
 		entry.timer.unref() // Don't keep the process alive for debounced writes
 	}
 
+	// Full-barrier write shared by critical `set` and the flush drain.
+	// Certifies the key on success; on post-rename failure discards durable
+	// knowledge, marks uncertainty, and rethrows the original error.
+	const certifyWrite = async (cacheKey: string, path: string, value: Uint8Array): Promise<void> => {
+		try {
+			await durableWrite(path, value)
+		} catch (e) {
+			if (e instanceof BarrierUncertainty) {
+				durable.delete(cacheKey)
+				uncertain.add(cacheKey)
+				throw e.detail
+			}
+			throw e
+		}
+		uncertain.delete(cacheKey)
+		rememberDurable(cacheKey, copyBytes(value))
+	}
+
 	// Flush one pending key. Runs under the key lock (not tracked in
 	// `admitted`: the drain loop drives it, so tracking it would make
 	// `flush()` wait on itself). On failure the entry is RETAINED (timer
@@ -297,9 +373,8 @@ export async function useBridgeStore(
 				clearTimeout(pending.timer)
 				pending.timer = undefined
 			}
-			await durableWrite(pending.path, pending.value)
+			await certifyWrite(cacheKey, pending.path, pending.value)
 			if (pendingWrites.get(cacheKey) === pending) pendingWrites.delete(cacheKey)
-			rememberDurable(cacheKey, copyBytes(pending.value))
 		})
 
 	// Same as `withKeyLock` but invisible to the flush admission barrier.
@@ -328,6 +403,9 @@ export async function useBridgeStore(
 		// already-running critical write completes before quiescence is
 		// declared. `flushOne` internals are not admitted, so the barrier
 		// never waits on the drain loop itself (no self-deadlock).
+		// Failures observed by the barrier propagate: a failed admitted
+		// write fails the flush. Only operations outstanding during this
+		// flush are reported — settled history never poisons later flushes.
 		// A pass with zero successes and nothing newly admitted cannot make
 		// progress by immediate retry (persistent failure), so stop and
 		// report the first error with the entries still pending for the
@@ -337,7 +415,12 @@ export async function useBridgeStore(
 		const errors: unknown[] = []
 		for (let i = 0; i < FLUSH_MAX_PASSES; i++) {
 			const outstanding = [...admitted]
-			if (outstanding.length > 0) await Promise.allSettled(outstanding)
+			if (outstanding.length > 0) {
+				const settled = await Promise.allSettled(outstanding)
+				for (const result of settled) {
+					if (result.status === 'rejected') errors.push(result.reason)
+				}
+			}
 			if (pendingWrites.size === 0) {
 				if (admitted.size === 0) break
 				continue
@@ -370,10 +453,10 @@ export async function useBridgeStore(
 	// private admission-time copy. Must run under the key lock — callers
 	// wrap it via `withKeyLock`.
 	const doSetLocked = async (store: string, key: string, cacheKey: string, incoming: Uint8Array): Promise<void> => {
-		// Skip only when the identical bytes are already durable or already
-		// queued. A failed write never reaches `durable`/`pendingWrites`,
-		// so an identical retry always re-attempts instead of resolving
-		// without persisting.
+		// Skip only when the identical bytes are already barrier-certified
+		// or already queued. Uncertainty discards certification, so a
+		// retry after an uncertified barrier always re-attempts instead of
+		// resolving without persisting.
 		const pending = pendingWrites.get(cacheKey)
 		if (pending) {
 			if (bytesEqual(pending.value, incoming)) return
@@ -390,8 +473,7 @@ export async function useBridgeStore(
 
 			// Propagate every failure (ENOSPC/EACCES/EIO/ENOTDIR/ENOENT) —
 			// losing a critical Signal write silently corrupts next decrypt.
-			await durableWrite(filePath(store, key), incoming)
-			rememberDurable(cacheKey, copyBytes(incoming))
+			await certifyWrite(cacheKey, filePath(store, key), incoming)
 			return
 		}
 
@@ -423,13 +505,18 @@ export async function useBridgeStore(
 	// Returns a copy — callers can never mutate the cache or in-flight data.
 	// A pending (debounced, not yet durable) value satisfies read-your-write
 	// immediately; it is exposed as pending, and `flush()` is the call that
-	// makes it durable.
+	// makes it durable. Under uncertainty, disk bytes are served
+	// best-available WITHOUT re-certifying them: caching them as durable
+	// would let a later identical set skip its still-required barrier.
 	const doGetLocked = async (store: string, key: string, cacheKey: string): Promise<Uint8Array | null> => {
 		const pending = pendingWrites.get(cacheKey)
 		if (pending) return copyBytes(pending.value)
 
-		const known = durable.get(cacheKey)
-		if (known) return copyBytes(known)
+		const keyUncertain = uncertain.has(cacheKey)
+		if (!keyUncertain) {
+			const known = durable.get(cacheKey)
+			if (known) return copyBytes(known)
+		}
 
 		let data: Awaited<ReturnType<typeof readFile>>
 		try {
@@ -442,7 +529,7 @@ export async function useBridgeStore(
 			throw e
 		}
 		const arr = copyBytes(new Uint8Array(data.buffer, data.byteOffset, data.byteLength))
-		rememberDurable(cacheKey, copyBytes(arr))
+		if (!keyUncertain) rememberDurable(cacheKey, copyBytes(arr))
 		return arr
 	}
 
@@ -453,17 +540,21 @@ export async function useBridgeStore(
 
 	// Delete path shared by `delete`, `deleteMany` and `deletePrefix`.
 	// Runs under the key lock. The preceding pending/durable state is only
-	// cleared once the unlink succeeds (its linearization point); if the
-	// unlink fails with a real error, that state is restored — timer
-	// re-armed — so an acknowledged value stays readable and flushable, and
-	// the error propagates. Only ENOENT (already absent) is tolerated. A
-	// successful unlink is followed by a directory sync with the same
-	// scoped fallback as the write path, so the deletion itself is durable.
+	// cleared once the unlink succeeds; if the unlink fails with a real
+	// error, that state is restored (timer re-armed) so an acknowledged
+	// value stays readable and flushable, and the error propagates. A
+	// successful unlink completes the directory barrier; if that barrier
+	// fails, the key is marked uncertain. A delete retried while uncertain
+	// re-runs the directory barrier instead of mistaking ENOENT for
+	// certified absence — but a directory removed externally still surfaces
+	// ENOENT rather than success, by explicit policy. Certain absence stays
+	// idempotent.
 	const doDeleteOne = (store: string, key: string): Promise<void> => {
 		const cacheKey = `${store}\0${key}`
 		return withKeyLock(cacheKey, async () => {
 			const prevPending = pendingWrites.get(cacheKey)
 			const prevDurable = durable.get(cacheKey)
+			const wasUncertain = uncertain.has(cacheKey)
 			if (prevPending?.timer) clearTimeout(prevPending.timer)
 			pendingWrites.delete(cacheKey)
 			durable.delete(cacheKey)
@@ -471,7 +562,15 @@ export async function useBridgeStore(
 			try {
 				await unlink(filePath(store, key))
 			} catch (e) {
-				if (isEnoent(e)) return
+				if (isEnoent(e) && !wasUncertain) return
+				if (isEnoent(e)) {
+					// Absent on disk, but a prior barrier was never
+					// certified: certify the absence now instead of
+					// swallowing the uncertainty.
+					await io.syncDir(folder)
+					uncertain.delete(cacheKey)
+					return
+				}
 				if (prevDurable) rememberDurable(cacheKey, prevDurable)
 				if (prevPending) {
 					armTimer(cacheKey, prevPending)
@@ -479,7 +578,13 @@ export async function useBridgeStore(
 				}
 				throw e
 			}
-			await syncDir(folder)
+			try {
+				await io.syncDir(folder)
+			} catch (e) {
+				uncertain.add(cacheKey)
+				throw e
+			}
+			uncertain.delete(cacheKey)
 		})
 	}
 

--- a/src/Utils/use-bridge-store.ts
+++ b/src/Utils/use-bridge-store.ts
@@ -209,8 +209,10 @@ let tmpSeq = 0
  *   (barrier), then drains the pending writes those operations produced.
  *   Failures observed by the barrier propagate — a failed admitted write
  *   fails the flush — but only operations outstanding during that flush
- *   are reported, so history never poisons later flushes. `flush()` never
- *   reports quiescence while prior admitted work is still running.
+ *   are reported, so history never poisons later flushes. A drain pass
+ *   with any failure stops at that pass and leaves the failed entries
+ *   for the next explicit flush. `flush()` never reports quiescence
+ *   while prior admitted work is still running.
  * - All operations on one key (set, delete, flush, concurrent batches) run
  *   through a per-key chain, so a stale failure can never erase newer
  *   state and an in-flight write can never resurrect a deleted key.
@@ -440,12 +442,13 @@ export async function useBridgeStore(
 		// Failures observed by the barrier propagate: a failed admitted
 		// write fails the flush. Only operations outstanding during this
 		// flush are reported — settled history never poisons later flushes.
-		// A pass with zero successes and nothing newly admitted cannot make
-		// progress by immediate retry (persistent failure), so stop and
-		// report the first error with the entries still pending for the
-		// next flush. The pass cap only guards a caller emitting writes in
-		// a tight loop — `Socket/index.ts.end()` waits on this and must
-		// return.
+		// After a drain pass with any failure, stop and leave the failed
+		// entries for a subsequent explicit flush: retrying them inside the
+		// same call would resolve-or-reject on a stale error while hiding
+		// whether the retry itself persisted. A fully successful pass loops,
+		// since new work may have landed during the drain. The pass cap only
+		// guards a caller emitting writes in a tight loop —
+		// `Socket/index.ts.end()` waits on this and must return.
 		const errors: unknown[] = []
 		for (let i = 0; i < FLUSH_MAX_PASSES; i++) {
 			const outstanding = [...admitted]
@@ -460,20 +463,19 @@ export async function useBridgeStore(
 				continue
 			}
 			const keys = [...pendingWrites.keys()]
-			let progressed = false
+			let failed = false
 			await Promise.all(
 				keys.map(key =>
 					flushOne(key).then(
-						() => {
-							progressed = true
-						},
+						() => {},
 						e => {
+							failed = true
 							errors.push(e)
 						}
 					)
 				)
 			)
-			if (!progressed && admitted.size === 0) break
+			if (failed) break
 		}
 		if (errors.length > 0) throw errors[0]
 		if (pendingWrites.size > 0 || admitted.size > 0) {


### PR DESCRIPTION
## Summary

Makes the WASM bridge file store (`useBridgeStore`) durable and error-honest. At baseline `8d99efa`, the store updated its cache before writing, skipped identical retries after failures, dropped pending flush work while reporting success, treated critical `ENOENT` writes as success, and swallowed real read/delete errors. This PR fixes those failure boundaries without changing namespaces, the on-disk final filenames, the bridge pin, or the `Socket` integration.

## Per-file changes

- `src/Utils/use-bridge-store.ts`
  - Caller buffers are copied synchronously at admission with `Uint8Array.from` (real copy for `Buffer` too; `Buffer.slice` only views). Post-call caller mutation can never change persisted bytes.
  - Durable cache records bytes only after the full barrier (exclusive temp write + file sync + close + atomic rename + directory sync). Identical retries after failure always re-attempt.
  - Post-rename/post-unlink barrier failure marks the key uncertain: prior certification is discarded, reads serve best-available bytes without re-certifying, identical sets are never skipped until a later op completes the barrier.
  - `flush()` waits for operations admitted before it (barrier) and propagates barrier-observed failures; settled history never poisons later flushes; no false quiescence while admitted work runs. A drain pass with any failure stops at that pass and leaves failed entries for the next explicit flush (no in-call retry on a stale error).
  - Per-key serialization for set/delete/flush/batches. Failed deletes restore preceding pending/durable state via one shared helper — including the uncertain+absent retry whose directory barrier fails — so acknowledged values stay readable and flushable; uncertainty is kept until certified. Only certified absence and genuinely completed unlinks clear state.
  - Reads/deletes propagate real errors (`ENOTDIR`/`EACCES`/`EIO`/`ENOSPC`); only genuine absence (`ENOENT` on missing key, missing folder on `listKeys`) reads as empty/absent.
  - Atomic replacement: short fixed-shape temp basename (`.bstore-<pid>-<seq>-<rand>.tmp`, ~30 bytes) in the same directory regardless of key length, exclusive (`wx`) create with mode `0600` (POSIX; Windows ignores mode bits) so hardened auth files are never widened, close failures included in owned-temp cleanup with the original error preserved, cleanup limited to owned temps, foreign temps never touched.
  - `setMany` stays best-effort across keys with idempotent retry; no multi-key transaction is invented.
- `src/Utils/__tests__/use-bridge-store-durability.test.ts` (new, 29 tests)
  - Failure-to-retry for `set`/`setMany`/flush, best-effort batch with per-key fault, admission-copy adversaries (`Buffer`/`Uint8Array`/`setMany` mutated synchronously behind a held op), flush-barrier gates (no settle while blocked, queued-set observed, barrier-error propagation without poisoning), real rename-then-error uncertainty sequence, post-unlink barrier retry + externally-removed-directory policy,   uncertain-delete retry preserving admitted pending data, 228-char valid key round-trip, `0600` create/replace under umask `022` (POSIX; round-trip only on Windows), default-writer close-failure cleanup with no temp accumulation, failed drain pass leaving work for the next flush (no stale-error retry inside the call), temp ownership, pending-vs-durable reads, quiesce reporting, and the `isUnsupportedDirSync` code×platform matrix.
- `src/Utils/__tests__/use-bridge-store-errors.test.ts`
  - The test that required silent success on critical `ENOENT` now requires rejection, plus an identical-retry-persists case.

## Honest public-surface accounting

- `useBridgeStore(folder, options?)` has an optional second parameter: per-store `{ io }` with optional `{ writeTmp, publishTmp, syncDir, openTmp }`, a test/fault-injection seam scoped to one store instance (no shared mutable global; every member falls back to its default). Only the default implementation provides the durability contract; custom implementations carry no guarantees. The bridge and all existing callers use the one-argument form.
- New pure export `isUnsupportedDirSync(err, platform?)`: directory-barrier error classifier. Swallows `ENOSYS`/`ENOTSUP` everywhere plus `EINVAL`/`EPERM`/`EISDIR` on `win32` only (documented platform fallback); `EIO`/`ENOSPC`/`EROFS`/`EACCES`/`ENOENT`/`EBADF` propagate on all platforms.
- `compat:audit` and `compat:audit:strict` exit 0. The audit lists these as informational `extra` (same category as the pre-existing `useBridgeStore` extra); no missing/mismatch regression.

## Behavior contract (changed)

- Writes (critical `set`/`setMany`, flushes) reject on any failure including `ENOENT` — resolving without durable bytes is no longer allowed.
- New files and replacements are created `0600` (POSIX); replacement never widens a restrictive target (a previously wider file narrows to `0600`, the safe direction for secrets).
- `get`/`getMany` return `null`/omit only on genuine absence; real I/O errors propagate. `delete` tolerates only certain absence; uncertain absence re-runs the barrier, and an externally removed directory surfaces `ENOENT`.
- `setMany`/`deleteMany` attempt every key even when a sibling fails; first error propagates; batches are idempotent so the core can retry.
- Durability guarantee is scoped: atomic rename against process crash, file + directory syncs toward power-loss durability where the platform honors them. **Physical power loss was not tested** (no harness); tests prove failure atomicity (old file intact), retryability, and barrier propagation.

## Before/after evidence

Before (baseline, adapted `evidence/repro-store.mjs` against the worktree): all 5 dossier defects observed — identical retry after failed `set`/`setMany` resolved without persisting; failed `flush` lost pending work silently; critical `ENOENT` write resolved; caller-buffer mutation skipped a required write. After: the same repro fails at its first old-defect assertion (retry now persists).

Review-round regressions (each new test failed on the pre-fix tree for the reported reason, then passed):
- Uncertain delete retry with failing barrier returned `null` and dropped pending work; now preserves it.
- 228-char valid key failed with `ENAMETOOLONG` on the extended temp name; now round-trips.
- New/replaced files were `0644` under umask `022`; now `0600` (POSIX).
- Default-writer close failure orphaned secret temp files; now cleaned with the original error propagated and no accumulation on retry.

## Validation (actual runs)

- Focused store suites: 51/51 pass (29 durability + 6 error-propagation + 16 batch/enumeration).
- Dependent suites (auth-state hydration, socket-dispose, bridge-client-owner, terminal-close, legacy-mirror): 66/66 pass.
- Full `npm test`: 1448 pass / 0 fail / 1 skipped (1449 total).
- `npm run build`, `npm run format:check`, `npm run lint` (tsc + oxlint): exit 0.
- `compat:audit`, `compat:audit:strict`: exit 0. Not run: `test:e2e` (requires infra; none needed for this lot), release wasm-opt build (not applicable, TS-only change).

## Compatibility / migration

- On-disk format and `<store>-<key>.bin` namespaces unchanged; no migration needed. `CRITICAL_STORES` unchanged and matches `Compatibility/legacy-store` constants.
- `Socket/index.ts`, `package.json`, bridge pin (`0.20.0`) untouched.
- Deliberate behavior breaks, covered by updated tests: critical writes to a removed folder now reject with `ENOENT` instead of resolving; new/replaced files are `0600` instead of umask-derived modes.
