### PR TITLE
fix(bridge): validate all civil time components before Date.parse

### DIFF
--- a/src/Bridge/__tests__/strict-calendar.test.ts
+++ b/src/Bridge/__tests__/strict-calendar.test.ts
@@ -1,0 +1,119 @@
+import { describe, it } from 'node:test'
+import type { WhatsAppEvent } from '@oxidezap/whatsapp-rust-bridge'
+import { adaptBridgeEvent } from '../adapt.ts'
+import { toUnixSeconds } from '../index.ts'
+import { asUnixSeconds } from '../primitives.ts'
+import { expect } from '../../__tests__/expect.ts'
+
+const jid = (user: string, server = 's.whatsapp.net') => ({ user, server, agent: 0, device: 0, integrator: 0 })
+
+const receiptWith = (timestamp: unknown) => ({
+	type: 'receipt',
+	data: {
+		source: { chat: jid('5511'), sender: jid('5511'), is_group: false, is_from_me: false },
+		message_ids: ['M1'],
+		type: 'Read',
+		timestamp
+	}
+})
+
+const messageWith = (timestamp: unknown) => ({
+	type: 'message',
+	data: {
+		message: { conversation: 'hi' },
+		info: {
+			id: 'MSG1',
+			timestamp,
+			source: { chat: jid('5511'), sender: jid('5511'), is_from_me: false, is_group: false }
+		}
+	}
+})
+
+describe('strict calendar — impossible civil times never become an instant', () => {
+	it('rejects day overflow without rolling into the next month', () => {
+		for (const raw of [
+			'2026-02-30T00:00:00Z',
+			'2026-02-30T00:00:00+02:00',
+			'2026-02-30T00:00:00.123Z',
+			'2026-02-30 00:00:00Z',
+			'2023-02-29T00:00:00Z',
+			'1900-02-29T00:00:00Z',
+			'2026-04-31T00:00:00Z',
+			'2026-01-32T00:00:00Z'
+		]) {
+			expect(asUnixSeconds(raw)).toBeUndefined()
+		}
+	})
+
+	it('rejects zero and out-of-range months and days', () => {
+		for (const raw of [
+			'2026-00-10T00:00:00Z',
+			'2026-13-10T00:00:00Z',
+			'2026-01-00T00:00:00Z',
+			'2026-02-00T00:00:00Z',
+			'2026-01-00 00:00:00z'
+		]) {
+			expect(asUnixSeconds(raw)).toBeUndefined()
+		}
+	})
+
+	it('rejects out-of-range clock components without rolling forward', () => {
+		for (const raw of [
+			'2026-01-15T24:00:00Z',
+			'2026-01-15T00:60:00Z',
+			'2026-01-15T00:00:60Z',
+			'2026-01-15 24:00:00+00:00',
+			'2026-01-15t00:00:60z'
+		]) {
+			expect(asUnixSeconds(raw)).toBeUndefined()
+		}
+	})
+
+	it('keeps valid leap days, fractions, offsets, and accepted spellings', () => {
+		expect(asUnixSeconds('2024-02-29T00:00:00Z')).toBe(Date.parse('2024-02-29T00:00:00Z') / 1000)
+		expect(asUnixSeconds('2000-02-29T00:00:00Z')).toBe(Date.parse('2000-02-29T00:00:00Z') / 1000)
+		expect(asUnixSeconds('2026-04-18T05:00:00.987Z')).toBe(Math.floor(Date.parse('2026-04-18T05:00:00.987Z') / 1000))
+		expect(asUnixSeconds('2026-04-18T05:00:00+02:00')).toBe(Date.parse('2026-04-18T05:00:00+02:00') / 1000)
+		expect(asUnixSeconds('2026-04-18T05:00:00-0530')).toBe(Date.parse('2026-04-18T05:00:00-0530') / 1000)
+		expect(asUnixSeconds('2026-04-18t05:00:00z')).toBe(Date.parse('2026-04-18T05:00:00Z') / 1000)
+		expect(asUnixSeconds('2026-04-18 05:00:00Z')).toBe(Date.parse('2026-04-18T05:00:00Z') / 1000)
+		expect(asUnixSeconds('2026-01-31T23:59:59Z')).toBe(Date.parse('2026-01-31T23:59:59Z') / 1000)
+	})
+
+	it('keeps the existing numeric policy: finite passes, the rest is absent', () => {
+		expect(asUnixSeconds(1_734_000_000)).toBe(1_734_000_000)
+		expect(asUnixSeconds(0)).toBe(0)
+		expect(asUnixSeconds(-1)).toBe(-1)
+		expect(asUnixSeconds(Number.NaN)).toBeUndefined()
+		expect(asUnixSeconds(Number.POSITIVE_INFINITY)).toBeUndefined()
+		expect(asUnixSeconds(undefined)).toBeUndefined()
+		expect(asUnixSeconds(null)).toBeUndefined()
+		expect(asUnixSeconds({})).toBeUndefined()
+	})
+
+	it('drops required-timestamp events carrying an impossible date', () => {
+		expect(adaptBridgeEvent(receiptWith('2026-02-30T00:00:00Z') as unknown as WhatsAppEvent)).toBe(null)
+		expect(adaptBridgeEvent(messageWith('2026-02-30T00:00:00Z') as unknown as WhatsAppEvent)).toBe(null)
+		expect(adaptBridgeEvent(messageWith('2026-01-15T24:00:00Z') as unknown as WhatsAppEvent)).toBe(null)
+	})
+
+	it('omits optional timestamps carrying an impossible date instead of dropping the event', () => {
+		const presence = adaptBridgeEvent({
+			type: 'presence',
+			data: { from: jid('5511'), unavailable: false, last_seen: '2026-02-30T00:00:00Z' }
+		} as unknown as WhatsAppEvent)
+		if (presence?.type !== 'presence') throw new Error('expected canonical presence')
+		expect(presence.lastSeen).toBeUndefined()
+
+		const ack = adaptBridgeEvent({
+			type: 'server_ack',
+			data: { id: 'ACK-1', timestamp: '2026-02-30T00:00:00Z' }
+		} as unknown as WhatsAppEvent)
+		if (ack?.type !== 'serverAck') throw new Error('expected canonical serverAck')
+		expect(ack.timestamp).toBeUndefined()
+	})
+
+	it('still throws from the validating export on an impossible date', () => {
+		expect(() => toUnixSeconds('2026-02-30T00:00:00Z')).toThrow(RangeError)
+	})
+})

--- a/src/Bridge/primitives.ts
+++ b/src/Bridge/primitives.ts
@@ -97,14 +97,20 @@ const parseRfc3339Seconds = (raw: string): number | undefined => {
 	// below, and asking the engine for capture groups costs more than the whole
 	// rest of this function.
 	if (!RFC_3339.test(raw)) return undefined
-	// `Date.parse` refuses month 13, hour 25 and second 61, but rolls a day
-	// past the end of its month forward instead: `2023-02-30` comes back as
-	// March 2. That is the one component worth checking here.
+	// Every civil component is bounded here, so `Date.parse` below only
+	// converts an already-valid timestamp to epoch: it can no longer
+	// normalize an impossible date (Feb 30 rolling into March) or time
+	// into a wrong-but-plausible instant. Day overflow and hour 24 were
+	// guarded before; month/day-zero and minute/second overflow used to
+	// fall through to the engine's own rejection, which this makes
+	// engine-independent. Fixed-width offsets: the date is always at 0-9
+	// and the time at 11-18 whatever separator, fraction, or zone follows.
 	const year = digits2(raw, 0) * 100 + digits2(raw, 2)
-	if (digits2(raw, 8) > daysInMonth(year, digits2(raw, 5))) return undefined
-	// The other one it rolls forward rather than refusing: RFC 3339 stops the
-	// hour at 23, while `2023-11-14T24:00:00Z` parses as midnight the next day.
-	if (digits2(raw, 11) > 23) return undefined
+	const month = digits2(raw, 5)
+	const day = digits2(raw, 8)
+	if (month < 1 || month > 12) return undefined
+	if (day < 1 || day > daysInMonth(year, month)) return undefined
+	if (digits2(raw, 11) > 23 || digits2(raw, 14) > 59 || digits2(raw, 17) > 59) return undefined
 	const ms = Date.parse(raw)
 	return Number.isFinite(ms) ? Math.floor(ms / 1000) : undefined
 }


### PR DESCRIPTION
# Follow-up: strict civil-time validation before Date.parse

Addresses the Greptile finding on PR #104 (review 3939433945) that
`asUnixSeconds` uses `Date.parse`, which normalizes impossible dates such
as `2026-02-30T00:00:00Z` into March.

## Verification first

The literal example was **already rejected** on current main: the
pre-existing day-overflow and hour-24 guards return `undefined` for it. A
component x separator x zone matrix (bad days, zero/out-of-range months
and days, hour 24, minute/second 60, across `T`/`t`/space and
`Z`/`z`/offset zones) run against the real parser confirmed zero live
normalization holes, and the new regression tests pass identically with
the fix stashed. So this is hardening plus locked semantics, not a
behavior repair — reported honestly as such.

## Changes by file

- `src/Bridge/primitives.ts` — `parseRfc3339Seconds` now bounds every
  civil component explicitly (month 1-12, day 1-daysInMonth with the
  existing Gregorian leap rule, hour 0-23, minute/second 0-59) at
  fixed offsets. `Date.parse` is thereby reduced to an epoch converter
  for an already-valid timestamp and can no longer normalize anything;
  month/day-zero and minute/second overflow no longer depend on engine
  rejection. No accepted input changes: valid leap days (2024, 2000),
  fractions (truncated), offsets (colon, non-colon, negative),
  lowercase/space spellings, and the finite-number policy (including 0)
  are untouched; NaN/Infinity/absence stay absent and `toUnixSeconds`
  still throws `RangeError` on them.
- `src/Bridge/__tests__/strict-calendar.test.ts` (new) — 8 semantic
  tests: impossible dates/times rejected, valid forms preserved,
  numeric policy locked, required adapters (receipt, message) drop on an
  impossible date, optional adapters (presence `last_seen`, server-ack)
  omit it, validating export throws.

## Validation (HEAD `8e5e1c3`, bridge 0.20.0 pinned, no bump)

- New suite: 8/8 pass; identical 8/8 with the `primitives.ts` change
  stashed (pre-existing guards already rejected the finding's example).
- `npm test`: 1455 tests, 1454 pass, 0 fail, 1 pre-existing skip.
- `npm run build`, `format:check`, `lint` (`tsc` + `oxlint`): pass.
- Audits, all exit 0 with unchanged baselines: `compat:audit` 97.83%,
  events 100%; `compat:audit:wire` (2 known `pollResultSnapshotMessageV3`
  divergences); `compat:audit:proto` (known wire gaps only);
  `compat:audit:lifecycle` (28 hold, 0 violated).
- `test:e2e` not run (dedicated infra required; nothing in this lot
  needs a session).

## Compatibility notes

- No exported-type change; no dispatcher, receipt-category, or
  `receiptTypeRaw` change; diagnostics policy untouched
  (metadata-only rejection logs).
- Behavior change is intentionally nil on every input constructible in
  testing; the guarantee being added is engine-independence of the
  rejection verdict.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes RFC 3339 timestamp parsing reject impossible civil time components before `Date.parse`, instead of letting it normalize them (Feb 30 rolling into March) or relying on engine rejection. No accepted input changes.

**Bug Fixes**
- Bounds month (1-12), day (1-daysInMonth), hour (0-23), and minute/second (0-59) in `parseRfc3339Seconds`, making rejection engine-independent.
- Adds `src/Bridge/__tests__/strict-calendar.test.ts` covering impossible dates/times, preserved valid forms, and optional-timestamp omission.

<sup>Written for commit 8e5e1c35c69552d5c7db853a9c15ab141d3de48d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

