### PR TITLE
feat(socket): configure Noise certificate verification per client

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,7 @@ jobs:
       # so a preview-pinned runtime dependency would otherwise reach the
       # registry. Fails the release until the dependency selects the matching
       # registry release.
-      - run: node scripts/check-registry-deps.ts
+      - run: node scripts/check-registry-deps.mjs
 
       # No NODE_AUTH_TOKEN and no --provenance: trusted publishing authenticates
       # over OIDC and attaches provenance on its own. Published from the package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,6 +281,12 @@ jobs:
       # anything is published.
       - run: node scripts/check-pack.ts
 
+      # Same reason as above, for the dependency guard: hooks never fire here,
+      # so a preview-pinned runtime dependency would otherwise reach the
+      # registry. Fails the release until the dependency selects the matching
+      # registry release.
+      - run: node scripts/check-registry-deps.ts
+
       # No NODE_AUTH_TOKEN and no --provenance: trusted publishing authenticates
       # over OIDC and attaches provenance on its own. Published from the package
       # directory rather than a prebuilt tarball, which is the shape npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
-        "@oxidezap/whatsapp-rust-bridge": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@01a5e5f19465de487020a96f927319b863a968cf",
+        "@oxidezap/whatsapp-rust-bridge": "0.21.0",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -975,9 +975,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.0.0-preview-01a5e5f",
-      "resolved": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@01a5e5f19465de487020a96f927319b863a968cf",
-      "integrity": "sha512-oTLPmSYAVq9q81unC3olZMrq8jJh8OzM9GjxYUt2WONXx8FNBnut9rggJ/8yX4pqnQymzZ0dCuMn8bse+QxfWg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.21.0.tgz",
+      "integrity": "sha512-y6OAmBr8o0uKS3758L3XUBocEtMXZiUoHH/UBVqvrbd0P+lSw8IshPQF/11B/7Mn2HlLBQLcy08ZiAyj/BX4pw==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
-        "@oxidezap/whatsapp-rust-bridge": "0.20.0",
+        "@oxidezap/whatsapp-rust-bridge": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@4f5fbb857dce83723f7ceb87ed11c82de44abe5d",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -69,7 +69,6 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.1.tgz",
       "integrity": "sha512-agRJn3+EJDUe8AvxTx/LnHA/GErvLE62pSaSk7+MwFOtOv8eWBu/qCq2qoZjBjVZ3C2aiFJCveuSs17KMkYGOw==",
-      "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cacheable/memory": {
@@ -976,10 +975,13 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.20.0.tgz",
-      "integrity": "sha512-Mu5FXISUUp0y1W7iRUMwGsNyleNOG2P5YIFeT0HaP10B4E0nN7w7H7GgEVIzRBA7Cv5dzItsbZdtfftPobHgXg==",
-      "license": "MIT"
+      "version": "0.0.0-preview-4f5fbb8",
+      "resolved": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@4f5fbb857dce83723f7ceb87ed11c82de44abe5d",
+      "integrity": "sha512-rQAexN3xmFwbsRhbSX2IqFnCF8/WzGWBIe0IW+deTUE3eEohm8nW1BWwXCcGN4AU9wsxTdU7IlMlcU20wsiCJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0"
+      }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
       "version": "1.81.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
-        "@oxidezap/whatsapp-rust-bridge": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@4f5fbb857dce83723f7ceb87ed11c82de44abe5d",
+        "@oxidezap/whatsapp-rust-bridge": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@01a5e5f19465de487020a96f927319b863a968cf",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -975,9 +975,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.0.0-preview-4f5fbb8",
-      "resolved": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@4f5fbb857dce83723f7ceb87ed11c82de44abe5d",
-      "integrity": "sha512-rQAexN3xmFwbsRhbSX2IqFnCF8/WzGWBIe0IW+deTUE3eEohm8nW1BWwXCcGN4AU9wsxTdU7IlMlcU20wsiCJQ==",
+      "version": "0.0.0-preview-01a5e5f",
+      "resolved": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@01a5e5f19465de487020a96f927319b863a968cf",
+      "integrity": "sha512-oTLPmSYAVq9q81unC3olZMrq8jJh8OzM9GjxYUt2WONXx8FNBnut9rggJ/8yX4pqnQymzZ0dCuMn8bse+QxfWg==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",
-    "@oxidezap/whatsapp-rust-bridge": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@01a5e5f19465de487020a96f927319b863a968cf",
+    "@oxidezap/whatsapp-rust-bridge": "0.21.0",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",
-    "@oxidezap/whatsapp-rust-bridge": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@4f5fbb857dce83723f7ceb87ed11c82de44abe5d",
+    "@oxidezap/whatsapp-rust-bridge": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@01a5e5f19465de487020a96f927319b863a968cf",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "lint": "tsc && oxlint",
     "lint:fix": "oxlint --fix && oxfmt src Example",
     "prepack": "npm run build && node scripts/check-pack.ts",
+    "prepublishOnly": "node scripts/check-registry-deps.ts",
     "prepare": "npm run build",
     "test": "node --test",
     "fuzz": "node --test --test-timeout=600000 ./src/__fuzz__/**/*.test.ts",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "lint": "tsc && oxlint",
     "lint:fix": "oxlint --fix && oxfmt src Example",
     "prepack": "npm run build && node scripts/check-pack.ts",
-    "prepublishOnly": "node scripts/check-registry-deps.ts",
+    "prepublishOnly": "node scripts/check-registry-deps.mjs",
     "prepare": "npm run build",
     "test": "node --test",
     "fuzz": "node --test --test-timeout=600000 ./src/__fuzz__/**/*.test.ts",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",
-    "@oxidezap/whatsapp-rust-bridge": "0.20.0",
+    "@oxidezap/whatsapp-rust-bridge": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@4f5fbb857dce83723f7ceb87ed11c82de44abe5d",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"

--- a/scripts/__tests__/check-registry-deps.test.ts
+++ b/scripts/__tests__/check-registry-deps.test.ts
@@ -12,9 +12,9 @@ import { join, resolve } from 'node:path'
 import { describe, it } from 'node:test'
 
 import { expect } from '../../src/__tests__/expect.ts'
-import { findPreviewDependencies } from '../check-registry-deps.ts'
+import { findPreviewDependencies } from '../check-registry-deps.mjs'
 
-const guard = resolve(import.meta.dirname, '..', 'check-registry-deps.ts')
+const guard = resolve(import.meta.dirname, '..', 'check-registry-deps.mjs')
 
 const runGuard = (dir: string): Promise<{ code: number | null; stdout: string; stderr: string }> =>
 	new Promise(resolvePromise => {

--- a/scripts/__tests__/check-registry-deps.test.ts
+++ b/scripts/__tests__/check-registry-deps.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The release guard only ever reads a package manifest and exits — it has no
+ * publish path, so these tests can drive the real CLI entrypoint in a child
+ * process without any risk of publishing. Each case points the guard at a
+ * synthetic fixture directory, never at the repository itself.
+ */
+
+import { execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { describe, it } from 'node:test'
+
+import { expect } from '../../src/__tests__/expect.ts'
+import { findPreviewDependencies } from '../check-registry-deps.ts'
+
+const guard = resolve(import.meta.dirname, '..', 'check-registry-deps.ts')
+
+const runGuard = (dir: string): Promise<{ code: number | null; stdout: string; stderr: string }> =>
+	new Promise(resolvePromise => {
+		execFile(process.execPath, [guard, dir], { timeout: 30_000 }, (error, stdout, stderr) => {
+			resolvePromise({
+				code: error && 'code' in error ? (error.code as number) : 0,
+				stdout: String(stdout),
+				stderr: String(stderr)
+			})
+		})
+	})
+
+const fixtureDir = async (pkg: unknown): Promise<string> => {
+	const dir = await mkdtemp(join(tmpdir(), 'baileyrs-guard-'))
+	await writeFile(join(dir, 'package.json'), JSON.stringify(pkg))
+	return dir
+}
+
+describe('check-registry-deps release guard', { timeout: 60_000 }, () => {
+	it('rejects a runtime dependency pinned to a preview URL', async () => {
+		const dir = await fixtureDir({
+			dependencies: {
+				'@oxidezap/whatsapp-rust-bridge': 'https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@4f5fbb8'
+			}
+		})
+		try {
+			const { code, stderr } = await runGuard(dir)
+			expect(code).toBe(1)
+			expect(stderr).toContain('@oxidezap/whatsapp-rust-bridge')
+			expect(stderr).toContain('registry release')
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('allows a registry version for the same dependency', async () => {
+		const dir = await fixtureDir({
+			dependencies: { '@oxidezap/whatsapp-rust-bridge': '0.20.1' }
+		})
+		try {
+			const { code, stdout } = await runGuard(dir)
+			expect(code).toBe(0)
+			expect(stdout).toContain('no preview URLs')
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('ignores preview URLs outside runtime dependencies', async () => {
+		const dir = await fixtureDir({
+			dependencies: { '@oxidezap/whatsapp-rust-bridge': '0.20.1' },
+			devDependencies: { 'some-tool': 'https://pkg.pr.new/some-tool@12' }
+		})
+		try {
+			const { code } = await runGuard(dir)
+			expect(code).toBe(0)
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('lists every preview-pinned runtime dependency', () => {
+		expect(
+			findPreviewDependencies({
+				dependencies: {
+					a: 'https://pkg.pr.new/a@1',
+					b: '^2.0.0',
+					c: 'https://pkg.pr.new/c@3'
+				}
+			}).map(entry => entry.name)
+		).toEqual(['a', 'c'])
+	})
+})

--- a/scripts/check-registry-deps.mjs
+++ b/scripts/check-registry-deps.mjs
@@ -9,45 +9,50 @@
  * publishes with `--ignore-scripts`, so no npm hook would fire there) plus
  * through `prepublishOnly` for ad-hoc local publishes. `npm pack` runs
  * neither, so `prepack` and the pkg.pr.new preview CI stay green.
+ *
+ * Plain JavaScript on purpose: `prepublishOnly` must run on every Node.js the
+ * package `engines` allow (currently >=22.0.0), and direct `.ts` execution
+ * needs type stripping that only became default in 22.18.0.
  */
 import { readFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const repoRoot = resolve(fileURLToPath(import.meta.url), '..', '..')
-
 export const PREVIEW_SPEC_MARK = 'pkg.pr.new'
 
-export interface PreviewDependency {
-	name: string
-	spec: string
-}
+/**
+ * @typedef {{ name: string, spec: string }} PreviewDependency
+ */
 
-/** Runtime dependency specs that point at the preview service. */
-export const findPreviewDependencies = (pkg: {
-	dependencies?: Record<string, string> | undefined
-}): PreviewDependency[] =>
+/**
+ * Runtime dependency specs that point at the preview service.
+ * @param {{ dependencies?: Record<string, string> | undefined }} pkg
+ * @returns {PreviewDependency[]}
+ */
+export const findPreviewDependencies = (pkg) =>
 	Object.entries(pkg.dependencies ?? {})
-		.filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1].includes(PREVIEW_SPEC_MARK))
+		.filter((entry) => typeof entry[1] === 'string' && entry[1].includes(PREVIEW_SPEC_MARK))
 		.map(([name, spec]) => ({ name, spec }))
 
-export const checkPackageDir = (dir: string): PreviewDependency[] => {
-	const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as {
-		dependencies?: Record<string, string> | undefined
-	}
+/**
+ * @param {string} dir directory holding the package.json to check
+ * @returns {PreviewDependency[]}
+ */
+export const checkPackageDir = (dir) => {
+	const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
 	return findPreviewDependencies(pkg)
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-	const dir = process.argv[2] ? resolve(process.argv[2]) : repoRoot
+const invokedDirectly = process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (invokedDirectly) {
+	const dir = process.argv[2] !== undefined ? resolve(process.argv[2]) : resolve(fileURLToPath(import.meta.url), '..', '..')
 	const bad = checkPackageDir(dir)
 	if (bad.length > 0) {
 		for (const { name, spec } of bad) {
 			console.error(`check-registry-deps: ${name} still pins a preview build (${spec})`)
 		}
-		console.error(
-			'check-registry-deps: refusing to publish; switch the dependency to the matching registry release first'
-		)
+		console.error('check-registry-deps: refusing to publish; switch the dependency to the matching registry release first')
 		process.exit(1)
 	}
 	console.log('check-registry-deps: no preview URLs in runtime dependencies')

--- a/scripts/check-registry-deps.ts
+++ b/scripts/check-registry-deps.ts
@@ -1,0 +1,54 @@
+/**
+ * Release guard: refuse an official npm publication while a runtime
+ * dependency still pins a `pkg.pr.new` preview URL.
+ *
+ * Preview tarballs are only guaranteed to resolve while the preview service
+ * keeps them; a published package pointing at one can stop installing at any
+ * time. The guard is deliberately narrow — runtime `dependencies` only, never
+ * `devDependencies` — and it runs explicitly in the release workflow (which
+ * publishes with `--ignore-scripts`, so no npm hook would fire there) plus
+ * through `prepublishOnly` for ad-hoc local publishes. `npm pack` runs
+ * neither, so `prepack` and the pkg.pr.new preview CI stay green.
+ */
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), '..', '..')
+
+export const PREVIEW_SPEC_MARK = 'pkg.pr.new'
+
+export interface PreviewDependency {
+	name: string
+	spec: string
+}
+
+/** Runtime dependency specs that point at the preview service. */
+export const findPreviewDependencies = (pkg: {
+	dependencies?: Record<string, string> | undefined
+}): PreviewDependency[] =>
+	Object.entries(pkg.dependencies ?? {})
+		.filter((entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1].includes(PREVIEW_SPEC_MARK))
+		.map(([name, spec]) => ({ name, spec }))
+
+export const checkPackageDir = (dir: string): PreviewDependency[] => {
+	const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as {
+		dependencies?: Record<string, string> | undefined
+	}
+	return findPreviewDependencies(pkg)
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	const dir = process.argv[2] ? resolve(process.argv[2]) : repoRoot
+	const bad = checkPackageDir(dir)
+	if (bad.length > 0) {
+		for (const { name, spec } of bad) {
+			console.error(`check-registry-deps: ${name} still pins a preview build (${spec})`)
+		}
+		console.error(
+			'check-registry-deps: refusing to publish; switch the dependency to the matching registry release first'
+		)
+		process.exit(1)
+	}
+	console.log('check-registry-deps: no preview URLs in runtime dependencies')
+}

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -506,7 +506,13 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			bridgeStore,
 			fullConfig.cache ?? null,
 			fullConfig.version,
-			fullConfig.wantedPreKeyCount ?? null
+			fullConfig.wantedPreKeyCount ?? null,
+			// Passed through exactly as configured, never normalized by truthiness:
+			// the bridge only honours a literal `true` here and rejects any
+			// other truthy value at construction, so a `!!`/ternary-style
+			// coercion could promote a malformed opt-out into an opt-in.
+			// Absent stays strict.
+			fullConfig.dangerSkipCertChainVerify
 		)
 		// `end()` can land while the client is still being built — a `sock.end()`
 		// or `await using` right after `makeWASocket()` does exactly that. When

--- a/src/Socket/unsupported-config.ts
+++ b/src/Socket/unsupported-config.ts
@@ -102,6 +102,7 @@ export const READ_CONFIG_KEYS = [
 	'cache',
 	'deviceProps',
 	'wantedPreKeyCount',
+	'dangerSkipCertChainVerify',
 	'emitOwnEvents',
 	'shouldIgnoreJid',
 	'defaultQueryTimeoutMs',

--- a/src/Types/Socket.ts
+++ b/src/Types/Socket.ts
@@ -101,6 +101,15 @@ export type SocketConfig = {
 	 */
 	wantedPreKeyCount?: number
 
+	/**
+	 * Testing-only bypass for the Noise server-cert chain check, for mock
+	 * servers that cannot sign a chain rooted in WhatsApp's issuer. Strict by
+	 * default: absent, null and false all verify, and only a literal `true`
+	 * opts in — the bridge rejects any other truthy value at construction
+	 * rather than treating it as opt-in. Never set this outside tests.
+	 */
+	dangerSkipCertChainVerify?: boolean
+
 	// ─────────────────────────────────────────────────────────────────────
 	// Compatibility options are either translated by the socket or owned by
 	// the native runtime. Keep their public declarations exact.

--- a/src/__tests__/cert-chain-verify-plumbing.test.ts
+++ b/src/__tests__/cert-chain-verify-plumbing.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Plumbing for the testing-only Noise cert-chain bypass.
+ *
+ * The bridge verifies the server cert chain strictly unless
+ * `createWhatsAppClient` receives a literal `true` as its 8th argument; any
+ * other truthy value rejects the construction as `invalid-argument` instead
+ * of opting in. The socket exposes this as the optional per-socket
+ * `dangerSkipCertChainVerify` flag and forwards it unchanged.
+ *
+ * What is pinned here, all offline against a dead loopback port:
+ *
+ * - the default config carries no opt-in, so a socket built without the flag
+ *   constructs exactly like strict;
+ * - `false`/`null`/absent construct fine at the bridge (strictness itself is
+ *   proven against the mock in e2e: strict rejects, `true` pairs);
+ * - malformed truthy values (`'true'`, `1`) reject — directly with
+ *   `invalid-argument`, and through the socket factory as a failed
+ *   initialization rather than a socket that pairs.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+import {
+	createWhatsAppClient,
+	initWasmEngine,
+	type JsHttpClientConfig,
+	type JsStoreCallbacks,
+	type JsTransportCallbacks
+} from '@oxidezap/whatsapp-rust-bridge'
+
+import { DEFAULT_CONNECTION_CONFIG } from '../Defaults/index.ts'
+import makeWASocket from '../Socket/index.ts'
+import { delay } from '../Utils/generics.ts'
+import type { ILogger } from '../Utils/logger.ts'
+import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
+import { expect } from './expect.ts'
+
+const silentLogger = {
+	level: 'silent',
+	child: () => silentLogger,
+	trace: () => undefined,
+	debug: () => undefined,
+	info: () => undefined,
+	warn: () => undefined,
+	error: () => undefined
+} as unknown as ILogger
+
+const deadTransport = (): JsTransportCallbacks => ({
+	connect: async () => undefined,
+	send: async () => undefined,
+	disconnect: async () => undefined
+})
+
+const deadHttp = (): JsHttpClientConfig => ({
+	execute: async () => ({ statusCode: 503, body: new Uint8Array() })
+})
+
+const memoryStore = (): JsStoreCallbacks => ({
+	get: async () => null,
+	set: async () => undefined,
+	delete: async () => undefined
+})
+
+initWasmEngine(silentLogger)
+
+describe('cert chain verification bypass plumbing', { timeout: 60_000 }, () => {
+	it('the default config carries no opt-in', () => {
+		expect(DEFAULT_CONNECTION_CONFIG.dangerSkipCertChainVerify).toBe(undefined)
+	})
+
+	for (const label of ['absent', 'null', 'false', 'true'] as const) {
+		it(`bridge construction accepts ${label} (strict unless literal true)`, async () => {
+			const eighth = label === 'absent' ? undefined : label === 'null' ? null : label === 'true'
+			const client = await createWhatsAppClient(
+				deadTransport(),
+				deadHttp(),
+				null,
+				memoryStore(),
+				null,
+				undefined,
+				null,
+				eighth
+			)
+			try {
+				expect(typeof client.disconnect).toBe('function')
+			} finally {
+				try {
+					await client.disconnect()
+				} catch {
+					/* ignore */
+				}
+				client.free()
+			}
+		})
+	}
+
+	for (const malformed of ['true', 1] as const) {
+		it(`bridge construction rejects malformed ${JSON.stringify(malformed)} as invalid-argument, never as opt-in`, async () => {
+			const outcome = await createWhatsAppClient(
+				deadTransport(),
+				deadHttp(),
+				null,
+				memoryStore(),
+				null,
+				undefined,
+				null,
+				malformed as unknown as boolean
+			).then(
+				client => {
+					client.free()
+					return { settled: 'resolved' } as const
+				},
+				(error: { kind?: unknown }) => ({ settled: 'rejected', kind: error?.kind }) as const
+			)
+
+			expect(outcome.settled).toBe('rejected')
+			expect(outcome.settled === 'rejected' ? outcome.kind : undefined).toBe('invalid-argument')
+		})
+	}
+
+	for (const flag of [undefined, false, true] as const) {
+		it(`socket factory with ${String(flag)} initializes its bridge client`, async () => {
+			const authFolder = await mkdtemp(join(tmpdir(), 'baileyrs-certflag-'))
+			try {
+				const { state } = await useMultiFileAuthState(authFolder)
+				const sock = makeWASocket({
+					auth: state,
+					logger: silentLogger,
+					waWebSocketUrl: 'ws://127.0.0.1:1',
+					...(flag === undefined ? {} : { dangerSkipCertChainVerify: flag })
+				})
+				try {
+					sock.setAutoReconnect(false)
+					for (let i = 0; i < 100 && !sock.waClient; i++) await delay(50)
+					expect(Boolean(sock.waClient)).toBe(true)
+				} finally {
+					await sock.end(undefined)
+				}
+			} finally {
+				await rm(authFolder, { recursive: true, force: true })
+			}
+		})
+	}
+
+	for (const malformed of ['true', 1] as const) {
+		it(`socket factory with malformed ${JSON.stringify(malformed)} fails initialization instead of pairing`, async () => {
+			const authFolder = await mkdtemp(join(tmpdir(), 'baileyrs-certflag-'))
+			try {
+				const { state } = await useMultiFileAuthState(authFolder)
+				const sock = makeWASocket({
+					auth: state,
+					logger: silentLogger,
+					waWebSocketUrl: 'ws://127.0.0.1:1',
+					dangerSkipCertChainVerify: malformed as unknown as boolean
+				})
+				try {
+					sock.setAutoReconnect(false)
+					const error = await sock
+						.query({ tag: 'iq', attrs: { id: 'cert-flag-probe', type: 'get', xmlns: 'test' } }, 1000)
+						.then(
+							() => undefined,
+							err => err as Error
+						)
+					expect(error).toBeDefined()
+					expect(String((error as Error)?.message)).toContain('failed to initialize')
+				} finally {
+					await sock.end(undefined)
+				}
+			} finally {
+				await rm(authFolder, { recursive: true, force: true })
+			}
+		})
+	}
+})

--- a/src/__tests__/e2e/baileys-handoff.test-e2e.ts
+++ b/src/__tests__/e2e/baileys-handoff.test-e2e.ts
@@ -162,6 +162,9 @@ async function createBridgeClient(label: string, authFolder?: string): Promise<B
 		// companion slot instead of deriving one from random Noise key bytes.
 		pushName: basename(folder),
 		waWebSocketUrl: socketUrl,
+		// Test-only: the mock server's cert is self-signed and strict
+		// verification (the default) rejects it. Production code must never set this.
+		dangerSkipCertChainVerify: true,
 		logger: logger.child({ user: label, impl: 'bridge' })
 	})
 

--- a/src/__tests__/e2e/cert-chain-policy.test-e2e.ts
+++ b/src/__tests__/e2e/cert-chain-policy.test-e2e.ts
@@ -1,0 +1,172 @@
+/**
+ * E2E: the Noise server-cert policy, through the real socket factory.
+ *
+ * The offline plumbing tests prove the flag reaches the bridge constructor;
+ * they never perform a handshake, so they cannot prove what the engine does
+ * with it. This file pairs against the mock three times with `makeWASocket`
+ * directly (not through the fixture factory, whose default opt-in would hide
+ * the production default):
+ *
+ * - flag absent (the production default) → the mock's self-signed chain is
+ *   rejected, observed as `Server certificate verification failed ... XEdDSA`
+ *   in the engine log, and the socket never opens;
+ * - flag explicitly `false` → same rejection;
+ * - flag literal `true` → pairs and opens.
+ *
+ * A pairing timeout alone proves nothing (any outage times out), so the
+ * strict cases assert the cert-failure log signal itself; the timeout only
+ * bounds how long a broken mock gets before the case fails.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { describe, test } from 'node:test'
+import P from 'pino'
+import { makeWASocket, useMultiFileAuthState } from '../../index.ts'
+import { expect } from '../expect.ts'
+import { attachQrAutoresponder } from './qr-autoresponder.ts'
+import { waitForEvent } from './wait.ts'
+
+type WASocket = ReturnType<typeof makeWASocket>
+
+const socketUrl = process.env.SOCKET_URL ?? 'wss://127.0.0.1:8080/ws/chat'
+/** Failure bound only: the strict proof is the log signal, not this timer. */
+const CERT_FAILURE_TIMEOUT_MS = 30_000
+
+// One shared engine logger for every socket in this file. The wasm engine
+// initializes once per process with the first socket's logger, so sharing one
+// capturing logger (rather than one per case) is what makes the cert-failure
+// lines observable no matter which case runs first.
+const captured: string[] = []
+const engineLogger = P({ level: 'debug' }, {
+	write: (chunk: string | Uint8Array) => {
+		captured.push(String(chunk))
+		return true
+	}
+} as never)
+
+const certFailureLines = (from: number): string[] =>
+	captured.slice(from).filter(line => /certificate verification failed/i.test(line))
+
+const waitForCertRejection = async (from: number): Promise<string[]> => {
+	const deadline = Date.now() + CERT_FAILURE_TIMEOUT_MS
+	for (;;) {
+		const hits = certFailureLines(from)
+		if (hits.length > 0) return hits
+		if (Date.now() >= deadline) {
+			throw new Error('timed out waiting for the Noise cert-rejection log signal')
+		}
+		await new Promise<void>(resolve => setTimeout(resolve, 250))
+	}
+}
+
+interface StrictClient {
+	sock: WASocket
+	authFolder: string
+	onUpdate: (update: ConnectionUpdate) => void
+	opened: boolean
+	mark: number
+}
+
+const startStrictClient = async (label: string, flag: boolean | undefined): Promise<StrictClient> => {
+	const authFolder = mkdtempSync(join(tmpdir(), 'baileyrs-certpolicy-'))
+	const { state } = await useMultiFileAuthState(authFolder)
+	const client: StrictClient = {
+		sock: makeWASocket({
+			auth: state,
+			waWebSocketUrl: socketUrl,
+			logger: engineLogger.child({ case: label }),
+			...(flag === undefined ? {} : { dangerSkipCertChainVerify: flag })
+		}),
+		authFolder,
+		onUpdate: update => {
+			if (update.connection === 'open') client.opened = true
+		},
+		opened: false,
+		mark: captured.length
+	}
+	client.sock.ev.on('connection.update', client.onUpdate)
+	return client
+}
+
+type ConnectionUpdate = { connection?: string }
+
+const stopClient = async (client: {
+	sock: WASocket
+	authFolder: string
+	onUpdate?: (update: ConnectionUpdate) => void
+}) => {
+	if (client.onUpdate) {
+		try {
+			client.sock.ev.off('connection.update', client.onUpdate)
+		} catch {
+			/* ignore */
+		}
+	}
+	try {
+		client.sock.setAutoReconnect(false)
+		await client.sock.end(undefined)
+	} catch {
+		/* ignore */
+	}
+	try {
+		rmSync(client.authFolder, { recursive: true, force: true })
+	} catch {
+		/* ignore */
+	}
+}
+
+describe('E2E: Noise server-cert policy against the mock', { timeout: 180_000 }, () => {
+	test('absent flag (production default) rejects the mock chain and never opens', async () => {
+		const client = await startStrictClient('absent', undefined)
+		try {
+			const hits = await waitForCertRejection(client.mark)
+			expect(hits.length > 0).toBe(true)
+			expect(hits.some(line => /XEdDSA/.test(line))).toBe(true)
+			expect(client.opened).toBe(false)
+		} finally {
+			await stopClient(client)
+		}
+	})
+
+	test('explicit false rejects the mock chain and never opens', async () => {
+		const client = await startStrictClient('explicit-false', false)
+		try {
+			const hits = await waitForCertRejection(client.mark)
+			expect(hits.length > 0).toBe(true)
+			expect(hits.some(line => /XEdDSA/.test(line))).toBe(true)
+			expect(client.opened).toBe(false)
+		} finally {
+			await stopClient(client)
+		}
+	})
+
+	test('literal true pairs and opens', async () => {
+		const authFolder = mkdtempSync(join(tmpdir(), 'baileyrs-certpolicy-'))
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const sock = makeWASocket({
+				auth: state,
+				waWebSocketUrl: socketUrl,
+				logger: engineLogger.child({ case: 'opt-in' }),
+				dangerSkipCertChainVerify: true
+			})
+			const detachQr = attachQrAutoresponder(sock, socketUrl)
+			try {
+				await waitForEvent(sock, 'connection.update', update => update.connection === 'open', 30_000)
+				expect(sock.user?.id).toBeTruthy()
+			} finally {
+				detachQr()
+				await stopClient({ sock, authFolder })
+			}
+		} finally {
+			try {
+				rmSync(authFolder, { recursive: true, force: true })
+			} catch {
+				/* ignore */
+			}
+		}
+	})
+})

--- a/src/__tests__/e2e/test-client.ts
+++ b/src/__tests__/e2e/test-client.ts
@@ -70,6 +70,9 @@ export async function createTestClient(opts: CreateTestClientOptions): Promise<T
 		auth: state,
 		pushName: basename(folder),
 		waWebSocketUrl: url,
+		// Test-only: the mock server's cert is self-signed and strict
+		// verification (the default) rejects it. Production code must never set this.
+		dangerSkipCertChainVerify: true,
 		logger: defaultLogger.child({ user: opts.label })
 	})
 


### PR DESCRIPTION
Adds an explicit per-socket `dangerSkipCertChainVerify` option, backed by bridge 0.21.0 from npm. Certificate verification remains strict by default; mock E2E fixtures opt in explicitly.

Adds factory-level E2E coverage for strict rejection and explicit opt-in, plus a publication guard against runtime preview dependencies.

Validation: build, types, lint and formatting; 1,497 unit tests passed, 1 skipped; all 88 E2E tests passed against the local mock with bridge 0.21.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the optional `dangerSkipCertChainVerify` socket setting for testing connections to servers with self-signed certificates.
  - Certificate verification remains enabled by default and can only be bypassed with the explicit value `true`.

- **Chores**
  - Added release checks to prevent publishing packages with preview registry dependencies.
  - Updated the WhatsApp bridge dependency to version 0.21.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->