### PR TITLE
feat(socket): observe bridge run completion

### DIFF
--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -55,7 +55,7 @@ import {
 import { emitMessageUpsert, type MessageUpsertMetadata } from '../Compatibility/message-upsert.ts'
 import { extractMessageCappingPayload } from './message-capping.ts'
 import { mapReachoutTimelock } from './reachout.ts'
-import { isReconnectableConnectFailure } from './terminal-close.ts'
+import { isReconnectableConnectFailure, mapConnectFailureToDisconnect } from './terminal-close.ts'
 import type { SocketContext } from './types.ts'
 
 const CANONICAL_MESSAGE_EVENT = 'message'
@@ -310,42 +310,6 @@ const emitRetrying = (ctx: SocketContext) =>
  * dispatcher for why `badSession` was the wrong home.
  */
 const CLIENT_OUTDATED_STATUS = 405
-
-/**
- * Map bridge `ConnectFailureReason` wire codes (per the bridge's
- * `.d.ts` annotation) onto upstream Baileys' `DisconnectReason`.
- * Unknown codes fall through to `connectionClosed` so existing
- * reconnect heuristics keep working.
- *
- * Several cases here are belt-and-braces: the engine dispatches its own event
- * for `is_logged_out()` reasons (401/403/406) and for 405, so those never
- * reach `connectFailure` in practice. Kept because they cost nothing and the
- * engine's routing is not ours to depend on.
- */
-const mapConnectFailureToDisconnect = (reason: number | undefined): number => {
-	switch (reason) {
-		case 401: // LoggedOut
-		case 403: // MainDeviceGone
-		case 406: // UnknownLogout
-			return DisconnectReason.loggedOut
-		case 402: // TempBanned
-			return DisconnectReason.forbidden
-		case 405: // ClientOutdated
-			return CLIENT_OUTDATED_STATUS
-		case 411: // MultideviceMismatch (legacy alias)
-			return DisconnectReason.multideviceMismatch
-		case 503: // ServiceUnavailable
-		case 501: // Experimental
-			return DisconnectReason.unavailableService
-		case 408: // Timed out
-			return DisconnectReason.timedOut
-		case 515: // RestartRequired
-			return DisconnectReason.restartRequired
-		// 400, 409, 413, 414, 415, 418, 500, undefined → generic close
-		default:
-			return DisconnectReason.connectionClosed
-	}
-}
 
 const describeTempBan = (code: number | undefined): string => {
 	switch (code) {

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -4,6 +4,7 @@ import {
 	createWhatsAppClient,
 	type DevicePlatformType,
 	initWasmEngine,
+	type RunCompletionResult,
 	type UploadMediaResult
 } from '@oxidezap/whatsapp-rust-bridge'
 import { encodeProtoCompat } from '../Compatibility/encode-proto.ts'
@@ -58,6 +59,7 @@ import { makeBridgeClientOwner } from './bridge-client-owner.ts'
 import { warnUnsupportedConfig } from './unsupported-config.ts'
 import { wrapBridgeClient } from './bridge-error-boundary.ts'
 import { makeTerminalCloseReporter } from './terminal-close-reporter.ts'
+import { mapConnectFailureToDisconnect } from './terminal-close.ts'
 import { makeEventHandlers } from './events.ts'
 import { makeGroupMethods } from './groups.ts'
 import { makeInternalMethods, makeUnexpectedErrorReporter } from './internals.ts'
@@ -296,6 +298,54 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	let autoReconnectEnabled = true
 	/** Owns reporting the terminal close: once, after teardown, never not at all. */
 	const terminalClose = makeTerminalCloseReporter({ logger })
+	const completionFailureCode = (reason: string): number | undefined => {
+		const known: Record<string, number> = {
+			Generic: 400,
+			LoggedOut: 401,
+			TempBanned: 402,
+			AccountLocked: 403,
+			UnknownLogout: 406,
+			ClientOutdated: 405,
+			BadUserAgent: 409,
+			CatExpired: 413,
+			CatInvalid: 414,
+			NotFound: 415,
+			ClientUnknown: 418,
+			InternalServerError: 500,
+			Experimental: 501,
+			ServiceUnavailable: 503
+		}
+		const named = known[reason]
+		if (named !== undefined) return named
+		const unknown = /^Unknown\((-?\d+)\)$/.exec(reason)?.[1]
+		return unknown === undefined ? undefined : Number(unknown)
+	}
+	const runCompletionError = (completion: RunCompletionResult): Boom => {
+		let statusCode = DisconnectReason.connectionClosed
+		let message = 'Connection closed'
+		if (completion.reason === 'unknown') {
+			message = `Connection run ended: ${completion.detail}`
+		} else if (completion.reason === 'stopped') {
+			message = 'Connection run stopped'
+		} else if (completion.reason === 'already-running') {
+			message = 'Connection run was already running'
+		} else if (completion.reason === 'auto-reconnect-disabled') {
+			const protocol = completion.protocolError
+			if (protocol?.kind === 'conflict') {
+				statusCode = DisconnectReason.connectionReplaced
+				message = 'Connection replaced'
+			} else if (protocol?.kind === 'stream-error') {
+				statusCode = mapConnectFailureToDisconnect(protocol.code)
+			} else if (protocol?.kind === 'connect-failure') {
+				statusCode = mapConnectFailureToDisconnect(completionFailureCode(protocol.reason))
+			} else if (completion.connection?.kind === 'server-close') {
+				message = completion.connection.reason
+			}
+		}
+		return new Boom(message, { statusCode, data: { runCompletion: completion } })
+	}
+	const reportTerminalClose = (error: Error, publish: () => void) =>
+		terminalClose.reportAfter(() => owner.close(error).finally(() => initPromise), publish)
 	/**
 	 * Held in a reporter rather than captured, because `sock.onUnexpectedError`
 	 * is an assignable property: a consumer that replaces it has to be the one
@@ -437,7 +487,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 			// is still owned. This waits for the real teardown, and cannot
 			// deadlock because `reportAfter` runs it detached; nothing in the
 			// teardown is waiting on this.
-			terminalClose.reportAfter(() => owner.close(error).finally(() => initPromise), publish)
+			reportTerminalClose(error, publish)
 		},
 		isAutoReconnectEnabled: () => autoReconnectEnabled,
 		// Timers the dispatcher armed outlive the events that armed them, and
@@ -585,23 +635,46 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// starting the read loop now would run against a handle about to go.
 		if (owner.isClosing()) return
 
-		// `run()` spawns the connect/handshake/read/reconnect loop as a
-		// background task and returns `void` — it deliberately is not `async`,
-		// so that it does not hold a wasm-bindgen borrow on `self` that would
-		// block `disconnect()`.
-		//
-		// Consequence: the loop's exit is not observable from here. The engine
-		// clears `enable_auto_reconnect` and breaks out on every terminal
-		// disconnect (conflict/401/409/516, and any `<failure>` whose reason is
-		// not 500/503), and when it does, the `WasmWhatsAppClient` is dead
-		// weight that only `sock.end()` can free — nothing else can, because
-		// the bridge holds the JS event callbacks as wasm-bindgen externrefs,
-		// those close over `ctx`, and `ctx` closes over `client`, so the cycle
-		// crosses the JS/wasm boundary and no `FinalizationRegistry` fires.
-		// Freeing that automatically needs the bridge to expose loop completion
-		// (a terminal callback or an awaitable handle); until it does, the
-		// consumer has to call `sock.end()` on a terminal close.
+		// `run()` deliberately returns immediately so callers can use the
+		// client while supervision owns its background task. Registering the
+		// completion observer after it is started is safe: bridge 0.21.0 admits
+		// late observers against the stored result for this run generation.
 		created.run()
+		const observedClient = created
+		void created
+			.waitForRunCompletion()
+			.then(
+				completion => {
+					// The owner identity is the socket generation fence. A completion
+					// from a client that teardown already released must never close a
+					// later socket using the same auth state.
+					if (owner.isClosing() || owner.peek() !== observedClient) return
+					const error = runCompletionError(completion)
+					reportTerminalClose(error, () =>
+						ev.emit('connection.update', {
+							connection: 'close',
+							lastDisconnect: { error, date: new Date() }
+						} as Partial<ConnectionState>)
+					)
+				},
+				error => {
+					if (owner.isClosing() || owner.peek() !== observedClient) return
+					logger.error({ err: error }, 'bridge run completion observation failed')
+					const closeError = new Boom('Connection run ended without a completion result', {
+						statusCode: DisconnectReason.connectionClosed
+					})
+					reportTerminalClose(closeError, () =>
+						ev.emit('connection.update', {
+							connection: 'close',
+							lastDisconnect: { error: closeError, date: new Date() }
+						} as Partial<ConnectionState>)
+					)
+				}
+			)
+			.catch(() => {
+				// The reporter contains teardown and publish failures; this final guard
+				// also contains a consumer logger that throws from an observation path.
+			})
 		initialized = true
 	}
 

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -104,6 +104,30 @@ const browserToPlatformType = (browser: string): DevicePlatformType => {
 	}
 }
 
+const COMPLETION_FAILURE_CODES = new Map<string, number>([
+	['Generic', 400],
+	['LoggedOut', 401],
+	['TempBanned', 402],
+	['AccountLocked', 403],
+	['UnknownLogout', 406],
+	['ClientOutdated', 405],
+	['BadUserAgent', 409],
+	['CatExpired', 413],
+	['CatInvalid', 414],
+	['NotFound', 415],
+	['ClientUnknown', 418],
+	['InternalServerError', 500],
+	['Experimental', 501],
+	['ServiceUnavailable', 503]
+])
+
+const completionFailureCode = (reason: string): number | undefined => {
+	const named = COMPLETION_FAILURE_CODES.get(reason)
+	if (named !== undefined) return named
+	const unknown = /^Unknown\((-?\d+)\)$/.exec(reason)?.[1]
+	return unknown === undefined ? undefined : Number(unknown)
+}
+
 /** Build the ws EventEmitter with auto-enable raw node forwarding */
 const makeWASocket = (config: UserFacingSocketConfig) => {
 	const fullConfig = { ...DEFAULT_CONNECTION_CONFIG, ...config }
@@ -298,28 +322,6 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	let autoReconnectEnabled = true
 	/** Owns reporting the terminal close: once, after teardown, never not at all. */
 	const terminalClose = makeTerminalCloseReporter({ logger })
-	const completionFailureCode = (reason: string): number | undefined => {
-		const known: Record<string, number> = {
-			Generic: 400,
-			LoggedOut: 401,
-			TempBanned: 402,
-			AccountLocked: 403,
-			UnknownLogout: 406,
-			ClientOutdated: 405,
-			BadUserAgent: 409,
-			CatExpired: 413,
-			CatInvalid: 414,
-			NotFound: 415,
-			ClientUnknown: 418,
-			InternalServerError: 500,
-			Experimental: 501,
-			ServiceUnavailable: 503
-		}
-		const named = known[reason]
-		if (named !== undefined) return named
-		const unknown = /^Unknown\((-?\d+)\)$/.exec(reason)?.[1]
-		return unknown === undefined ? undefined : Number(unknown)
-	}
 	const runCompletionError = (completion: RunCompletionResult): Boom => {
 		let statusCode = DisconnectReason.connectionClosed
 		let message = 'Connection closed'
@@ -659,7 +661,6 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 				},
 				error => {
 					if (owner.isClosing() || owner.peek() !== observedClient) return
-					logger.error({ err: error }, 'bridge run completion observation failed')
 					const closeError = new Boom('Connection run ended without a completion result', {
 						statusCode: DisconnectReason.connectionClosed
 					})
@@ -669,6 +670,11 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 							lastDisconnect: { error: closeError, date: new Date() }
 						} as Partial<ConnectionState>)
 					)
+					try {
+						logger.error({ err: error }, 'bridge run completion observation failed')
+					} catch {
+						// A consumer logger cannot prevent the terminal cleanup above.
+					}
 				}
 			)
 			.catch(() => {

--- a/src/Socket/terminal-close.ts
+++ b/src/Socket/terminal-close.ts
@@ -1,3 +1,5 @@
+import { DisconnectReason } from '../Types/index.ts'
+
 /**
  * Which bridge disconnects end the socket for good.
  *
@@ -6,11 +8,10 @@
  * on exactly these, and retries everything else on the WA Web Fibonacci backoff
  * (`client/lifecycle.rs`).
  *
- * The socket layer needs the answer because `WasmWhatsAppClient.run()` returns
- * `void` — it spawns the loop as a background task, so the loop's exit is not
- * observable from JS (`whatsapp_rust_bridge.d.ts`, `run(): void`). Until the
- * bridge exposes loop completion, this table is how the socket knows a client
- * has become dead weight that only `free()` can reclaim.
+ * The socket layer needs the answer for bridge events that classify a terminal
+ * close before the supervised run completion is observed. Bridge 0.21.0 also
+ * exposes `waitForRunCompletion()` for exits with no terminal event; that
+ * observer uses the same terminal-close reporter and owner as this table.
  *
  * The upstream Baileys contract this buys us: `connection.update { close }`
  * means "this socket is finished, build a new one" — which is what every
@@ -51,3 +52,28 @@ const RECONNECTABLE_CONNECT_FAILURE_REASONS: ReadonlySet<number> = new Set([
 /** True when the engine will keep retrying after this `<failure>`. */
 export const isReconnectableConnectFailure = (reason: number | undefined): boolean =>
 	reason !== undefined && RECONNECTABLE_CONNECT_FAILURE_REASONS.has(reason)
+
+/** Map a typed bridge connect-failure code to Baileys' close status. */
+export const mapConnectFailureToDisconnect = (reason: number | undefined): number => {
+	switch (reason) {
+		case 401:
+		case 403:
+		case 406:
+			return DisconnectReason.loggedOut
+		case 402:
+			return DisconnectReason.forbidden
+		case 405:
+			return 405
+		case 411:
+			return DisconnectReason.multideviceMismatch
+		case 503:
+		case 501:
+			return DisconnectReason.unavailableService
+		case 408:
+			return DisconnectReason.timedOut
+		case 515:
+			return DisconnectReason.restartRequired
+		default:
+			return DisconnectReason.connectionClosed
+	}
+}

--- a/src/__tests__/cert-chain-verify-plumbing.test.ts
+++ b/src/__tests__/cert-chain-verify-plumbing.test.ts
@@ -132,7 +132,6 @@ describe('cert chain verification bypass plumbing', { timeout: 60_000 }, () => {
 					...(flag === undefined ? {} : { dangerSkipCertChainVerify: flag })
 				})
 				try {
-					sock.setAutoReconnect(false)
 					for (let i = 0; i < 100 && !sock.waClient; i++) await delay(50)
 					expect(Boolean(sock.waClient)).toBe(true)
 				} finally {

--- a/src/__tests__/run-completion-lifecycle.test.ts
+++ b/src/__tests__/run-completion-lifecycle.test.ts
@@ -1,0 +1,169 @@
+import { createServer } from 'node:net'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, describe, it } from 'node:test'
+import P from 'pino'
+
+import makeWASocket from '../Socket/index.ts'
+import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
+import { expect } from './expect.ts'
+
+const silentLogger = P({ level: 'silent' })
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+describe('run completion lifecycle adoption', { timeout: 30_000 }, () => {
+	let authFolder: string
+
+	before(async () => {
+		authFolder = await mkdtemp(join(tmpdir(), 'baileyrs-run-completion-'))
+	})
+
+	after(async () => {
+		await rm(authFolder, { recursive: true, force: true })
+	})
+
+	it('owns and reports a spontaneous supervised-run exit', async () => {
+		let releaseConnection!: () => void
+		const connectionGate = new Promise<void>(resolve => {
+			releaseConnection = resolve
+		})
+		let acceptConnection!: () => void
+		const connectionAccepted = new Promise<void>(resolve => {
+			acceptConnection = resolve
+		})
+		const server = createServer(socket => {
+			socket.on('error', () => {})
+			acceptConnection()
+			void connectionGate.then(() => socket.destroy())
+		})
+		await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+		const address = server.address()
+		if (!address || typeof address === 'string') throw new Error('expected a local TCP address')
+
+		let sock: ReturnType<typeof makeWASocket> | undefined
+		let releaseFlush!: () => void
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			const flushGate = new Promise<void>(resolve => {
+				releaseFlush = resolve
+			})
+			let flushStarted!: () => void
+			const flushStartedGate = new Promise<void>(resolve => {
+				flushStarted = resolve
+			})
+			const store = new Proxy(state.store as object, {
+				get(target, property, receiver) {
+					const value = Reflect.get(target, property, receiver)
+					if (property !== 'flush' || typeof value !== 'function') return value
+					return async (...args: unknown[]) => {
+						flushStarted()
+						await flushGate
+						return (value as (...values: unknown[]) => unknown).apply(target, args)
+					}
+				}
+			}) as typeof state.store
+			sock = makeWASocket({
+				auth: { ...state, store },
+				logger: silentLogger,
+				waWebSocketUrl: `ws://127.0.0.1:${address.port}`
+			})
+			sock.setAutoReconnect(false)
+			await connectionAccepted
+
+			let client: NonNullable<typeof sock.waClient> | undefined
+			for (let attempt = 0; attempt < 100 && !client; attempt++) {
+				client = sock.waClient
+				if (!client) await wait(20)
+			}
+			if (!client) throw new Error('bridge client did not finish startup')
+
+			let closes = 0
+			const closePublished = new Promise<void>((resolve, reject) => {
+				const timeout = setTimeout(() => reject(new Error('spontaneous run exit was not reported')), 5_000)
+				sock!.ev.on('connection.update', update => {
+					if (update.connection !== 'close') return
+					closes++
+					clearTimeout(timeout)
+					resolve()
+				})
+			})
+			const first = client.waitForRunCompletion()
+			const second = client.waitForRunCompletion()
+			releaseConnection()
+			const completion = await first
+			expect(completion.reason).toBe('auto-reconnect-disabled')
+			expect(completion.generation).toBe(0)
+			expect(await second).toEqual(completion)
+			expect(await client.waitForRunCompletion()).toEqual(completion)
+			await flushStartedGate
+			releaseFlush()
+			await closePublished
+
+			expect(closes).toBe(1)
+			expect(sock.waClient).toBeUndefined()
+		} finally {
+			releaseConnection()
+			releaseFlush()
+			await sock?.end(undefined).catch(() => {})
+			await new Promise<void>(resolve => server.close(() => resolve()))
+		}
+	})
+
+	it('lets an explicit end own a concurrent run completion', async () => {
+		let releaseConnection!: () => void
+		const connectionGate = new Promise<void>(resolve => {
+			releaseConnection = resolve
+		})
+		let acceptConnection!: () => void
+		const connectionAccepted = new Promise<void>(resolve => {
+			acceptConnection = resolve
+		})
+		const server = createServer(socket => {
+			socket.on('error', () => {})
+			acceptConnection()
+			void connectionGate.then(() => socket.destroy())
+		})
+		await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+		const address = server.address()
+		if (!address || typeof address === 'string') throw new Error('expected a local TCP address')
+
+		let sock: ReturnType<typeof makeWASocket> | undefined
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			sock = makeWASocket({
+				auth: state,
+				logger: silentLogger,
+				waWebSocketUrl: `ws://127.0.0.1:${address.port}`
+			})
+			sock.setAutoReconnect(false)
+			await connectionAccepted
+
+			let client: NonNullable<typeof sock.waClient> | undefined
+			for (let attempt = 0; attempt < 100 && !client; attempt++) {
+				client = sock.waClient
+				if (!client) await wait(20)
+			}
+			if (!client) throw new Error('bridge client did not finish startup')
+
+			let closes = 0
+			sock.ev.on('connection.update', update => {
+				if (update.connection === 'close') closes++
+			})
+			const completion = client.waitForRunCompletion()
+			const ending = sock.end(undefined)
+			releaseConnection()
+			const result = await completion
+			expect(result.reason).toBe('shutdown-requested')
+			await ending
+			await wait(100)
+
+			expect(closes).toBe(0)
+			expect(sock.waClient).toBeUndefined()
+		} finally {
+			releaseConnection()
+			await sock?.end(undefined).catch(() => {})
+			await new Promise<void>(resolve => server.close(() => resolve()))
+		}
+	})
+})

--- a/src/__tests__/run-completion-lifecycle.test.ts
+++ b/src/__tests__/run-completion-lifecycle.test.ts
@@ -10,7 +10,6 @@ import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
 import { expect } from './expect.ts'
 
 const silentLogger = P({ level: 'silent' })
-const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 describe('run completion lifecycle adoption', { timeout: 30_000 }, () => {
 	let authFolder: string
@@ -71,11 +70,7 @@ describe('run completion lifecycle adoption', { timeout: 30_000 }, () => {
 			sock.setAutoReconnect(false)
 			await connectionAccepted
 
-			let client: NonNullable<typeof sock.waClient> | undefined
-			for (let attempt = 0; attempt < 100 && !client; attempt++) {
-				client = sock.waClient
-				if (!client) await wait(20)
-			}
+			const client = sock.waClient
 			if (!client) throw new Error('bridge client did not finish startup')
 
 			let closes = 0
@@ -139,11 +134,7 @@ describe('run completion lifecycle adoption', { timeout: 30_000 }, () => {
 			sock.setAutoReconnect(false)
 			await connectionAccepted
 
-			let client: NonNullable<typeof sock.waClient> | undefined
-			for (let attempt = 0; attempt < 100 && !client; attempt++) {
-				client = sock.waClient
-				if (!client) await wait(20)
-			}
+			const client = sock.waClient
 			if (!client) throw new Error('bridge client did not finish startup')
 
 			let closes = 0
@@ -156,7 +147,6 @@ describe('run completion lifecycle adoption', { timeout: 30_000 }, () => {
 			const result = await completion
 			expect(result.reason).toBe('shutdown-requested')
 			await ending
-			await wait(100)
 
 			expect(closes).toBe(0)
 			expect(sock.waClient).toBeUndefined()

--- a/src/__tests__/run-completion-lifecycle.test.ts
+++ b/src/__tests__/run-completion-lifecycle.test.ts
@@ -4,12 +4,27 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { after, before, describe, it } from 'node:test'
 import P from 'pino'
+import { WasmWhatsAppClient } from '@oxidezap/whatsapp-rust-bridge'
 
 import makeWASocket from '../Socket/index.ts'
+import { DisconnectReason } from '../Types/index.ts'
 import { useMultiFileAuthState } from '../Utils/use-multi-file-auth-state.ts'
+import type { ILogger } from '../Utils/logger.ts'
 import { expect } from './expect.ts'
 
 const silentLogger = P({ level: 'silent' })
+const throwingErrorLogger = {
+	trace() {},
+	debug() {},
+	info() {},
+	warn() {},
+	error() {
+		throw new Error('logger failed')
+	},
+	child() {
+		return throwingErrorLogger
+	}
+} as unknown as ILogger
 
 describe('run completion lifecycle adoption', { timeout: 30_000 }, () => {
 	let authFolder: string
@@ -152,6 +167,94 @@ describe('run completion lifecycle adoption', { timeout: 30_000 }, () => {
 			expect(sock.waClient).toBeUndefined()
 		} finally {
 			releaseConnection()
+			await sock?.end(undefined).catch(() => {})
+			await new Promise<void>(resolve => server.close(() => resolve()))
+		}
+	})
+
+	it('cleans up a rejected completion even when the logger throws', async () => {
+		const originalWait = WasmWhatsAppClient.prototype.waitForRunCompletion
+		WasmWhatsAppClient.prototype.waitForRunCompletion = () => Promise.reject(new Error('observation failed'))
+		const server = createServer(socket => {
+			socket.on('error', () => {})
+			socket.destroy()
+		})
+		await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+		const address = server.address()
+		if (!address || typeof address === 'string') throw new Error('expected a local TCP address')
+
+		let sock: ReturnType<typeof makeWASocket> | undefined
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			sock = makeWASocket({
+				auth: state,
+				logger: throwingErrorLogger,
+				waWebSocketUrl: `ws://127.0.0.1:${address.port}`
+			})
+			let closes = 0
+			const closePublished = new Promise<void>((resolve, reject) => {
+				const timeout = setTimeout(() => reject(new Error('rejected completion was not reported')), 5_000)
+				sock!.ev.on('connection.update', update => {
+					if (update.connection !== 'close') return
+					closes++
+					clearTimeout(timeout)
+					resolve()
+				})
+			})
+
+			await closePublished
+			expect(closes).toBe(1)
+			expect(sock.waClient).toBeUndefined()
+		} finally {
+			WasmWhatsAppClient.prototype.waitForRunCompletion = originalWait
+			await sock?.end(undefined).catch(() => {})
+			await new Promise<void>(resolve => server.close(() => resolve()))
+		}
+	})
+
+	it('maps a completion cause when it wins the terminal event race', async () => {
+		const originalWait = WasmWhatsAppClient.prototype.waitForRunCompletion
+		WasmWhatsAppClient.prototype.waitForRunCompletion = () =>
+			Promise.resolve({
+				reason: 'auto-reconnect-disabled',
+				generation: 0,
+				protocolError: { kind: 'conflict' }
+			} as never)
+		const server = createServer(socket => {
+			socket.on('error', () => {})
+			socket.destroy()
+		})
+		await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+		const address = server.address()
+		if (!address || typeof address === 'string') throw new Error('expected a local TCP address')
+
+		let sock: ReturnType<typeof makeWASocket> | undefined
+		try {
+			const { state } = await useMultiFileAuthState(authFolder)
+			sock = makeWASocket({
+				auth: state,
+				logger: silentLogger,
+				waWebSocketUrl: `ws://127.0.0.1:${address.port}`
+			})
+			const close = new Promise<Error>((resolve, reject) => {
+				const timeout = setTimeout(() => reject(new Error('typed completion was not reported')), 5_000)
+				sock!.ev.on('connection.update', update => {
+					if (update.connection !== 'close') return
+					clearTimeout(timeout)
+					resolve(update.lastDisconnect!.error!)
+				})
+			})
+
+			const error = await close
+			expect((error as { output?: { statusCode?: number } }).output?.statusCode).toBe(
+				DisconnectReason.connectionReplaced
+			)
+			expect(
+				(error as { data?: { runCompletion?: { protocolError?: { kind?: string } } } }).data?.runCompletion
+					?.protocolError?.kind
+			).toBe('conflict')
+		} finally {
+			WasmWhatsAppClient.prototype.waitForRunCompletion = originalWait
 			await sock?.end(undefined).catch(() => {})
 			await new Promise<void>(resolve => server.close(() => resolve()))
 		}


### PR DESCRIPTION
## Problem

Baileyrs started the bridge supervision loop with `run()` but never observed its completion. A reconnect-disabled or otherwise spontaneous loop exit could leave the bridge client owned indefinitely without a terminal `connection.update`, while the existing terminal event and logout paths already had idempotent teardown rules.

## Change

- Observe bridge 0.21.0 `waitForRunCompletion()` on the exact adopted client.
- Route spontaneous completion through the existing terminal-close reporter and `BridgeClientOwner`, preserving one close and one release per socket.
- Fence observations by owner state and client identity so explicit `end()`/`logout()`, late startup admission, and stale callbacks cannot affect another socket.
- Preserve typed completion causes in the terminal Boom data and reuse Baileys disconnect status mapping.
- Keep bridge run completion separate from full host teardown; late and concurrent observers are covered while teardown is gated.

## Validation

- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test` — 1,499 passed, 1 skipped
- Focused lifecycle and cert plumbing tests — 14 passed

The tests use only fictitious local TCP endpoints and temporary auth state. No package release, merge, or deployment is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Observes bridge run completion so a spontaneous supervision-loop exit now emits a terminal close and releases the bridge client, instead of leaving the socket owned indefinitely.

- Routes spontaneous completion through the existing terminal-close reporter and `BridgeClientOwner`, preserving one close and one release per socket.
- Fences observations by owner state and client identity so explicit `end()`/`logout()`, late startup admission, and stale callbacks can't affect another socket.
- Preserves typed completion causes in the terminal `Boom` data and reuses the Baileys disconnect status mapping.
- Keeps bridge run completion separate from full host teardown; late and concurrent observers are covered while teardown is gated.
- Moves `mapConnectFailureToDisconnect` into `terminal-close.ts` and drops a now-redundant `setAutoReconnect(false)` from a cert plumbing test.
- Adds lifecycle tests for spontaneous exit ownership, explicit `end()` racing a completion, and cleanup when the run observer rejects even if a consumer logger throws.

<sup>Written for commit 92d0c1dd8c5f61db1c5bc7fb4ab1e0e1866b3fbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpected bridge shutdowns so connection closure events are reported consistently.
  * Preserved protocol error details and mapped connection failures to appropriate disconnect statuses.
  * Prevented duplicate close notifications when shutdown and terminal events occur at the same time.
  * Ensured connection state and authentication resources are cleaned up after supervised runs complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->