### PR TITLE
test(lifecycle): type completion fixture

### DIFF
--- a/src/__tests__/run-completion-lifecycle.test.ts
+++ b/src/__tests__/run-completion-lifecycle.test.ts
@@ -214,12 +214,12 @@ describe('run completion lifecycle adoption', { timeout: 30_000 }, () => {
 
 	it('maps a completion cause when it wins the terminal event race', async () => {
 		const originalWait = WasmWhatsAppClient.prototype.waitForRunCompletion
-		WasmWhatsAppClient.prototype.waitForRunCompletion = () =>
-			Promise.resolve({
-				reason: 'auto-reconnect-disabled',
-				generation: 0,
-				protocolError: { kind: 'conflict' }
-			} as never)
+		const completion: Awaited<ReturnType<WasmWhatsAppClient['waitForRunCompletion']>> = {
+			reason: 'auto-reconnect-disabled',
+			generation: 0,
+			protocolError: { kind: 'conflict' }
+		}
+		WasmWhatsAppClient.prototype.waitForRunCompletion = () => Promise.resolve(completion)
 		const server = createServer(socket => {
 			socket.on('error', () => {})
 			socket.destroy()


### PR DESCRIPTION
Types the mocked run completion with the installed bridge return type and removes the never cast. Tests: node --test src/__tests__/run-completion-lifecycle.test.ts; npx tsc --noEmit -p tsconfig.json --pretty false; npx oxfmt --check src/__tests__/run-completion-lifecycle.test.ts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Types the mocked run completion in the lifecycle test with the installed bridge's return type instead of casting it as `never`. This makes the test fixture type-checked against the real API and removes the unsafe cast.

<sup>Written for commit 099ccaa580b401e5a0cd1fad4b3ce3621234d14b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test type safety and readability for run-completion lifecycle coverage.
  - Preserved verification that completion causes are correctly mapped when terminal events race.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->