### PR TITLE
fix(socket): accept bare join success in groupAcceptInviteV4

### DIFF
--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -48,6 +48,26 @@ export type JoinApprovalMode = (typeof JOIN_APPROVAL_MODES)[number]
 // forms, and reconstructs the high word instead of dropping it.
 const inviteExpirationNumber = (value: proto.Message.IGroupInviteMessage['inviteExpiration']): number => toNumber(value)
 
+// The core's V4 join parser only accepts a `<group>`, `<community>` or
+// `<membership_approval_request>` child, but the server also answers a
+// successful join with a bare `<iq type="result">` (WA Web's own
+// `AcceptGroupAddResponseSuccess` variant requires no child at all — only the
+// result envelope whose `from` echoes the request's `to`). The core reports
+// that shape as an `IqError::ParseError`, which the bridge surfaces as
+// `kind: 'internal'`. Error stanzas never reach the parser (they become
+// `kind: 'server'` one layer below), so this substring can only mean the join
+// was accepted and the JID carrier is missing — never a rejection.
+const BARE_JOIN_SUCCESS_FRAGMENT = 'expected <group>, <community>, or <membership_approval_request> in join response'
+
+// A bare `<iq type="result">` join success, as described above. Anything else
+// (server rejections, timeouts, transport loss) must keep propagating.
+const isBareJoinSuccess = (error: unknown): boolean => {
+	if (!(error instanceof Error) || error.name !== 'WhatsAppError') return false
+	const kind = (error as { kind?: unknown }).kind
+	if (kind !== 'internal' && kind !== 'protocol-violation') return false
+	return typeof error.message === 'string' && error.message.includes(BARE_JOIN_SUCCESS_FRAGMENT)
+}
+
 export const makeGroupMethods = (ctx: SocketContext) => {
 	const groupMetadata = async (jid: string): Promise<GroupMetadata> => {
 		const metadata = await (await ctx.getClient()).getGroupMetadata(jid)
@@ -67,18 +87,28 @@ export const makeGroupMethods = (ctx: SocketContext) => {
 			// oxlint-disable-next-line typescript/no-explicit-any -- the established public contract returns Promise<any>.
 		): Promise<any> => {
 			const messageKey = typeof key === 'string' ? { remoteJid: key } : key
-			if (!inviteMessage.groupJid || !inviteMessage.inviteCode || !messageKey.remoteJid) {
+			const groupJid = inviteMessage.groupJid
+			if (!groupJid || !inviteMessage.inviteCode || !messageKey.remoteJid) {
 				throw new TypeError('groupAcceptInviteV4 requires groupJid, inviteCode and inviter JID')
 			}
 
-			const joinedJid = await (
-				await ctx.getClient()
-			).groupAcceptInviteV4(
-				inviteMessage.groupJid,
-				inviteMessage.inviteCode,
-				inviteExpirationNumber(inviteMessage.inviteExpiration),
-				messageKey.remoteJid
-			)
+			let joinedJid: string
+			try {
+				joinedJid = await (
+					await ctx.getClient()
+				).groupAcceptInviteV4(
+					groupJid,
+					inviteMessage.inviteCode,
+					inviteExpirationNumber(inviteMessage.inviteExpiration),
+					messageKey.remoteJid
+				)
+			} catch (error) {
+				// The join was accepted but the response carried no JID node.
+				// Baileys returns the envelope's `from` here, which echoes the
+				// request's `to` — the group JID we already hold.
+				if (!isBareJoinSuccess(error)) throw error
+				joinedJid = groupJid
+			}
 
 			if (messageKey.id) {
 				const expiredInvite = proto.Message.GroupInviteMessage.fromObject(inviteMessage)

--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -60,11 +60,12 @@ const inviteExpirationNumber = (value: proto.Message.IGroupInviteMessage['invite
 const BARE_JOIN_SUCCESS_FRAGMENT = 'expected <group>, <community>, or <membership_approval_request> in join response'
 
 // A bare `<iq type="result">` join success, as described above. Anything else
-// (server rejections, timeouts, transport loss) must keep propagating.
+// (server rejections, timeouts, transport loss, protocol violations) must keep
+// propagating.
 const isBareJoinSuccess = (error: unknown): boolean => {
 	if (!(error instanceof Error) || error.name !== 'WhatsAppError') return false
 	const kind = (error as { kind?: unknown }).kind
-	if (kind !== 'internal' && kind !== 'protocol-violation') return false
+	if (kind !== 'internal') return false
 	return typeof error.message === 'string' && error.message.includes(BARE_JOIN_SUCCESS_FRAGMENT)
 }
 

--- a/src/__tests__/group-operations-compatibility.test.ts
+++ b/src/__tests__/group-operations-compatibility.test.ts
@@ -112,8 +112,9 @@ describe('group operation compatibility', () => {
 	})
 
 	// Only the bare-success shape falls back. Genuine failures — server
-	// rejections and unrelated internal errors — must keep propagating by
-	// identity, with no lifecycle side effects.
+	// rejections, unrelated internal errors, and protocol violations even when
+	// they carry the same fragment — must keep propagating by identity, with
+	// no lifecycle side effects.
 	it('rethrows V4 join failures that are not a bare success', async () => {
 		const rejections = [
 			Object.assign(new Error('server error 403: forbidden'), {
@@ -125,7 +126,13 @@ describe('group operation compatibility', () => {
 			Object.assign(new Error('internal: something else broke'), {
 				name: 'WhatsAppError',
 				kind: 'internal'
-			})
+			}),
+			Object.assign(
+				new Error(
+					'protocol violation: expected <group>, <community>, or <membership_approval_request> in join response'
+				),
+				{ name: 'WhatsAppError', kind: 'protocol-violation' }
+			)
 		]
 		for (const rejection of rejections) {
 			const ev = Object.assign(new EventEmitter(), {

--- a/src/__tests__/group-operations-compatibility.test.ts
+++ b/src/__tests__/group-operations-compatibility.test.ts
@@ -63,6 +63,104 @@ describe('group operation compatibility', () => {
 		])
 	})
 
+	// The server also answers an accepted V4 join with a bare
+	// `<iq type="result">` (no `<group>`/`<community>`/
+	// `<membership_approval_request>` child). The core surfaces that shape as
+	// an internal parse error even though the join succeeded; Baileys returns
+	// the envelope's `from` there, which echoes the request's `to`, so this
+	// layer answers with the requested group JID and still runs the buffered
+	// lifecycle instead of rejecting (issue #114).
+	it('answers a bare join success with the group JID and keeps the buffered lifecycle', async () => {
+		const ev = Object.assign(new EventEmitter(), {
+			createBufferedFunction: <Args extends unknown[], Result>(work: (...args: Args) => Promise<Result>) => work
+		})
+		const updates: unknown[] = []
+		const upserts: unknown[] = []
+		ev.on('messages.update', value => updates.push(value))
+		ev.on('messages.upsert', value => upserts.push(value))
+		const calls: unknown[][] = []
+		const bareSuccess = Object.assign(
+			new Error(
+				'failed to parse IQ response: expected <group>, <community>, or <membership_approval_request> in join response'
+			),
+			{ name: 'WhatsAppError', kind: 'internal' }
+		)
+		const client = {
+			groupAcceptInviteV4: async (...args: unknown[]) => {
+				calls.push(args)
+				throw bareSuccess
+			}
+		} as unknown as WasmWhatsAppClient
+		const ctx = {
+			ev,
+			getClient: async () => client,
+			getUser: () => ({ id: 'bot@s.whatsapp.net', lid: 'bot@lid' }),
+			getMe: () => ({ id: 'bot@s.whatsapp.net', lid: 'bot@lid', name: 'Bot' })
+		} as unknown as SocketContext
+
+		const result = await makeGroupMethods(ctx).groupAcceptInviteV4(
+			{ remoteJid: 'inviter@lid', id: 'invite-message-id', fromMe: false },
+			{ groupJid: 'parent@g.us', inviteCode: 'INVITE', inviteExpiration: 1_800_000_000 }
+		)
+
+		assert.equal(result, 'parent@g.us')
+		assert.deepEqual(calls, [['parent@g.us', 'INVITE', 1_800_000_000, 'inviter@lid']])
+		assert.equal(updates.length, 1)
+		assert.equal(upserts.length, 1)
+		const upsert = upserts[0] as { type: string }
+		assert.equal(upsert.type, 'notify')
+	})
+
+	// Only the bare-success shape falls back. Genuine failures — server
+	// rejections and unrelated internal errors — must keep propagating by
+	// identity, with no lifecycle side effects.
+	it('rethrows V4 join failures that are not a bare success', async () => {
+		const rejections = [
+			Object.assign(new Error('server error 403: forbidden'), {
+				name: 'WhatsAppError',
+				kind: 'server',
+				serverCode: 403,
+				serverText: 'forbidden'
+			}),
+			Object.assign(new Error('internal: something else broke'), {
+				name: 'WhatsAppError',
+				kind: 'internal'
+			})
+		]
+		for (const rejection of rejections) {
+			const ev = Object.assign(new EventEmitter(), {
+				createBufferedFunction: <Args extends unknown[], Result>(work: (...args: Args) => Promise<Result>) => work
+			})
+			const updates: unknown[] = []
+			const upserts: unknown[] = []
+			ev.on('messages.update', value => updates.push(value))
+			ev.on('messages.upsert', value => upserts.push(value))
+			const client = {
+				groupAcceptInviteV4: async () => {
+					throw rejection
+				}
+			} as unknown as WasmWhatsAppClient
+			const ctx = {
+				ev,
+				getClient: async () => client,
+				getUser: () => ({ id: 'bot@s.whatsapp.net', lid: 'bot@lid' }),
+				getMe: () => ({ id: 'bot@s.whatsapp.net', lid: 'bot@lid', name: 'Bot' })
+			} as unknown as SocketContext
+
+			const thrown = await makeGroupMethods(ctx)
+				.groupAcceptInviteV4(
+					{ remoteJid: 'inviter@lid', id: 'invite-message-id', fromMe: false },
+					{ groupJid: 'parent@g.us', inviteCode: 'INVITE', inviteExpiration: 1_800_000_000 }
+				)
+				.then(() => undefined)
+				.catch((err: unknown) => err)
+
+			assert.equal(thrown, rejection, 'the original error object must survive')
+			assert.equal(updates.length, 0)
+			assert.equal(upserts.length, 0)
+		}
+	})
+
 	// The `prev` conflict token that makes an update of an existing description
 	// work is resolved by the core; this side only has to hand the description
 	// over untouched, including the `undefined` that means "delete".


### PR DESCRIPTION
## Scope

Owns only `src/Socket/groups.ts` (`groupAcceptInviteV4` path) and two regression cases in `src/__tests__/group-operations-compatibility.test.ts`. No bridge pin change, no dispatcher, schema, store, or compat-surface change; the public signature stays `(key, inviteMessage) => Promise<any>`. Fixes #114.

## Problem (reproduced, not assumed)

`groupAcceptInviteV4` joined the group server-side and then rejected with:

```
WhatsAppError: failed to parse IQ response: expected <group>, <community>, or <membership_approval_request> in join response
```

Reproduced locally with an ephemeral script mocking the bridge client to reject with that exact chain: the call rejected and emitted neither `messages.update` nor `messages.upsert` (script removed after use).

## Root cause (verified against primary sources, not assumed)

- Upstream Baileys (`node_modules/baileys/lib/Socket/groups.js`, `groupAcceptInviteV4`) never parses children: it returns `results.attrs.from`, so a bare `<iq type=result>` resolves with the group JID.
- The official WA Web bundle (whatspec `.wa-cache`, `WASmaxGroupsAcceptGroupAddRPC`) has an `AcceptGroupAddResponseSuccess` variant that requires only the result envelope — no child — while `...GroupJoinRequestSuccess` requires `<membership_approval_request>`. A bare result is a success there.
- The Rust core (`wacore/src/iq/groups.rs::parse_join_group_response`) demands a `<group>`/`<community>`/`<membership_approval_request>` child, so a bare success becomes `IqError::ParseError`, surfaced by the bridge as `kind: 'internal'`.
- Error stanzas never reach that parser: `execute_prepared` classifies `type=error` into `kind: 'server'` first, and timeouts/disconnects take their own paths. So this internal parse error can only mean the join was accepted and the JID carrier is missing — never a rejection.

## Fix

On exactly that rejection shape (`name: 'WhatsAppError'`, `kind` `internal`/`protocol-violation`, message containing the parser's fragment), answer with the requested `groupJid` — the value Baileys' `results.attrs.from` echoes, since WA Web asserts response `from` == request `to` — and continue through the normal buffered lifecycle (invite expiry update + `GROUP_PARTICIPANT_ADD` upsert). Every other rejection propagates by identity with no side effects.

## Performance cost

Zero on the happy path: one local binding plus a `try` with no `catch` taken (no extra allocation, no extra round-trip, no regex). The matcher (one string `includes` over a constant fragment) runs only on the throw path.

## Type-safety

The validated `groupJid` is hoisted into a narrowed `const groupJid: string` (the protobuf field is `string | null | undefined`), so both the bridge call and the fallback are statically strings; the fallback assigns `let joinedJid: string`, keeping the established `Promise<any>` contract untouched.

## Files

- `src/Socket/groups.ts`: `BARE_JOIN_SUCCESS_FRAGMENT` + `isBareJoinSuccess` guard; `groupAcceptInviteV4` falls back to the requested group JID on a bare join success and otherwise rethrows.
- `src/__tests__/group-operations-compatibility.test.ts`: bare-success resolves with the group JID and keeps update+upsert; server rejections and unrelated internal errors rethrow by identity with no side effects.

## Validation (final SHA `5b5e8af`)

- Fail-before/pass-after: with `groups.ts` restored to `17d774a`, the new bare-success case fails with the exact issue error; with the fix all pass.
- Focused: `group-operations-compatibility` 5/5 pass; related suites (group-metadata, participant-stub, community, error-boundary, event-buffer, server-queries) show only the 2 pre-existing `bridge-rejection-caller-stack` failures, identical on the clean tree.
- `npm run build` passes; `oxfmt`/`oxlint` clean on touched files; `tsc` shows only the 18 pre-existing errors (none in touched files); `compat:audit:missing` shows no new missing/mismatch (`groupAcceptInviteV4` signature unchanged).
- Not run: full `npm test` (exceeds 10 min in this env; fuzz/e2e heavy) and `test:e2e` (no infra).

## Follow-up (not in scope)

The durable fix belongs in `wacore`'s `parse_join_group_response` (accept a bare result, JID from the envelope `from`) plus a bridge bump; this shim is the drop-in-compat layer so bots stop seeing a rejection for a join that succeeded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `groupAcceptInviteV4` rejecting successful joins when the server returns a bare `<iq type="result">` without a `<group>` child, which the core parses as an internal error even though the join succeeded. The method now recognizes that exact shape, falls back to the requested group JID, and continues the normal buffered lifecycle (invite expiry update and participant add). Addresses #114.

- The fallback triggers only on `WhatsAppError` with `kind: 'internal'` carrying the parser's error fragment; `protocol-violation` and all other rejections rethrow unchanged.
- Adds regression tests for the bare-success path and for rejections that must propagate untouched.

<sup>Written for commit 8e3052660517052f850f69905635315c6f394eb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed group invite acceptance when a successful join response is incorrectly reported as a parsing error.
  - Preserved group membership results and lifecycle events for these compatibility cases.
  - Genuine server and unrelated internal errors continue to be reported unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->