### PR TITLE
fix(proto): resolve enum names the bridge codec refuses

### DIFF
--- a/src/Compatibility/encode-proto.ts
+++ b/src/Compatibility/encode-proto.ts
@@ -2,14 +2,18 @@ import { encodeProto } from '@oxidezap/whatsapp-rust-bridge'
 import { repairProtoMessage } from './proto-runtime.ts'
 
 /**
- * `encodeProto`, with the two inputs the bridge codec stopped accepting put back.
+ * `encodeProto`, with the three inputs the bridge codec refuses put back.
  *
  * From 0.8.0 the codec refuses an empty string where the schema declares a
  * 64-bit integer, and an unpaired surrogate in a text field. Both were written
  * before — as `0` and as U+FFFD — and upstream Baileys still encodes both, so a
  * message that used to reach the server would now throw in the caller's face.
- * This is where that is absorbed, so the strict contract stays true of the
- * bridge and the tolerant one stays true of this library.
+ * The codec also refuses enum names where the schema declares an enum
+ * (issue #109: `"NONE"` where an int32 goes on the wire), which upstream's
+ * `fromObject` resolves and its direct `encode` coerces — that repair lives in
+ * `repairProtoMessage`, next to the other two. This is where all three are
+ * absorbed, so the strict contract stays true of the bridge and the tolerant
+ * one stays true of this library.
  *
  * Repair on failure rather than check on write: the ordinary encode is exactly
  * the call it was before, with no scan of any field, and the repair runs only
@@ -22,8 +26,9 @@ export const encodeProtoCompat = (path: string, message: unknown): Uint8Array =>
 	} catch (error) {
 		const repaired = repairProtoMessage(path, message)
 		// Reference equality: nothing was coerced, so the failure is something this
-		// does not explain — an unmodelled type, a number no int64 can hold — and
-		// it has to keep propagating rather than be retried into a second throw.
+		// does not explain — an unmodelled type, a number no int64 can hold, an
+		// unknown enum name — and it has to keep propagating rather than be
+		// retried into a second throw.
 		if (repaired === message) throw error
 		return encodeProto(path, repaired)
 	}

--- a/src/Compatibility/proto-runtime.ts
+++ b/src/Compatibility/proto-runtime.ts
@@ -123,7 +123,7 @@ const UNPAIRED_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBF
 /**
  * Puts back what the codec used to do with an input it now refuses.
  *
- * Two cases, both measured against upstream Baileys, which still encodes both:
+ * Three cases, all measured against upstream Baileys, which still encodes them:
  *
  * - An empty string where the schema declares a 64-bit integer. Every one of the
  *   134 send-path failures this addresses carried exactly `''`; a string that is
@@ -132,6 +132,13 @@ const UNPAIRED_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBF
  * - An unpaired surrogate in a text field, replaced with U+FFFD. That is the
  *   substitution `TextEncoder` used to make, so the bytes are unchanged from what
  *   this library sent before.
+ * - An enum name where the schema declares an enum (issue #109: `"NONE"` where
+ *   an int32 goes on the wire). Upstream's `fromObject` resolves names to numbers
+ *   and its direct `encode` coerces any string with `| 0`, so a caller passing a
+ *   name never sees a throw. The bridge codec accepts only numbers (numeric
+ *   strings aside) and throws `invalid int32: "NONE"`. An unknown name is left to
+ *   throw rather than silenced to `0`: upstream's direct encode would write `0`
+ *   for it, but that puts a value on the wire nobody sent.
  *
  * Returns `item` itself when it has nothing to do, so the caller can tell a
  * repair from a failure it does not understand.
@@ -144,6 +151,34 @@ const repairScalar = (kind: number, item: unknown): unknown => {
 	if (kind !== PROTO_FIELD_KIND.string) return item
 	const replaced = item.replace(UNPAIRED_SURROGATE, '\uFFFD')
 	return replaced === item ? item : replaced
+}
+
+/**
+ * Enum name to wire number, built per enum on the first repair that needs it.
+ *
+ * Only the repair path reads this, and only for a field that actually holds a
+ * string — a message the codec accepts never reaches here, and a numeric enum
+ * never touches a map. Each table is built once from the generated entries and
+ * then reused; an importer that never sends a refused value allocates nothing.
+ * A `Map` (not a plain object) so names like `__proto__` are keys, not hazards.
+ */
+let enumTablesById: Array<Map<string, number> | undefined> | undefined
+const enumValueFor = (enumId: number, name: string): number | undefined => {
+	if (enumId < 0 || enumId >= PROTO_ENUM_SCHEMAS.length) return undefined
+	enumTablesById ??= []
+	let byName = enumTablesById[enumId]
+	if (byName === undefined) {
+		const entries = PROTO_ENUM_SCHEMAS[enumId]?.[1]
+		if (!entries) return undefined
+		byName = new Map<string, number>()
+		for (let index = 0; index < entries.length; index += 2) {
+			const entryName = entries[index]
+			const entryValue = entries[index + 1]
+			if (typeof entryName === 'string' && typeof entryValue === 'number') byName.set(entryName, entryValue)
+		}
+		enumTablesById[enumId] = byName
+	}
+	return byName.get(name)
 }
 
 const longFromWords = (low: number, high: number, unsigned: boolean): Long => LongRuntime.fromBits(low, high, unsigned)
@@ -343,12 +378,13 @@ const schemaIdFor = (path: string): number | undefined => {
 }
 
 /**
- * Coerces the two inputs the bridge codec stopped accepting back to what it
- * used to write, and returns `value` itself when there was nothing to coerce.
+ * Coerces the three inputs the bridge codec refuses back to what upstream
+ * Baileys writes, and returns `value` itself when there was nothing to coerce.
  *
  * Reference equality is the signal: the caller only reaches here after an
  * encode threw, and an unchanged result means the failure was something else
- * — a genuinely invalid number, a missing codec — which must keep propagating.
+ * — a genuinely invalid number, an unknown enum name, a missing codec — which
+ * must keep propagating.
  *
  * Copy-on-write throughout, like `projectForEncode`: a branch with nothing to
  * fix is shared, not rebuilt.
@@ -370,8 +406,14 @@ const repairMessage = (schemaId: number, value: unknown, ancestors?: Set<object>
 		if (!hasOwn(value, field[0])) continue
 		const current = value[field[0]]
 		if (current === null || current === undefined) continue
-		const repair = (item: unknown): unknown =>
-			field[1] === PROTO_FIELD_KIND.message ? repairMessage(field[2], item, seen) : repairScalar(field[1], item)
+		const repair = (item: unknown): unknown => {
+			if (field[1] === PROTO_FIELD_KIND.message) return repairMessage(field[2], item, seen)
+			// `?? item`, not `|| item`: 0 is a valid wire value (e.g. `"NONE"`).
+			// Unknown names stay strings, so the retry still throws and the
+			// original failure keeps propagating instead of becoming a silent 0.
+			if (field[1] === PROTO_FIELD_KIND.enum && typeof item === 'string') return enumValueFor(field[2], item) ?? item
+			return repairScalar(field[1], item)
+		}
 		let converted: unknown = current
 		if (field[3] & PROTO_FIELD_FLAG.repeated) {
 			if (Array.isArray(current)) {
@@ -562,8 +604,8 @@ class ProtoCompatibilityRuntime {
 			if (!sourceCodec) throw new Error(`protobuf codec unavailable for ${path}`)
 			const projected = this.projectForEncode(schemaId, message)
 			const encoded = sourceCodec.encode(projected)
-			// The bridge refuses two inputs it used to accept silently, and upstream
-			// Baileys still encodes both. Repairing on failure rather than checking
+			// The bridge refuses three inputs it used to accept silently, and upstream
+			// Baileys still encodes all three. Repairing on failure rather than checking
 			// every field on the way in is what keeps the ordinary encode free: a
 			// message the codec accepts never reaches the repair, and one that does
 			// not was already going to throw.

--- a/src/__tests__/encode-proto-compat.test.ts
+++ b/src/__tests__/encode-proto-compat.test.ts
@@ -95,6 +95,53 @@ describe('encodeProtoCompat — inputs the bridge codec stopped accepting', () =
 		}) as { sections: { title: string }[] }
 		expect(repaired.sections.map(section => section.title)).toEqual(['�', 'ok', '�'])
 	})
+
+	/**
+	 * Issue #109: `relayMessage` threw `invalid int32: "NONE"`. The bridge codec
+	 * accepts only numbers for enums while upstream Baileys resolves names in
+	 * `fromObject` and coerces them in direct `encode`, so a caller passing a
+	 * name never saw a throw there. The bytes below match upstream exactly: like
+	 * upstream, `"NONE"` writes `0` (`5000`).
+	 */
+	it('resolves an enum name where the schema declares an enum', () => {
+		// Message.extendedTextMessage = field 6 (32), length 6: text = field 1
+		// (0a02 `hi`), previewType = field 10 (50) holding 0.
+		expect(hex(encodeProtoCompat('Message', { extendedTextMessage: { text: 'hi', previewType: 'NONE' } }))).toBe(
+			'32060a0268695000'
+		)
+	})
+
+	it('resolves a non-zero enum name to its number, not to zero', () => {
+		// Upstream's direct `encode` coerces every string with `| 0` and would
+		// write `5000` here; `fromObject` resolves `VIDEO` to 1 (`5001`), which
+		// is what the caller meant. Deliberately the latter.
+		expect(hex(encodeProtoCompat('Message', { extendedTextMessage: { text: 'hi', previewType: 'VIDEO' } }))).toBe(
+			'32060a0268695001'
+		)
+	})
+
+	it('resolves an enum name nested several messages deep', () => {
+		const bytes = encodeProtoCompat('Message', {
+			extendedTextMessage: { text: 'hi', contextInfo: { externalAdReply: { title: 't', mediaType: 'NONE' } } }
+		})
+		const decoded = proto.Message.decode(bytes)
+		expect(decoded.extendedTextMessage?.contextInfo?.externalAdReply?.title).toBe('t')
+		expect(decoded.extendedTextMessage?.contextInfo?.externalAdReply?.mediaType).toBe(0)
+	})
+
+	it('still refuses an enum name the schema does not define', () => {
+		// Upstream's direct encode would silently write 0 for this; writing a
+		// value nobody sent is the worse answer, so the throw propagates.
+		expect(() => encodeProtoCompat('Message', { extendedTextMessage: { text: 'hi', previewType: 'BOGUS' } })).toThrow()
+	})
+
+	it('does not mutate the caller’s message when resolving an enum name', () => {
+		const message = { extendedTextMessage: { text: 'hi', previewType: 'NONE' } }
+		const repaired = repairProtoMessage('Message', message) as typeof message
+		expect(message.extendedTextMessage.previewType).toBe('NONE')
+		expect(repaired.extendedTextMessage).toEqual({ text: 'hi', previewType: 0 })
+		expect(repaired).not.toBe(message)
+	})
 })
 
 describe('repairProtoMessage — copy-on-write contract', () => {
@@ -142,5 +189,12 @@ describe('proto.X.encode — the same repair through the facade', () => {
 
 	it('leaves an acceptable message untouched through the facade', () => {
 		expect(hex(proto.Message.encode({ conversation: 'hi' }).finish())).toBe('0a026869')
+	})
+
+	it('resolves an enum name through the facade too', () => {
+		// `as never`: the test deliberately passes a name where the types
+		// declare a number — that boundary crossing is the compat scenario.
+		const writer = proto.Message.encode({ extendedTextMessage: { text: 'hi', previewType: 'NONE' as never } })
+		expect(hex(writer.finish())).toBe('32060a0268695000')
 	})
 })


### PR DESCRIPTION
## Summary

Fixes #109: `relayMessage` threw `invalid int32: "NONE"` for any message carrying an enum name where the schema declares an enum.

The bridge codec accepts only numbers for enums (numeric strings aside) while upstream Baileys never throws for names: its `fromObject` resolves them to numbers and its direct `encode` coerces any string with `| 0`. The send path calls the neutral `encodeProto` directly, bypassing the facade's `fromObject` name resolution, and the existing repair only covered empty-string int64s and unpaired surrogates — so a caller passing `NONE` (or any enum name) saw the bridge's throw. The repair in `repairMessage` now also maps known enum names to their wire numbers, which fixes both `encodeProtoCompat` (send/`relayMessage`) and the facade's lazy `finish` retry in one place.

## Changes by file

- `src/Compatibility/proto-runtime.ts`
  - New `enumValueFor` + lazy per-enum `Map` tables built from `PROTO_ENUM_SCHEMAS` on the first repair that actually holds an enum string; importers that never send a refused value allocate nothing (same guarantee as the existing `schemaIdsByPath`).
  - `repairMessage` dispatches `enum`-kind string fields through that lookup (`?? item`, not `|| item`, so `0` stays a result). Unknown names are left untouched so the retry still throws and the original failure propagates instead of becoming a silent `0`.
  - Repair-on-failure and copy-on-write contracts unchanged: the success path is byte-identical code, numeric enums never touch a map.
- `src/Compatibility/encode-proto.ts`
  - Comment-only: documents the third repaired input and its provenance.
- `src/__tests__/encode-proto-compat.test.ts` (6 new tests)
  - `"NONE"` encodes to `32060a0268695000`, byte-identical to upstream; non-zero `"VIDEO"` resolves to `1` (`5001`); nested `externalAdReply.mediaType`; unknown `"BOGUS"` still throws; no caller mutation; facade `finish` path.

## Upstream behavior (drop-in notes, verified against installed baileys 7.0.0-rc13)

- `"NONE"`: identical bytes to upstream (`5000`).
- Non-zero names (e.g. `"VIDEO"`): resolves to the declared number (`5001`), matching upstream `fromObject` + `encode`. Upstream direct `encode` (what its `relayMessage` uses) coerces every string with `| 0` and would write `5000` — silently the wrong value. Deliberately better here; documented in code.
- Unknown names (e.g. `"BOGUS"`): still throws. Upstream direct `encode` would silently write `0`; failing loud is consistent with this library's existing strictness (e.g. `'abc'` in an int64 field throws).

## Validation (actual runs, worktree `fix/invalid-int32-109` @ `650dda5`)

- Repro from the issue: `encodeProto('Message', { extendedTextMessage: { text: 'hi', previewType: 'NONE' } })` failed with `invalid int32: "NONE"` before, encodes after — via `encodeProtoCompat` and the facade, byte-identical to Baileys.
- `node --test src/__tests__/encode-proto-compat.test.ts`: 21/21 pass (15 pre-existing + 6 new).
- Related suites (`relay-message-context-info`, `relay-derived-stanza-node`, `send-message-caller-id`, `socket-boundary-compatibility`, `quoted-media-enum-regression`): 70/70 pass. Proto suites (`proto-decoded-shape`, `proto-lazy-namespace`, `proto-namespace-alignment`, `proto-runtime-compatibility`, `proto-tojson-long`): 30/30 pass.
- `npx oxlint`: exit 0. `npx oxfmt --check` on touched files: clean. `tsc --noEmit`: no new errors (only the pre-existing bridge-version mismatches also present on `main` in this checkout).
- Performance: fast path (`encodeProtoCompat` on an accepted message) measures identically to raw `encodeProto` (~17ms vs ~18ms per 20k encodes — noise; success-path code untouched). Repair steady state ~10µs/op, first repair ~600µs one-off (schema index + one enum table); only messages that would otherwise throw pay it.
- Not run: full `npm test` (exceeds 10 min here — includes long-timeout fuzz suites), `test:e2e` (requires dedicated infra).

## Compatibility / migration

- No API, schema, on-disk, or bridge-pin changes. Well-formed numeric messages encode byte-identically to before.
- Deliberate behavior deltas, both covered by tests: known enum names now encode instead of throwing; non-zero names resolve correctly where upstream direct-encode would write 0; unknown names keep throwing instead of upstream's silent 0.
- Closes #109.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes issue #109: messages carrying an enum name (like `previewType: 'NONE'`) now encode instead of throwing `invalid int32: "NONE"` from the bridge codec. Unknown enum names still throw rather than being silently written as 0.

- `"NONE"` encodes byte-identical to upstream Baileys (0 on the wire).
- Non-zero names like `"VIDEO"` resolve to their declared number (1), matching upstream's `fromObject`; upstream's direct encode would have written 0.
- Unknown names keep throwing instead of upstream's silent 0.
- No API, schema, or migration changes; messages with numeric enums encode identically to before.

<sup>Written for commit 650dda588eea8a928f34bedefd304efe2f9b8007. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

