### PR TITLE
fix(socket): drop bare-join shim on bridge 0.21.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
-        "@oxidezap/whatsapp-rust-bridge": "0.21.0",
+        "@oxidezap/whatsapp-rust-bridge": "0.21.1",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^7.6.5"
@@ -975,12 +975,12 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.21.0.tgz",
-      "integrity": "sha512-y6OAmBr8o0uKS3758L3XUBocEtMXZiUoHH/UBVqvrbd0P+lSw8IshPQF/11B/7Mn2HlLBQLcy08ZiAyj/BX4pw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.21.1.tgz",
+      "integrity": "sha512-9ag4fcZttFbnW9lDx2906009M0E27T1yZn1+CGtcxBuyNcYUzG1HEm/2YV1bFIXChzJjfLQeGmJ9W+LaAh7zFQ==",
       "license": "MIT",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.12.0"
+        "@bufbuild/protobuf": "^2.14.1"
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",
-    "@oxidezap/whatsapp-rust-bridge": "0.21.0",
+    "@oxidezap/whatsapp-rust-bridge": "0.21.1",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^7.6.5"

--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -48,27 +48,6 @@ export type JoinApprovalMode = (typeof JOIN_APPROVAL_MODES)[number]
 // forms, and reconstructs the high word instead of dropping it.
 const inviteExpirationNumber = (value: proto.Message.IGroupInviteMessage['inviteExpiration']): number => toNumber(value)
 
-// The core's V4 join parser only accepts a `<group>`, `<community>` or
-// `<membership_approval_request>` child, but the server also answers a
-// successful join with a bare `<iq type="result">` (WA Web's own
-// `AcceptGroupAddResponseSuccess` variant requires no child at all — only the
-// result envelope whose `from` echoes the request's `to`). The core reports
-// that shape as an `IqError::ParseError`, which the bridge surfaces as
-// `kind: 'internal'`. Error stanzas never reach the parser (they become
-// `kind: 'server'` one layer below), so this substring can only mean the join
-// was accepted and the JID carrier is missing — never a rejection.
-const BARE_JOIN_SUCCESS_FRAGMENT = 'expected <group>, <community>, or <membership_approval_request> in join response'
-
-// A bare `<iq type="result">` join success, as described above. Anything else
-// (server rejections, timeouts, transport loss, protocol violations) must keep
-// propagating.
-const isBareJoinSuccess = (error: unknown): boolean => {
-	if (!(error instanceof Error) || error.name !== 'WhatsAppError') return false
-	const kind = (error as { kind?: unknown }).kind
-	if (kind !== 'internal') return false
-	return typeof error.message === 'string' && error.message.includes(BARE_JOIN_SUCCESS_FRAGMENT)
-}
-
 export const makeGroupMethods = (ctx: SocketContext) => {
 	const groupMetadata = async (jid: string): Promise<GroupMetadata> => {
 		const metadata = await (await ctx.getClient()).getGroupMetadata(jid)
@@ -93,23 +72,14 @@ export const makeGroupMethods = (ctx: SocketContext) => {
 				throw new TypeError('groupAcceptInviteV4 requires groupJid, inviteCode and inviter JID')
 			}
 
-			let joinedJid: string
-			try {
-				joinedJid = await (
-					await ctx.getClient()
-				).groupAcceptInviteV4(
-					groupJid,
-					inviteMessage.inviteCode,
-					inviteExpirationNumber(inviteMessage.inviteExpiration),
-					messageKey.remoteJid
-				)
-			} catch (error) {
-				// The join was accepted but the response carried no JID node.
-				// Baileys returns the envelope's `from` here, which echoes the
-				// request's `to` — the group JID we already hold.
-				if (!isBareJoinSuccess(error)) throw error
-				joinedJid = groupJid
-			}
+			const joinedJid: string = await (
+				await ctx.getClient()
+			).groupAcceptInviteV4(
+				groupJid,
+				inviteMessage.inviteCode,
+				inviteExpirationNumber(inviteMessage.inviteExpiration),
+				messageKey.remoteJid
+			)
 
 			if (messageKey.id) {
 				const expiredInvite = proto.Message.GroupInviteMessage.fromObject(inviteMessage)

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -251,24 +251,19 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		},
 
 		release: async client => {
-			// `disconnect()` before `free()` is defence in depth, not a fix for a
-			// reproduced bug on this path.
+			// `disconnect()` before `free()` drains exactly one shape: a
+			// `disconnect()` still in flight. Since bridge 0.21.1, freeing
+			// with ordinary calls pending (`fetchBlocklist()`, `logout()`) is
+			// safe — its `Drop` signals shutdown and aborts the background
+			// tasks — but freeing mid-`disconnect()` still aborts the process
+			// (`async-lock` panicking while panicking). See
+			// `__tests__/bridge-free-safety.test.ts`.
 			//
-			// The hazard is real and reproducible at the bridge: freeing a client
-			// with any call still pending corrupts the wasm heap — dlmalloc trips
-			// `assertion failed: psize <= size + max_overhead` and the process
-			// dies on `RuntimeError: unreachable`, from a microtask no try/catch
-			// here can reach, since `free()` itself returns normally.
-			// `logout()`, `disconnect()` and a plain `fetchBlocklist()` all
-			// reproduce it — see `__tests__/bridge-free-safety.test.ts`.
-			//
-			// What keeps teardown off that path is the `ws.close()` above, which
-			// is itself a `client.disconnect()` (`Compatibility/websocket-client.ts`).
-			// This is the belt to that braces, and the gap it closes is
-			// `WebSocketClient.close()`'s early return when `closing`/`closed` is
-			// already set: that path does NOT await the disconnect it skipped, so
-			// `void sock.ws.close(); await sock.end()` could otherwise reach
-			// `free()` with the first disconnect still running.
+			// That shape is reachable: `WebSocketClient.close()` early-returns
+			// when `closing`/`closed` is already set without awaiting the
+			// disconnect it skipped, so `void sock.ws.close(); await sock.end()`
+			// could otherwise reach `free()` with the first disconnect still
+			// running. Awaiting it here is the belt to `ws.close()`'s braces.
 			let disconnected = true
 			try {
 				await client.disconnect()

--- a/src/__tests__/bridge-free-safety.test.ts
+++ b/src/__tests__/bridge-free-safety.test.ts
@@ -1,32 +1,26 @@
 /**
  * Pins the bridge invariant that `sock.end()` depends on.
  *
- * Calling `WasmWhatsAppClient.free()` while any bridge call is still in flight
- * corrupts the wasm heap, and the process dies from inside wasm, in a microtask
- * no `try/catch` around `free()` can reach. `free()` itself returns normally.
- * It is not specific to one method; `logout()`, `disconnect()` and a plain
- * `fetchBlocklist()` all reproduce it.
+ * Since bridge 0.21.1, calling `WasmWhatsAppClient.free()` with ordinary
+ * calls still in flight is safe: its `Drop` signals shutdown, aborts the
+ * background tasks and closes the transport. Before that, any pending call
+ * corrupted the wasm heap and the process died from inside wasm (dlmalloc
+ * assertion, out-of-bounds access, js-sys future panic depending on the
+ * build).
  *
- * Which memory check trips first is a property of the build, not of the hazard:
- * bridge 0.6.5 hit dlmalloc's own consistency assertion, 0.7.0 faults on an
- * out-of-bounds access before dlmalloc gets to look. So the assertion below
- * accepts any signature a build has actually produced, and pins instead what
- * does not vary: the fault comes from inside wasm, and the process does not
- * survive it.
+ * One shape still kills the process: freeing mid-`disconnect()`, which
+ * aborts inside `async-lock` (`Panicking while panicking to abort`). That is
+ * why `end()` still drains with `disconnect()` before freeing
+ * (`src/Socket/index.ts`) — reachable via `void sock.ws.close(); await
+ * sock.end()`, whose skipped disconnect keeps running underneath.
  *
- * `await client.disconnect()` first drains those calls in order and makes the
- * `free()` safe. That is why `end()` awaits it before freeing
- * (`src/Socket/index.ts`).
- *
- * Why here and not through `makeWASocket`: offline, every socket method
- * rejects immediately, so the window never opens — the whole point is a call
- * that stays pending inside wasm, which needs either a live server or a
- * `free()` with no awaits in between. Driving the bridge directly is the only
- * way to hold that state open deterministically. Each case runs in a child
- * process because heap corruption takes the whole process with it.
+ * Each case runs in a child process because a heap-corruption regression
+ * would take the whole process with it — and a hang would take the watchdog.
+ * Driving the bridge directly (rather than through `makeWASocket`) is the
+ * only way to hold a pending call open deterministically: offline, every
+ * socket method rejects immediately, so the window never opens.
  */
 
-import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -107,43 +101,55 @@ describe('bridge: free() safety with a call in flight', { timeout: 90_000 }, () 
 		await rm(folder, { recursive: true, force: true })
 	})
 
-	it('free() with a pending call corrupts the heap and kills the process', async () => {
-		// Every way the corruption has been observed to announce itself, each
-		// tied to the build that produced it. Kept as a list rather than widened
-		// to "the child died": a rejection, a JS TypeError or an OOM would all
-		// mean the hazard moved. Add a signature only once a build emits it.
+	it('free() with an ordinary call pending survives instead of corrupting the heap', async () => {
+		// The shapes that used to kill the process and now must exit cleanly
+		// with no wasm fault on stderr. If a future bridge regresses one of
+		// these, the fix belongs in the bridge — not in a looser assertion.
+		const bodies = ['c.fetchBlocklist().catch(() => {})', 'c.logout().catch(() => {})']
 		const WASM_MEMORY_FAULTS = [
-			'psize <= size + max_overhead', // dlmalloc's own check (bridge 0.6.5)
-			'memory access out of bounds', // the fault that beats it (bridge 0.7.0)
-			'finish: result should be None' // js-sys future panic that beats both (bridge 0.14.0)
+			'psize <= size + max_overhead',
+			'memory access out of bounds',
+			'finish: result should be None',
+			'wasm://wasm/'
 		]
+		for (const body of bodies) {
+			const outcome = await runChild(
+				`
+				${body}
+				c.free()
+				`,
+				folder
+			)
 
-		// Documents the hazard rather than endorsing it. If a future bridge
-		// makes `free()` safe on its own, this test starts failing — which is
-		// the signal to drop the `disconnect()` from `end()`, not to relax the
-		// assertion.
+			// It got to `free()`…
+			expect(outcome.reachedTarget).toBe(true)
+			// …exited on its own rather than hanging…
+			expect(outcome.timedOut).toBe(false)
+			expect(outcome.code).toBe(0)
+			// …with no wasm fault on the way out.
+			for (const fault of WASM_MEMORY_FAULTS) {
+				expect(outcome.stderr.includes(fault)).toBe(false)
+			}
+		}
+	})
+
+	it('free() mid-disconnect still kills the process, so end() keeps draining', async () => {
+		// The one shape `free()` never became safe for: the disconnect future
+		// parks inside `async-lock`, and freeing under it aborts the process
+		// (`Panicking while panicking to abort`). This pins why `release`
+		// awaits `disconnect()` before freeing — drop that drain and `void
+		// sock.ws.close(); await sock.end()` can land here.
 		const outcome = await runChild(
 			`
-			c.fetchBlocklist().catch(() => {})
+			c.disconnect().catch(() => {})
 			c.free()
 			`,
 			folder
 		)
 
-		// It got to `free()`…
 		expect(outcome.reachedTarget).toBe(true)
-		// …died rather than hanging…
 		expect(outcome.timedOut).toBe(false)
 		expect(outcome.code === 0).toBe(false)
-		// …and died the documented way. Any other crash means the hazard moved
-		// and this suite is no longer describing it.
-		assert.ok(
-			WASM_MEMORY_FAULTS.some(fault => outcome.stderr.includes(fault)),
-			`no known wasm memory fault in stderr:\n${outcome.stderr}`
-		)
-		// The fault has to come from wasm. A crash raised in JS would satisfy
-		// the strings above by accident and describe something else entirely.
-		expect(outcome.stderr).toContain('wasm://wasm/')
 	})
 
 	it('await disconnect() before free() survives the same pending call', async () => {

--- a/src/__tests__/bridge-free-safety.test.ts
+++ b/src/__tests__/bridge-free-safety.test.ts
@@ -150,6 +150,11 @@ describe('bridge: free() safety with a call in flight', { timeout: 90_000 }, () 
 		expect(outcome.reachedTarget).toBe(true)
 		expect(outcome.timedOut).toBe(false)
 		expect(outcome.code === 0).toBe(false)
+		// The crash signature, not just any nonzero exit: anything else (a
+		// sync error, an unhandled rejection after setup) would satisfy the
+		// lines above while describing a different hazard.
+		expect(outcome.stderr).toContain('Panicking while panicking to abort')
+		expect(outcome.stderr).toContain('wasm://wasm/')
 	})
 
 	it('await disconnect() before free() survives the same pending call', async () => {

--- a/src/__tests__/group-operations-compatibility.test.ts
+++ b/src/__tests__/group-operations-compatibility.test.ts
@@ -63,59 +63,11 @@ describe('group operation compatibility', () => {
 		])
 	})
 
-	// The server also answers an accepted V4 join with a bare
-	// `<iq type="result">` (no `<group>`/`<community>`/
-	// `<membership_approval_request>` child). The core surfaces that shape as
-	// an internal parse error even though the join succeeded; Baileys returns
-	// the envelope's `from` there, which echoes the request's `to`, so this
-	// layer answers with the requested group JID and still runs the buffered
-	// lifecycle instead of rejecting (issue #114).
-	it('answers a bare join success with the group JID and keeps the buffered lifecycle', async () => {
-		const ev = Object.assign(new EventEmitter(), {
-			createBufferedFunction: <Args extends unknown[], Result>(work: (...args: Args) => Promise<Result>) => work
-		})
-		const updates: unknown[] = []
-		const upserts: unknown[] = []
-		ev.on('messages.update', value => updates.push(value))
-		ev.on('messages.upsert', value => upserts.push(value))
-		const calls: unknown[][] = []
-		const bareSuccess = Object.assign(
-			new Error(
-				'failed to parse IQ response: expected <group>, <community>, or <membership_approval_request> in join response'
-			),
-			{ name: 'WhatsAppError', kind: 'internal' }
-		)
-		const client = {
-			groupAcceptInviteV4: async (...args: unknown[]) => {
-				calls.push(args)
-				throw bareSuccess
-			}
-		} as unknown as WasmWhatsAppClient
-		const ctx = {
-			ev,
-			getClient: async () => client,
-			getUser: () => ({ id: 'bot@s.whatsapp.net', lid: 'bot@lid' }),
-			getMe: () => ({ id: 'bot@s.whatsapp.net', lid: 'bot@lid', name: 'Bot' })
-		} as unknown as SocketContext
-
-		const result = await makeGroupMethods(ctx).groupAcceptInviteV4(
-			{ remoteJid: 'inviter@lid', id: 'invite-message-id', fromMe: false },
-			{ groupJid: 'parent@g.us', inviteCode: 'INVITE', inviteExpiration: 1_800_000_000 }
-		)
-
-		assert.equal(result, 'parent@g.us')
-		assert.deepEqual(calls, [['parent@g.us', 'INVITE', 1_800_000_000, 'inviter@lid']])
-		assert.equal(updates.length, 1)
-		assert.equal(upserts.length, 1)
-		const upsert = upserts[0] as { type: string }
-		assert.equal(upsert.type, 'notify')
-	})
-
-	// Only the bare-success shape falls back. Genuine failures — server
-	// rejections, unrelated internal errors, and protocol violations even when
-	// they carry the same fragment — must keep propagating by identity, with
-	// no lifecycle side effects.
-	it('rethrows V4 join failures that are not a bare success', async () => {
+	// Bridge rejections propagate untouched: this layer adds no fallback of
+	// its own (the bare join success is answered by the core since bridge
+	// 0.21.1). Every failure keeps its identity, with no lifecycle side
+	// effects.
+	it('rethrows V4 join failures without masking them', async () => {
 		const rejections = [
 			Object.assign(new Error('server error 403: forbidden'), {
 				name: 'WhatsAppError',
@@ -123,15 +75,11 @@ describe('group operation compatibility', () => {
 				serverCode: 403,
 				serverText: 'forbidden'
 			}),
-			Object.assign(new Error('internal: something else broke'), {
-				name: 'WhatsAppError',
-				kind: 'internal'
-			}),
 			Object.assign(
 				new Error(
-					'protocol violation: expected <group>, <community>, or <membership_approval_request> in join response'
+					'failed to parse IQ response: expected <group>, <community>, or <membership_approval_request> in join response'
 				),
-				{ name: 'WhatsAppError', kind: 'protocol-violation' }
+				{ name: 'WhatsAppError', kind: 'internal' }
 			)
 		]
 		for (const rejection of rejections) {

--- a/src/__tests__/socket-dispose-integration.test.ts
+++ b/src/__tests__/socket-dispose-integration.test.ts
@@ -617,10 +617,9 @@ describe('makeWASocket: disposing stops the bridge run loop', { timeout: 120_000
  *  - `created.free()` on the mid-init dispose path. Nothing in the parent says
  *    whether that client was freed, but an unfreed `WasmWhatsAppClient` keeps
  *    the wasm instance alive and the process cannot exit.
- *  - `await c.disconnect()` before `c.free()` in `end()`. Freeing with a bridge
- *    call still in flight corrupts the wasm heap: dlmalloc trips
- *    `assertion failed: psize <= size + max_overhead` and the process dies on
- *    `RuntimeError: unreachable`, thrown from a microtask no try/catch reaches.
+ *  - `end()` with a bridge call still in flight exits cleanly. Since bridge
+ *    0.21.1 ordinary pending calls survive `free()`; the release drain covers
+ *    the remaining fatal shape (a `disconnect()` still running).
  *
  * Both therefore assert the same thing — the child exits cleanly, on its own.
  */
@@ -672,10 +671,9 @@ describe('makeWASocket: teardown frees the client without corrupting the wasm he
 		expect(result.code).toBe(0)
 	})
 
-	it('end() with a bridge call still in flight exits cleanly instead of corrupting the heap', async () => {
+	it('end() with a bridge call still in flight exits cleanly', async () => {
 		// `fetchBlocklist()` is deliberately not awaited: it stays pending
-		// inside wasm across the `end()`. Without `await c.disconnect()` before
-		// `c.free()`, this child dies on the dlmalloc assertion.
+		// inside wasm across the `end()`, which frees without draining first.
 		const result = await runChild(
 			`
 			await new Promise(r => setTimeout(r, 400))


### PR DESCRIPTION
## Scope

Bumps `@oxidezap/whatsapp-rust-bridge` `0.21.0` -> `0.21.1` and removes the temporary string-matching fallback in `groupAcceptInviteV4` added for #114. The bump also changes `free()` safety, which this PR accounts for without relaxing anything. No public-surface change. Closes #114 for real.

## Background (why the shim can go)

#115 merged the shim as explicitly temporary: the core's join parser rejected the bare `<iq type=result>` success, surfacing `IqError::ParseError` as bridge `kind: internal`. Since then the fix landed upstream layer by layer (whatspec child assertions, `AcceptGroupInviteV4Iq` accepting the bare result with the request's group JID, linked-group/passive shape-locks) and shipped in bridge `v0.21.1`. The core now answers the bare success itself, so this layer goes back to passing the bridge result — and its rejections — through untouched.

## Per-file changes

- `package.json` / `package-lock.json`: bridge pin `0.21.1` (exact).
- `src/Socket/groups.ts`: deletes `BARE_JOIN_SUCCESS_FRAGMENT` + `isBareJoinSuccess` and the try/catch fallback; the bridge call assigns straight through. Keeps the narrowed `groupJid` local and the `Promise<string>`-typed bridge result (verified against the 0.21.1 `.d.ts`).
- `src/__tests__/group-operations-compatibility.test.ts`: deletes the fallback test; the rethrow test now also covers the old parse-error shape, locking that no fallback exists anymore.
- `src/Socket/index.ts` (`release`): keeps the `disconnect()` drain, with the comment rewritten to the exact new truth — see below.
- `src/__tests__/bridge-free-safety.test.ts` + `socket-dispose-integration.test.ts`: comments updated; survival vs fatal shapes split (below).

## Bridge 0.21.1 also changes `free()` safety (verified, not assumed)

The bump flipped `bridge-free-safety` from crash to clean exit, so I probed all three pending-call shapes in child processes before touching `end()`:

- `fetchBlocklist()` / `logout()` in flight + `free()` → exit 0, empty stderr. Genuinely safe now (the bridge's `Drop` signals shutdown and aborts background tasks).
- `disconnect()` in flight + `free()` → still aborts (`Panicking while panicking to abort` in `async-lock`, exit 1).

So the drain stays: removing it would reintroduce a real crash via `void sock.ws.close(); await sock.end()` with the skipped disconnect still running. The tests now pin both halves — survival for ordinary pending calls, death mid-disconnect as the documented reason the drain exists.

## Validation (final SHA `a1f212c`)

- Focused: `bridge-free-safety` + `socket-dispose-integration` + `group-operations-compatibility` → 27/27 pass.
- `npm run build`, `format:check`, `lint` (tsc + oxlint): pass, tsc 0 errors (the 18 pre-existing ones are gone under the new bridge types).
- `compat:audit:missing`: no new missing (`groupAcceptInviteV4` signature unchanged).
- Not run: full `npm test` (timed out in this env before too) and `test:e2e` (no infra).