### PR TITLE
fix(deps): upgrade protobufjs to 8.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@oxidezap/whatsapp-rust-bridge": "0.21.1",
         "long": "^5.3.2",
         "pino": "^10.3.1",
-        "protobufjs": "^7.6.5"
+        "protobufjs": "^8.8.0"
       },
       "devDependencies": {
         "@bufbuild/protobuf": "^2.13.0",
@@ -1336,63 +1336,6 @@
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -1432,6 +1375,7 @@
       "version": "26.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
       "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -3038,22 +2982,11 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
-      "hasInstallScript": true,
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.8.0.tgz",
+      "integrity": "sha512-N3xhQ5yyBx3vQq4gubBfASzYhJGNzeDbjqBpu61g7UVylsN/qyffU96TKWD3GbbLOKF82VGNRNvv1+BFgE31Eg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
         "long": "^5.3.2"
       },
       "engines": {
@@ -3438,6 +3371,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@oxidezap/whatsapp-rust-bridge": "0.21.1",
     "long": "^5.3.2",
     "pino": "^10.3.1",
-    "protobufjs": "^7.6.5"
+    "protobufjs": "^8.8.0"
   },
   "devDependencies": {
     "@bufbuild/protobuf": "^2.13.0",
@@ -124,7 +124,7 @@
     }
   },
   "overrides": {
-    "protobufjs": "^7.6.5"
+    "protobufjs": "^8.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/__tests__/proto-runtime-compatibility.test.ts
+++ b/src/__tests__/proto-runtime-compatibility.test.ts
@@ -141,6 +141,61 @@ describe('generated protobuf runtime facade', () => {
 		)
 	})
 
+	it('preserves wire fixtures captured with Baileys rc14 and protobufjs 7.6.5', () => {
+		const fixtures: ReadonlyArray<readonly [string, Record<string, unknown>, string]> = [
+			['Message', { conversation: '' }, '0a00'],
+			[
+				'Message',
+				{
+					requestPaymentMessage: {
+						amount1000: '18446744073709551615',
+						expiryTimestamp: '-9007199254740993',
+						currencyCodeIso4217: 'BRL'
+					}
+				},
+				'b2011b0a0342524c10ffffffffffffffffff0128ffffffffffffffefff01'
+			],
+			[
+				'Config',
+				{ field: { '1': { minVersion: 1, maxVersion: 2, subfield: { '9': { isMessage: true } } } }, version: 3 },
+				'0a100801120c080110022a060809120220011003'
+			],
+			[
+				'Message',
+				{ imageMessage: { caption: 'hello', mediaKey: 'AQID', fileLength: '9007199254740993', width: 0 } },
+				'1a171a0568656c6c6f28818080808080801038004203010203'
+			]
+		]
+		for (const [path, input, hex] of fixtures) {
+			for (const root of [localProto, upstreamProto]) {
+				const type = messageType(root, path)
+				const message = type.fromObject(input)
+				assert.equal(Buffer.from(type.encode(message).finish()).toString('hex'), hex, path)
+				assert.deepEqual(
+					type.toObject(type.decode(Buffer.from(hex, 'hex')), { longs: String, bytes: String }),
+					type.toObject(message, { longs: String, bytes: String }),
+					path
+				)
+			}
+		}
+	})
+
+	it('preserves forked writer state and length-bounded reader positions', () => {
+		for (const writer of [new protobuf.Writer(), protobuf.Writer.create()]) {
+			writer.uint32(42).fork()
+			assert.equal(localProto.Message.encode({ conversation: 'hello' }, writer), writer)
+			writer.ldelim().uint32(99)
+			assert.equal(Buffer.from(writer.finish()).toString('hex'), '2a070a0568656c6c6f63')
+			const reader = protobuf.Reader.create(writer.finish())
+			assert.equal(reader.uint32(), 42)
+			const length = reader.uint32()
+			assert.equal(localProto.Message.decode(reader as unknown as Uint8Array, length).conversation, 'hello')
+			assert.equal(reader.pos, 9)
+			assert.equal(reader.uint32(), 99)
+			assert.equal(reader.pos, reader.len)
+		}
+	})
+
 	it('measures every upstream field on the wire and rejects unreviewed drift', () => {
 		const script = new URL('../../scripts/compatibility/proto-runtime-audit.ts', import.meta.url)
 		const result = spawnSync(process.execPath, [script.pathname, '--format=json', '--strict'], {


### PR DESCRIPTION
## Summary

- Upgrade the direct protobufjs dependency and existing override from ^7.6.5 to ^8.8.0. Baileys and libsignal also resolve to 8.8.0 in this checkout.
- Remove nine obsolete protobufjs subpackages from the lockfile.
- Add fixed wire fixtures captured with Baileys rc14 on protobufjs 7.6.5 for explicit defaults, nested bytes, maps, and signed/unsigned 64-bit values.
- Test generic and Node writers with forked state and length-bounded readers. These tests pass against both 7.6.5 and 8.8.0.

## Compatibility

Reviewed the upstream release changes and the local parser, generated declarations, Reader/Writer adapter, and bridge-backed codecs. No production-code adjustment or schema regeneration is needed for the interfaces used here.

The existing adapter already uses v8 Writer.raw and retains the v7 _push fallback for consumer-supplied writers. Removing that fallback would break compatibility. Enum and integer repairs still apply to the Rust bridge codec, so this upgrade does not make them redundant.

| Audit | Before | After |
| --- | --- | --- |
| General API coverage | 97.83% | 97.83% |
| Object contracts | 498/498 | 498/498 |
| Enums | 174/174 | 174/174 |
| Codec types | 497/498 | 497/498 |
| Wire fields | 2406/2424 | 2406/2424 |
| Send-path preserved fields | 1970 | 1970 |
| Send-path dropped / altered / errored | 0 / 0 / 0 | 0 / 0 / 0 |

Compared every general-audit item before and after, normalizing only TypeScript internal symbol IDs. Results and diagnostics are unchanged. Existing unsupported codecs, wire gaps, and the two accepted send-path divergences remain unchanged. No allowlists or thresholds were weakened.

## Validation

- Clean npm ci --ignore-scripts, with zero reported vulnerabilities.
- Full unit/fuzz-smoke suite passes on Node 26.5.0 and Node 24.20.0.
- All 88 E2E tests pass against the local bartender mock, including Baileys/baileyrs session and sender-key handoff. The run emits mock history-download and asynchronous teardown warnings despite passing assertions.
- Build, lint, format check, generated-facade check, and package-content check pass.
- Strict proto-runtime and send-path wire audits pass.

## Existing validation limitations

The general strict API audit already fails on main with 248 missing and 238 mismatched items. Both counts and all item results remain unchanged.

The compatibility-auditor typecheck reports existing EventNamesExact and EventMapExact failures at scripts/compatibility/type-contracts.ts lines 138-139. Reinstalled protobufjs 7.6.5 and reproduced the same two errors before restoring 8.8.0.

The combined typecheck:compat-auditor command also requires sibling whatsapp-rust and whatsapp-rust-bridge checkouts at fixed relative paths. Those paths do not exist beside this worktree, so its layer-boundary step cannot run here. The auditor TypeScript check was run separately as described above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `protobufjs` from ^7.6.5 to ^8.8.0 in both the direct dependency and override, and drops nine obsolete `@protobufjs/*` subpackages from the lockfile. No production-code changes are needed; wire fixtures are added to prove encoding and decoding behavior is byte-for-byte unchanged.

**Compatibility**
- The existing Writer adapter already uses v8 `Writer.raw` and keeps a v7 `_push` fallback for consumer-supplied writers; removing that fallback would break compatibility.
- Enum and integer repairs still apply to the Rust bridge codec, so this upgrade does not make them redundant.

**Validation**
- Wire fixtures captured with Baileys rc14 and protobufjs 7.6.5 pass against both 7.6.5 and 8.8.0 for explicit defaults, nested bytes, maps, and signed/unsigned 64-bit values.
- Full unit/fuzz-smoke suite passes on Node 26.5.0 and 24.20.0, and all 88 E2E tests pass.
- Strict proto-runtime and send-path wire audits are unchanged from main, with no allowlists or thresholds weakened.

<sup>Written for commit 318786860ef6437dd06b82ec522a65ae884f997c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

