### PR TITLE
fix(deps): bump @oxidezap/whatsapp-rust-bridge to 0.21.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
-        "@oxidezap/whatsapp-rust-bridge": "0.21.2",
+        "@oxidezap/whatsapp-rust-bridge": "0.21.3",
         "long": "^5.3.2",
         "pino": "^10.3.1",
         "protobufjs": "^8.8.0"
@@ -975,9 +975,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.21.2.tgz",
-      "integrity": "sha512-sOOSQMyKmHpTWgaFtme3imHRDnL46kvb9gg/qd4nu0XrBJ1p/WZGsvi/MsM3MyjeyRAEg5VXiGL61n4X4Ktazg==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.21.3.tgz",
+      "integrity": "sha512-dDotpd0kwf1C9L0pZnw9p5db+ZBtmh7OpK5EnmjMrXfYWIIWAoty/d28kfx75lMDokmdzp/RWoFE3hAdR6MAIQ==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.14.1"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",
-    "@oxidezap/whatsapp-rust-bridge": "0.21.2",
+    "@oxidezap/whatsapp-rust-bridge": "0.21.3",
     "long": "^5.3.2",
     "pino": "^10.3.1",
     "protobufjs": "^8.8.0"


### PR DESCRIPTION
Moves `@oxidezap/whatsapp-rust-bridge` `0.21.2` -> `0.21.3` (exact pin, as before). That release is the core bump `823158d7` -> `e14300d1` (bridge #110).

What 0.21.3 changes for this package:

- Core `fix(message)`: deduplicate PDO recovery and encrypted retries. Redundant retry/recovery work is skipped internally; sends that previously did duplicate retry work now dedupe, no adapter change, the JS surface is unchanged.
- Core memory perf: flatter cache slot entries, metadata-free tables for unbounded local maps, shared table growth, released dedup buckets, dropped empty sender protobuf fields, exactly-sized skipped-key buffers, inlined unshared `Arc` wrappers, runtime-only cache config, constant-pool report reconstruction, hashed-identity dispatch gate. All internals of the core's cache/signal/client paths; nothing in `src/` touches those paths.
- Core voip (`feat` exposing the immutable initial call peer, two 1:1 video-offer fixes) is not exposed through the bridge surface this package consumes — the voip feature is not compiled into the wasm bridge (`src/Socket/server-queries.ts` still throws for `createCallLink`).
- The rest (layout-budget asserts, cache-lifetime/size pins, demo-only memory logging, CI dep bumps) is test/tooling-only.

Changes in this PR:

- `package.json` / `package-lock.json`: bridge `0.21.3` (exact pin).
- No `src/` change: `npm run build` is green with no TS errors, so no adapter entry is missing and no mapping needed updating. The `bridge-free-safety` abort signature (`cannot recursively acquire mutex`) is unchanged, so its pinned assertion still holds.

Evidence:

- `npm run build`: green.
- `npm run lint` (tsc + oxlint): pass.
- `npm run format:check`: pass, 297 files.
- Focused `src/Bridge/__tests__/adapt.test.ts` + `src/__fuzz__/bridge-events.fuzz.test.ts`: 62 pass, 0 fail.
- `src/__tests__/bridge-free-safety.test.ts`: 4 pass, 0 fail.
- `npm run compat:audit:missing`: exit 0, no new missing (only the pre-existing WASocket field mismatches).
- `node scripts/check-pack.ts`: 293 files, no duplicates.

Not verified:

- Full `npm test` not run locally (heavy suite; CI runs it in parallel on this PR).
- `npm run test:e2e` not run (needs the mock server).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WhatsApp integration dependency to version 0.21.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@oxidezap/whatsapp-rust-bridge` from `0.21.2` to `0.21.3` (exact pin). This release fixes duplicate retry/recovery work in message sends and reduces memory use in core internals; no adapter changes are needed, and build, lint, format, and focused bridge tests all pass.

<sup>Written for commit 8f07fad3b1ed99e675040f9dfb11682374d6d31a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

