### PR TITLE
Fix Bundlephobia build failure: optional music-metadata peer, single WAProto export

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,11 @@ A few behaviors that differ from upstream — almost always to your advantage:
   `(err as Boom).output.statusCode` pattern works unchanged. If your
   `package.json` was pulling `@hapi/boom` only for baileys, you can drop
   the dependency.
+- **Audio duration needs the optional `music-metadata` peer.** Upstream
+  Baileys bundles it as a hard dependency; here it is optional like the
+  other media peers (`sharp`, `jimp`, `audio-decode`, `link-preview-js`).
+  Without it, audio messages still send — they just carry no `seconds`
+  value. Install `music-metadata` if you want durations computed.
 - **Your key store also holds bridge state, so "empty" is not "unpaired".**
   See [Bridge state in your key store](#bridge-state-in-your-key-store) — this
   one can break a boot path, so it has its own section.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "audio-decode": "^2.1.3",
         "jimp": "^1.6.0",
         "link-preview-js": "^3.0.0",
+        "music-metadata": "^11.14.0",
         "sharp": "*"
       },
       "peerDependenciesMeta": {
@@ -47,6 +48,9 @@
           "optional": true
         },
         "link-preview-js": {
+          "optional": true
+        },
+        "music-metadata": {
           "optional": true
         },
         "sharp": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "audio-decode": "^2.1.3",
     "jimp": "^1.6.0",
     "link-preview-js": "^3.0.0",
+    "music-metadata": "^11.14.0",
     "sharp": "*"
   },
   "peerDependenciesMeta": {
@@ -117,6 +118,9 @@
       "optional": true
     },
     "link-preview-js": {
+      "optional": true
+    },
+    "music-metadata": {
       "optional": true
     },
     "sharp": {

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -160,20 +160,28 @@ export const mediaMessageSHA256B64 = (message: WAMessageContent): string | null 
 
 /** Returns audio duration in seconds, parsed via `music-metadata`. */
 export async function getAudioDuration(buffer: Buffer | string | Readable) {
-	const musicMetadata = await import('music-metadata')
-	let metadata: IAudioMetadata
-	const options = {
-		duration: true
-	}
-	if (Buffer.isBuffer(buffer)) {
-		metadata = await musicMetadata.parseBuffer(buffer, undefined, options)
-	} else if (typeof buffer === 'string') {
-		metadata = await musicMetadata.parseFile(buffer, options)
-	} else {
-		metadata = await musicMetadata.parseStream(buffer, undefined, options)
-	}
+	// `music-metadata` is an optional peer: without it the duration is simply
+	// unknown and the caller sends without `seconds`. The specifier cast keeps
+	// bundlers from failing the build when the peer is absent, the same trick
+	// `link-preview.ts` uses for `link-preview-js`.
+	try {
+		const musicMetadata = await import('music-metadata' as string)
+		let metadata: IAudioMetadata
+		const options = {
+			duration: true
+		}
+		if (Buffer.isBuffer(buffer)) {
+			metadata = await musicMetadata.parseBuffer(buffer, undefined, options)
+		} else if (typeof buffer === 'string') {
+			metadata = await musicMetadata.parseFile(buffer, options)
+		} else {
+			metadata = await musicMetadata.parseStream(buffer, undefined, options)
+		}
 
-	return metadata.format.duration
+		return metadata.format.duration
+	} catch {
+		return undefined
+	}
 }
 
 /**

--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -1,4 +1,5 @@
 import type { IAudioMetadata } from 'music-metadata'
+import type * as musicMetadataTypes from 'music-metadata'
 import { Buffer } from 'node:buffer'
 import { execFile } from 'node:child_process'
 import { randomBytes } from 'node:crypto'
@@ -163,25 +164,28 @@ export async function getAudioDuration(buffer: Buffer | string | Readable) {
 	// `music-metadata` is an optional peer: without it the duration is simply
 	// unknown and the caller sends without `seconds`. The specifier cast keeps
 	// bundlers from failing the build when the peer is absent, the same trick
-	// `link-preview.ts` uses for `link-preview-js`.
+	// `link-preview.ts` uses for `link-preview-js`. Only the import is
+	// guarded: parser failures still throw so the caller's warning reports
+	// corrupt audio instead of silently dropping the duration.
+	let musicMetadata: typeof musicMetadataTypes
 	try {
-		const musicMetadata = await import('music-metadata' as string)
-		let metadata: IAudioMetadata
-		const options = {
-			duration: true
-		}
-		if (Buffer.isBuffer(buffer)) {
-			metadata = await musicMetadata.parseBuffer(buffer, undefined, options)
-		} else if (typeof buffer === 'string') {
-			metadata = await musicMetadata.parseFile(buffer, options)
-		} else {
-			metadata = await musicMetadata.parseStream(buffer, undefined, options)
-		}
-
-		return metadata.format.duration
+		musicMetadata = await import('music-metadata' as string)
 	} catch {
 		return undefined
 	}
+	let metadata: IAudioMetadata
+	const options = {
+		duration: true
+	}
+	if (Buffer.isBuffer(buffer)) {
+		metadata = await musicMetadata.parseBuffer(buffer, undefined, options)
+	} else if (typeof buffer === 'string') {
+		metadata = await musicMetadata.parseFile(buffer, options)
+	} else {
+		metadata = await musicMetadata.parseStream(buffer, undefined, options)
+	}
+
+	return metadata.format.duration
 }
 
 /**

--- a/src/__tests__/bundlephobia-exports.test.ts
+++ b/src/__tests__/bundlephobia-exports.test.ts
@@ -42,4 +42,14 @@ describe('bundler export surface', () => {
 		expect(typeof manifest.peerDependencies?.['music-metadata']).toBe('string')
 		expect(manifest.peerDependenciesMeta?.['music-metadata']?.optional).toBe(true)
 	})
+
+	it('keeps the music-metadata import opaque to bundlers', () => {
+		// Webpack turns a statically analyzable `import('music-metadata')`
+		// into a hard error when the optional peer is absent, but only warns
+		// on a non-literal specifier. The `as string` cast is what keeps the
+		// published build warning-only, so a change dropping it must fail here.
+		const source = readFileSync(resolve(repoRoot, 'src/Utils/messages-media.ts'), 'utf8')
+		expect(source.includes("import('music-metadata' as string)")).toBe(true)
+		expect(source.includes("await import('music-metadata')")).toBe(false)
+	})
 })

--- a/src/__tests__/bundlephobia-exports.test.ts
+++ b/src/__tests__/bundlephobia-exports.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { proto as rootProto, WAProto as rootWAProto } from '../index.ts'
+import { WAProto as typesWAProto } from '../Types/index.ts'
+import { proto as runtimeProto } from '../WAProto/runtime.ts'
+import { expect } from './expect.ts'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+// A bundler build of the published package once failed here with
+// `conflicting star exports for the name WAProto`: the WAProto shim and
+// `Types/Message` each exported the name and the package root re-exported
+// both by star. The root now names the binding explicitly, so there is one
+// binding whatever path a consumer imports it from.
+describe('bundler export surface', () => {
+	it('exposes a single proto/WAProto binding from the package root', () => {
+		expect(rootProto).toBe(runtimeProto)
+		expect(rootWAProto).toBe(runtimeProto)
+	})
+
+	it('keeps the Types-level WAProto alias on the same binding', () => {
+		expect(typesWAProto).toBe(runtimeProto)
+	})
+
+	it('re-exports WAProto from the root explicitly, never by star', () => {
+		const index = readFileSync(resolve(repoRoot, 'src/index.ts'), 'utf8')
+		for (const line of index.split('\n')) {
+			if (line.startsWith('export *')) {
+				expect(line.includes('WAProto')).toBe(false)
+			}
+		}
+		expect(index.includes('proto as WAProto')).toBe(true)
+	})
+
+	it('declares music-metadata as an installable optional peer', () => {
+		const manifest = JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8')) as {
+			peerDependencies?: Record<string, string>
+			peerDependenciesMeta?: Record<string, { optional?: boolean }>
+		}
+		expect(typeof manifest.peerDependencies?.['music-metadata']).toBe('string')
+		expect(manifest.peerDependenciesMeta?.['music-metadata']?.optional).toBe(true)
+	})
+})


### PR DESCRIPTION
Bundlephobia fails the baileyrs package with a build error while baileys@7.0.0-rc14 builds fine. I reproduced both reported errors locally with webpack 5 and fixed them in this change.

What broke

The published baileyrs@0.0.7 that Bundlephobia builds has two problems. Its lib/index.js star-exports both ../WAProto/index.js and ./Types/index.js, and each of those exports the name WAProto, so webpack stops with a conflicting star exports error. Upstream Baileys avoids this because its WAProto/index.js only exports proto while WAProto comes from Types alone. Separately, getAudioDuration does a bare await import('music-metadata') while the package declares it nowhere, so a production install has nothing to resolve and the build fails with module not found. I confirmed both errors by bundling the published tarball.

What I changed

The package root already re-exports proto and WAProto by name instead of by star, so there is one binding whatever path a consumer imports. I checked every WAProto export in src and confirmed the root, Types and the runtime all hand out the same object, then added src/__tests__/bundlephobia-exports.test.ts to pin it. The test asserts the three bindings are identical, fails if a WAProto star export ever returns to src/index.ts, and checks the manifest declares the peer below.

For the audio path I declared music-metadata an optional peer next to the other media peers and kept it in devDependencies so local builds and tests still use it. getAudioDuration now catches a missing or broken peer and returns undefined, and the dynamic import uses the same specifier cast link-preview.ts uses so bundlers warn instead of erroring when the peer is absent. The caller already sends the message without seconds in that case. The README Gotchas section documents the fallback.

Verification

npm run lint passes. npm run format:check passes. npm test passes with 1531 passed, 0 failed, 1 skipped. npm run build passes. node scripts/check-pack.ts passes with 293 files and no duplicates.

Compat audits are unchanged between base and head. The main audit lists the same findings on both. The proto audit reads 498/498 object contracts, 174/174 enum values, 497/498 codec types and 2406/2424 wire fields on both. The wire audit reads 1970 preserved with the same 2 known pollResultSnapshotMessageV3 divergences on both. The lifecycle audit reads 28 holds and 0 violations on both.

Perf on the touched path is flat. getAudioDuration over a synthetic 2s WAV, 60 runs: base p50 0.194ms mean 0.207ms, head p50 0.187ms mean 0.203ms on the repeat runs. That is noise.

Webpack after the fix shows no linking error. With music-metadata hidden the import downgrades from an error to a warning, matching how Baileys treats its own missing optional peers, and with the peer installed it resolves fully.

One check stays blocked. typecheck:compat-auditor needs the sibling core and bridge checkouts, which are not present in this worktree, so I could not run compat:layers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Bundlephobia build failure for the published `baileyrs` package: the `WAProto` star export conflict is gone, and the missing optional `music-metadata` dependency no longer breaks the build.

- Pins a single `WAProto` binding at the package root instead of star-exporting the name from two modules, covered by a new test.
- Declares `music-metadata` as an optional peer; `getAudioDuration` returns `undefined` when the peer is missing, so audio messages send without a `seconds` value.
- Documents the fallback in the README Gotchas section.

<sup>Written for commit b28a25e7926f4c0fcfdd0b4d32332c4b043a5813. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

