### PR TITLE
fix: use one music-metadata type import in the optional audio-duration path

### DIFF
--- a/src/Utils/messages-media.ts
+++ b/src/Utils/messages-media.ts
@@ -1,4 +1,3 @@
-import type { IAudioMetadata } from 'music-metadata'
 import type * as musicMetadataTypes from 'music-metadata'
 import { Buffer } from 'node:buffer'
 import { execFile } from 'node:child_process'
@@ -173,7 +172,7 @@ export async function getAudioDuration(buffer: Buffer | string | Readable) {
 	} catch {
 		return undefined
 	}
-	let metadata: IAudioMetadata
+	let metadata: musicMetadataTypes.IAudioMetadata
 	const options = {
 		duration: true
 	}


### PR DESCRIPTION
Follow-up to 129 so the Bundlephobia fix registers in the 0.3.3 release notes.

What happened: 129 merged with the squash title Fix Bundlephobia build failure, which is not a conventional commit message, so release-please skipped it and 128 only lists the perf entry. Commit history on main cannot be rewritten, so this small change in the same shipped code gives release-please a conventional fix commit to pick up. Full context for the actual fix is in 129.

The change itself consolidates the two music-metadata type imports in getAudioDuration into the one namespace import the file already uses. No runtime or emitted-JS change. Lint, format, build and the full suite pass (1532 passed, 0 failed, 1 skipped), and the emitted import stays in the bundler-opaque helper-call form.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates the `music-metadata` type imports in the optional audio-duration path to a single namespace import, so release-please records the earlier Bundlephobia fix in the release notes. No runtime or emitted-JS changes.

<sup>Written for commit 8f9721ff1bff826e0a1348155fa57c3fd7d5ec7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

