### PR TITLE
feat(events): carry the envelope's type on an undecryptable stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,18 @@ preserved. No QR re-scan, no logged-out events.
 
 A few behaviors that differ from upstream — almost always to your advantage:
 
+- **An undecryptable message tells you what it was.** The CIPHERTEXT stub
+  emitted on `messages.upsert` for a message that failed to decrypt carries
+  `stanzaType`: the envelope's `type` attribute as the server stamped it on the
+  sending stanza — `"text"`, `"media"`, `"pay"`, `"poll"`, `"reaction"`,
+  `"event"`. It describes the stanza rather than the ciphertext, so it survives
+  the failure, and it is stamped on the sender's own outgoing stanza, so it
+  cannot be pointed at anyone else. Upstream has no equivalent: there the
+  placeholder is unclassifiable. `messageStubParameters` is untouched and still
+  holds only the unavailability reason, when the server named one — the two are
+  independently optional, which is exactly what a positional array cannot
+  express.
+
 - **Auto-reconnect is built in, but `close` still means `close`.** The Rust
   engine retries transient drops on a fibonacci backoff and reports them as
   `connection: 'connecting'`, so the canonical upstream handler never fires

--- a/src/Bridge/schema.ts
+++ b/src/Bridge/schema.ts
@@ -255,6 +255,7 @@ const ADAPTERS = {
 			remoteJidAlt: resolveRemoteJidAlt(senderAlt, recipientAlt, isGroup, isFromMe),
 			isUnavailable: asBoolOr(data?.is_unavailable, false),
 			unavailableType: asString(data?.unavailable_type),
+			stanzaType: asString(info.type),
 			decryptFailMode: asString(data?.decrypt_fail_mode),
 			raw: data
 		}

--- a/src/Bridge/types.ts
+++ b/src/Bridge/types.ts
@@ -571,6 +571,13 @@ export interface CanonicalUndecryptableMessage {
 	isUnavailable: boolean
 	/** Bridge `unavailable_type`: "view_once" | "unknown". */
 	unavailableType?: string
+	/**
+	 * The envelope's `type` attribute, as the server stamped it: "text",
+	 * "media", "pay", "poll", "reaction", "event"… It describes the stanza,
+	 * not the ciphertext, so it survives a decryption failure — the one thing
+	 * a consumer can still learn about a message it cannot read.
+	 */
+	stanzaType?: string
 	/** Bridge `decrypt_fail_mode`: "show" | "hide". */
 	decryptFailMode?: string
 	/** Original raw payload, preserved for debug logging. */

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -619,17 +619,18 @@ const DISPATCHERS: DispatcherMap = {
 			messageTimestamp: evt.timestamp,
 			pushName: evt.pushName,
 			messageStubType: WAProto.WebMessageInfo.StubType.CIPHERTEXT,
-			// The envelope's `type` rides along with `unavailableType`. It is
-			// the only thing that survives a decryption failure to say what the
-			// message was — the server stamps it on the sender's outgoing
-			// stanza, in the clear — and dropping it here left a consumer with
-			// a placeholder it could not classify at all.
-			messageStubParameters: [evt.unavailableType, evt.stanzaType].filter(
-				(value): value is string => !!value
-			)
+			messageStubParameters: evt.unavailableType ? [evt.unavailableType] : []
 		}) as WAMessage
 		if (evt.participantAlt) stubMsg.key.participantAlt = evt.participantAlt
 		if (evt.remoteJidAlt) stubMsg.key.remoteJidAlt = evt.remoteJidAlt
+		// A field of its own, not a second slot in `messageStubParameters`:
+		// that array is positional, and two independently optional values in it
+		// cannot be told apart — a lone `"pay"` would sit where an
+		// unavailability reason used to. This is the one thing that survives a
+		// decryption failure to say what the message was (the server stamps it
+		// on the sender's own outgoing stanza, in the clear), so it is named
+		// rather than placed.
+		if (evt.stanzaType) stubMsg.stanzaType = evt.stanzaType
 		ctx.ev.emit('messages.upsert', { messages: [stubMsg], type: 'notify' })
 	},
 

--- a/src/Socket/events.ts
+++ b/src/Socket/events.ts
@@ -619,7 +619,14 @@ const DISPATCHERS: DispatcherMap = {
 			messageTimestamp: evt.timestamp,
 			pushName: evt.pushName,
 			messageStubType: WAProto.WebMessageInfo.StubType.CIPHERTEXT,
-			messageStubParameters: evt.unavailableType ? [evt.unavailableType] : []
+			// The envelope's `type` rides along with `unavailableType`. It is
+			// the only thing that survives a decryption failure to say what the
+			// message was — the server stamps it on the sender's outgoing
+			// stanza, in the clear — and dropping it here left a consumer with
+			// a placeholder it could not classify at all.
+			messageStubParameters: [evt.unavailableType, evt.stanzaType].filter(
+				(value): value is string => !!value
+			)
 		}) as WAMessage
 		if (evt.participantAlt) stubMsg.key.participantAlt = evt.participantAlt
 		if (evt.remoteJidAlt) stubMsg.key.remoteJidAlt = evt.remoteJidAlt

--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -37,6 +37,15 @@ export type WAMessage = Omit<proto.IWebMessageInfo, 'messageStubParameters' | 'm
 	// Kept deliberately broad by upstream Baileys for legacy stub payloads.
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	messageStubParameters?: any
+	/**
+	 * The envelope's `type` attribute, as the server stamped it on the sending
+	 * stanza: `"text"`, `"media"`, `"pay"`, `"poll"`, `"reaction"`, `"event"`.
+	 *
+	 * Set only on the CIPHERTEXT stub emitted for a message that failed to
+	 * decrypt, where it is the one fact about the message that survives — it
+	 * describes the stanza, not the ciphertext. Absent everywhere else.
+	 */
+	stanzaType?: string
 }
 export type WAMessageContent = proto.IMessage
 export type WAContactMessage = proto.Message.IContactMessage

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -963,7 +963,7 @@ describe('dispatch: undecryptable_message', () => {
 		expect(stub?.messageStubParameters).toEqual(['view_once'])
 	})
 
-	it("leaves messageStubParameters alone when the stanza has no unavailable type", () => {
+	it('leaves messageStubParameters alone when the stanza has no unavailable type', () => {
 		const upserts = collect(
 			{
 				type: 'undecryptable_message',

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -958,10 +958,12 @@ describe('dispatch: undecryptable_message', () => {
 			},
 			'messages.upsert'
 		)
-		expect(upserts[0]?.messages[0]?.messageStubParameters).toEqual(['view_once', 'pay'])
+		const stub = upserts[0]?.messages[0]
+		expect(stub?.stanzaType).toBe('pay')
+		expect(stub?.messageStubParameters).toEqual(['view_once'])
 	})
 
-	it("carries the envelope's type when the stanza has no unavailable type", () => {
+	it("leaves messageStubParameters alone when the stanza has no unavailable type", () => {
 		const upserts = collect(
 			{
 				type: 'undecryptable_message',
@@ -974,7 +976,9 @@ describe('dispatch: undecryptable_message', () => {
 			},
 			'messages.upsert'
 		)
-		expect(upserts[0]?.messages[0]?.messageStubParameters).toEqual(['pay'])
+		const stub = upserts[0]?.messages[0]
+		expect(stub?.stanzaType).toBe('pay')
+		expect(stub?.messageStubParameters).toEqual([])
 	})
 
 	it("suppresses emission when decrypt_fail_mode is 'hide'", () => {

--- a/src/__tests__/regressions.test.ts
+++ b/src/__tests__/regressions.test.ts
@@ -942,6 +942,41 @@ describe('dispatch: undecryptable_message', () => {
 		expect(stub?.key.id).toBe('BAD-1')
 	})
 
+	// The envelope's `type` is the one thing that survives a decryption failure
+	// to say what the message was: the server stamps it on the sender's
+	// outgoing stanza, in the clear. A consumer moderating a message it cannot
+	// read — a payment stanza, say — has nothing else to classify it by.
+	it("carries the envelope's type alongside the unavailable type", () => {
+		const upserts = collect(
+			{
+				type: 'undecryptable_message',
+				data: {
+					...baseUndecryptable,
+					info: { ...baseUndecryptable.info, type: 'pay' },
+					decrypt_fail_mode: 'show'
+				}
+			},
+			'messages.upsert'
+		)
+		expect(upserts[0]?.messages[0]?.messageStubParameters).toEqual(['view_once', 'pay'])
+	})
+
+	it("carries the envelope's type when the stanza has no unavailable type", () => {
+		const upserts = collect(
+			{
+				type: 'undecryptable_message',
+				data: {
+					...baseUndecryptable,
+					info: { ...baseUndecryptable.info, type: 'pay' },
+					unavailable_type: undefined,
+					decrypt_fail_mode: 'show'
+				}
+			},
+			'messages.upsert'
+		)
+		expect(upserts[0]?.messages[0]?.messageStubParameters).toEqual(['pay'])
+	})
+
 	it("suppresses emission when decrypt_fail_mode is 'hide'", () => {
 		const upserts = collect(
 			{ type: 'undecryptable_message', data: { ...baseUndecryptable, decrypt_fail_mode: 'hide' } },


### PR DESCRIPTION
## Summary

The stub emitted for a message that failed to decrypt says it is a CIPHERTEXT placeholder and, when the server named one, why it is unavailable. It does not say what the message *was* — even though the bridge hands that over on every one of them: `MessageInfo.type` is the envelope's `type` attribute (`"text" | "media" | "pay" | "poll" | "reaction" | "event"`), read from the stanza in the clear.

That attribute is the only thing about an unreadable message a consumer can still trust:

- it describes the **stanza**, not the ciphertext, so a decryption failure does not take it away;
- the server stamps it on the **sender's own** outgoing stanza, so it cannot be pointed at somebody else — unlike a `contextInfo.participant` in a quote, which names a third party and needs corroboration.

## Why it came up

Group moderation. A payment stanza whose sender deliberately withholds the sender key from one device arrives there as a placeholder that device cannot classify at all — the admins never see the content, and the bot holding the connection has nothing to act on. The signals left are a third party quoting the message, or a human reporting it: both are after the fact, and both need anti-forgery checks precisely because they point at someone else.

`type="pay"` on the envelope needs none of that. The same client on the Rust side reads `StanzaMessageType::Pay` off `Event::UndecryptableMessage` and acts on it directly; a JS consumer cannot, only because this handler drops the field.

## Changes

- `Bridge/types.ts` — `stanzaType` on the undecryptable event.
- `Bridge/schema.ts` — the adapter reads `info.type`, which it already had in hand.
- `Socket/events.ts` — it rides in `messageStubParameters` beside `unavailableType`, which is where the stub already carries envelope facts. Both are filtered for presence, so a stanza with neither still emits `[]` and nothing changes for a consumer that reads neither.

## Tests

Two beside the existing `undecryptable_message` cases: the type alongside an `unavailable_type`, and alone when the stanza carries none.

```
npx tsc -P tsconfig.build.json --noEmit    clean
npm test                                   1534 passed, 0 failed
```

## Not verified

No live account here, so nothing proves end to end that a real withheld-sender-key payment arrives with `type="pay"` — that claim rests on the bridge's own doc comment for `MessageInfo::type` and on the Rust client reading it from the same event.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carries the envelope's `type` on undecryptable message stubs so consumers can still classify a message whose content failed to decrypt.

Previously the stub only said it was a CIPHERTEXT placeholder and, when supplied, why it was unavailable. Now the stub carries `stanzaType` — the server-stamped envelope `type` (`"text" | "media" | "pay" | "poll" | "reaction" | "event"`) as its own field. It survives decryption failure and can't be attributed to a third party.

- Adds `stanzaType` to `CanonicalUndecryptableMessage` and reads it from `info.type` in the schema adapter.
- Emits it as a named field on the stub; `messageStubParameters` is untouched, so existing consumers see no shape change.
- Adds tests for the type with and without an `unavailable_type`.
- Documents the divergence from upstream in the README's Gotchas.

**Not verified**
- End-to-end delivery of a real withheld-sender-key payment stanza was not tested; the type's presence relies on the bridge's `MessageInfo.type` contract.

<sup>Written for commit 56c745e7b01b7d0d286b3f366a133165710414cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Undecryptable messages now retain their original message type, such as text, media, payments, polls, reactions, or events.
  * Placeholder ciphertext messages now include this type alongside any unavailable-message details, improving message classification when decryption fails.

* **Tests**
  * Added coverage for undecryptable messages both with and without unavailable-message type information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->