### PR TITLE
fix(deps): bump @oxidezap/whatsapp-rust-bridge to 0.21.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
-        "@oxidezap/whatsapp-rust-bridge": "0.21.3",
+        "@oxidezap/whatsapp-rust-bridge": "0.21.4",
         "long": "^5.3.2",
         "pino": "^10.3.1"
       },
@@ -73,6 +73,7 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.1.tgz",
       "integrity": "sha512-agRJn3+EJDUe8AvxTx/LnHA/GErvLE62pSaSk7+MwFOtOv8eWBu/qCq2qoZjBjVZ3C2aiFJCveuSs17KMkYGOw==",
+      "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cacheable/memory": {
@@ -979,13 +980,10 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.21.3.tgz",
-      "integrity": "sha512-dDotpd0kwf1C9L0pZnw9p5db+ZBtmh7OpK5EnmjMrXfYWIIWAoty/d28kfx75lMDokmdzp/RWoFE3hAdR6MAIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@bufbuild/protobuf": "^2.14.1"
-      }
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.21.4.tgz",
+      "integrity": "sha512-+WNLxNuN3wBbsH7WlAE+b2ciLhJ+iahctxuadm8ue5xxOMoqI5RjTK/wZLs6eOi4FoKMV+bXgQEW77msCRzvfA==",
+      "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
       "version": "1.81.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",
-    "@oxidezap/whatsapp-rust-bridge": "0.21.3",
+    "@oxidezap/whatsapp-rust-bridge": "0.21.4",
     "long": "^5.3.2",
     "pino": "^10.3.1"
   },


### PR DESCRIPTION
Bumps @oxidezap/whatsapp-rust-bridge from 0.21.3 to 0.21.4.

Upstream release v0.21.4 (https://github.com/oxidezap/whatsapp-rust-bridge/releases/tag/v0.21.4) headline fix is deps: move @bufbuild/protobuf to devDependencies (#113). The lockfile reflects this: the bridge entry drops its runtime dependency block and the hoisted @bufbuild/protobuf copy is now dev-only.

Verified: npm view confirms 0.21.4 is latest on npm; installed node_modules resolves to 0.21.4; lockfile diff is bridge-only (package spec, bridge entry, dev flag on @bufbuild/protobuf); npx tsc --noEmit and npx oxlint pass.

Did not verify: full npm test, build, compat audits, and E2E against the mock or live server.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@oxidezap/whatsapp-rust-bridge` from 0.21.3 to 0.21.4, which moves `@bufbuild/protobuf` to devDependencies and removes it from the bridge's runtime dependencies.

**Dependencies**
- Updates the bridge package spec and lockfile entry.
- `@bufbuild/protobuf` is now marked dev-only in the lockfile.

<sup>Written for commit 85c81ac5c0ef898542852f33ffce29e0f287c8ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the WhatsApp integration dependency to version 0.21.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->