### PR TITLE
ci: fix lint and format findings automatically with autofix.ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,56 @@
+name: autofix.ci
+
+# Commit the fixes `npm run lint:fix` already knows how to make — `oxlint
+# --fix` plus `oxfmt` — back to the pull request, so routine lint and format
+# findings fix themselves instead of bouncing the PR. The workflow name is part
+# of the setup: autofix.ci uses it to recognise this job's commits.
+#
+# One manual step outside this file: install the autofix.ci GitHub App on the
+# repository. Without it this job runs the fixers and has nothing to commit
+# through.
+#
+# Scope, on purpose:
+#   * Covers only what the fixers can rewrite: oxlint suggestions and oxfmt
+#     formatting over `src` and `Example`, the same tree `format:check` reads.
+#   * Everything else stays a reporting check in CI: `tsc` type errors, tests,
+#     the build, the e2e suite, fuzz and the release path never rewrite code.
+#
+# The job holds `contents: read`: pushing the fix is the App's job, through its
+# own installation token, not this runner's.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+# One run per PR or ref. A newer commit on a PR supersedes the run fixing the
+# older one; pushes to main queue instead, so each commit gets its own fix.
+concurrency:
+  group: autofix-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  autofix:
+    name: Fix lint & format
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      # --ignore-scripts skips `prepare`, like the lint job: the fixers read
+      # `src` and `Example`, never `lib`.
+      - run: npm ci --ignore-scripts
+
+      # The repo's own fixer: `oxlint --fix && oxfmt src Example`.
+      - run: npm run lint:fix
+
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -50,7 +50,29 @@ jobs:
       # `src` and `Example`, never `lib`.
       - run: npm ci --ignore-scripts
 
-      # The repo's own fixer: `oxlint --fix && oxfmt src Example`.
-      - run: npm run lint:fix
+      # Two steps instead of `npm run lint:fix` on purpose. `oxlint --fix`
+      # exits nonzero while unfixable findings remain, and the script's `&&`
+      # would then skip the formatter — so on exactly the mixed-error PRs this
+      # workflow exists for, neither the lint fixes already made nor any
+      # formatting fix would reach the commit below. Each fixer runs; the
+      # leftover failure is reported at the end instead, and the job still
+      # fails on it.
+      - name: Fix auto-fixable lint findings
+        id: lint-fix
+        continue-on-error: true
+        run: npm exec -- oxlint --fix
 
+      # Same formatter and scope as `npm run format`: `oxfmt src Example`.
+      - name: Format
+        run: npm run format
+
+      # `always()`: publish whatever the fixers produced even when the lint
+      # step above reported findings it could not fix.
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a
+        if: always()
+
+      # Still a check, not just a committer: mixed-error PRs stay red until
+      # the manual part is fixed. The CI lint job reports the same leftovers.
+      - name: Fail on findings the fixers could not fix
+        if: steps.lint-fix.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
Adds an autofix.ci workflow so routine lint and format findings get committed back to the pull request instead of bouncing it.

What it runs: the repo's own fixer, npm run lint:fix (oxlint --fix plus oxfmt over src and Example), then hands any resulting diff to the autofix.ci app, which commits it to the PR branch. Nothing else is covered on purpose: type errors, tests, build, e2e, fuzz and release checks keep reporting and never rewrite code.

Details worth knowing:

- The workflow file follows the setup in the autofix.ci docs: workflow named autofix.ci, triggers on pull requests and pushes to main, contents: read. Pushing the fix is the app's job through its own token, not the runner's.
- Action pins match this repo's habits (pinned by hash, same checkout and setup-node hashes as ci.yml). The autofix action pin is the current head of autofix-ci/action, checked today.
- One manual step remains outside this change: someone with admin rights needs to install the autofix.ci app on the repository. Until then the new job runs the fixers and has nothing to commit through.

Checked before opening:

- The new workflow parses as valid YAML with the expected triggers, permissions and steps.
- Ran npm run lint:fix locally on a clean tree: exits 0 and changes nothing, so the job stays quiet on clean pull requests and only touches files the fixers rewrite.
- Also confirmed oxlint --fix exits 1 when an unfixable finding is left, so those cases still fail loudly in CI for the author to fix by hand.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an autofix.ci workflow that commits routine lint and format fixes back to the pull request instead of bouncing it. It runs `oxlint --fix` and `oxfmt` as separate steps, so even when some lint findings can't be auto-fixed, the formatting fixes still get committed before the job fails on the remaining ones. Type errors, tests, build, e2e, fuzz, and release checks stay reporting-only.

One manual step remains outside this change: an admin needs to install the autofix.ci GitHub App on the repository. Until then the job runs the fixers but has nothing to commit through.

<sup>Written for commit 7e5c3770b69df407c910d164c7b268d1e5332119. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

