### PR TITLE
fix(deps): make boom and pino optional peers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Rust owns protocol parsing, Signal/session state, operational retries, media enc
 - Preserve client ownership and teardown ordering. Never free a WASM client while operations use it. Transient retries report `connecting`; terminal `close` is once-only. Do not add a competing reconnect loop.
 - Native binary auth and upstream JSON auth need different loaders. Preserve migration paths and `bridge-` rows in backups. Keep per-key ordering, required byte snapshots, durability barriers, and honest flush errors.
 - Never expose real credentials, session keys, QR data, or auth folders. Keep mock TLS/certificate bypasses out of production defaults.
+- Keep optional dependencies peer-only with a local fallback (`src/Utils/boom.ts`, `src/Utils/logger.ts` are the pattern) and keep published `.d.ts` free of bare imports of them. The declaration audit checks mutual assignability, so a fallback type must match the peer member for member.
 
 ## Verification
 
@@ -61,3 +62,10 @@ Report passed, failed, skipped, and blocked checks. For documentation-only chang
 - Keep PRs scoped, with compatibility evidence and performance measurements when applicable. Use English titles and bodies. Commit or publish only when requested; never include trailers or tool signatures.
 - PR titles become squash commit titles. Follow [.github/workflows/release.yml](.github/workflows/release.yml) and [release-please-config.json](release-please-config.json). With the current configuration, `feat`, `fix`, `perf`, `deps`, and `refactor` can generate a release PR. Use `fix(deps): ...` for runtime upgrades intended for release; keep documentation-only changes as `docs`.
 - Let release-please manage versions and release notes unless asked otherwise. Preserve publication of the exact CI-verified build. Do not ship preview URLs as runtime dependency pins.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -88,6 +88,37 @@ That writes the alias to your `package.json` (with the latest version at install
 Every `import { makeWASocket } from '@whiskeysockets/baileys'` in your codebase
 now resolves to baileyrs.
 
+### What gets installed
+
+`npm install @oxidezap/baileyrs` always brings two runtime dependencies.
+
+- `@oxidezap/whatsapp-rust-bridge` is the Rust engine doing the protocol
+  work. It is the library, not an add-on, so it stays a hard dependency.
+- `long` stays too. Fields like `messageTimestamp` and `fileLength` are
+  `Long` objects in the types, and the package builds real ones at runtime.
+  A consumer without it fails compilation in four declaration files and
+  fails at import, so there is nothing to save by dropping it. I checked.
+
+Everything else is an optional peer. It is used when present and skipped
+when not.
+
+| Peer | What it does | Without it |
+| --- | --- | --- |
+| `@hapi/boom` (`^9` or `^10`) | Backs the exported `Boom` errors | A built-in implementation with the same shape |
+| `pino` (`^9` or `^10`) | Backs the default logger | JSON lines on stdout, same redaction |
+| `sharp`, `jimp`, `audio-decode`, `link-preview-js`, `music-metadata` | Media work | Same behavior as before this change |
+
+Two setups both work.
+
+- Migrating a Baileys project. Your tree already has `@hapi/boom` and
+  `pino`, and baileyrs reuses those copies. Error identity is shared, so
+  `instanceof` and `isBoom` checks against your own copy keep passing.
+  Install nothing, remove nothing.
+- Fresh project. Install only what you touch. The defaults work with zero
+  extra dependencies. Add `@hapi/boom` if you compare errors against
+  another library's copy, and `pino` if you want transports and
+  pretty-printing instead of stdout JSON.
+
 ### Preview builds
 
 Every commit on `main` and every pull request publishes an installable build
@@ -304,11 +335,12 @@ A few behaviors that differ from upstream — almost always to your advantage:
   of one group can pick the same one, and a handler that keys on it would drop
   the second person's message rather than a duplicate. That is why the engine's
   own check carries the sender too.
-- **`Boom` ships in the box.** baileyrs exports its own
+- **`Boom` works with or without `@hapi/boom`.** baileyrs exports a
   `@hapi/boom`-compatible `Boom`, so the existing
-  `(err as Boom).output.statusCode` pattern works unchanged. If your
-  `package.json` was pulling `@hapi/boom` only for baileys, you can drop
-  the dependency.
+  `(err as Boom).output.statusCode` pattern works unchanged. The package is
+  an optional peer. With it installed your copy backs the export, without
+  it a built-in implementation with the same shape does. See
+  [What gets installed](#what-gets-installed).
 - **Audio duration needs the optional `music-metadata` peer.** Upstream
   Baileys bundles it as a hard dependency; here it is optional like the
   other media peers (`sharp`, `jimp`, `audio-decode`, `link-preview-js`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,12 @@
       "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
-        "@hapi/boom": "^10.0.1",
         "@oxidezap/whatsapp-rust-bridge": "0.21.4",
-        "long": "^5.3.2",
-        "pino": "^10.3.1"
+        "long": "^5.3.2"
       },
       "devDependencies": {
         "@bufbuild/protobuf": "^2.13.0",
+        "@hapi/boom": "^10.0.1",
         "@types/node": "^26.1.1",
         "baileys": "7.0.0-rc14",
         "jimp": "^1.6.0",
@@ -23,6 +22,7 @@
         "music-metadata": "^11.14.0",
         "oxfmt": "^0.66.0",
         "oxlint": "1.81.0",
+        "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "pkg-pr-new": "^0.0.88",
         "protobufjs": "^8.8.0",
@@ -34,13 +34,18 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
+        "@hapi/boom": "^9.1.0 || ^10.0.0",
         "audio-decode": "^2.1.3",
         "jimp": "^1.6.0",
         "link-preview-js": "^3.0.0",
         "music-metadata": "^11.14.0",
+        "pino": "^9.0.0 || ^10.0.0",
         "sharp": "*"
       },
       "peerDependenciesMeta": {
+        "@hapi/boom": {
+          "optional": true
+        },
         "audio-decode": {
           "optional": true
         },
@@ -51,6 +56,9 @@
           "optional": true
         },
         "music-metadata": {
+          "optional": true
+        },
+        "pino": {
           "optional": true
         },
         "sharp": {
@@ -119,6 +127,7 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.1.tgz",
       "integrity": "sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^11.0.2"
@@ -128,6 +137,7 @@
       "version": "11.0.7",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
       "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@jimp/core": {
@@ -1336,6 +1346,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
@@ -1810,6 +1821,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -2745,6 +2757,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -2980,6 +2993,7 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
       "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
@@ -3002,6 +3016,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
       "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
@@ -3036,6 +3051,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pixelmatch": {
@@ -3085,6 +3101,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
       "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3166,12 +3183,14 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
@@ -3216,6 +3235,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3262,6 +3282,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
       "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -3271,6 +3292,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -3310,6 +3332,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
       "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "real-require": "^1.0.0"
@@ -3322,6 +3345,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
       "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinycolor2": {

--- a/package.json
+++ b/package.json
@@ -82,13 +82,12 @@
     "test:e2e": "NODE_TLS_REJECT_UNAUTHORIZED=0 ADV_SECRET_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= node --expose-gc --test --test-concurrency=1 ./src/__tests__/e2e/*.test-e2e.ts ./scripts/compatibility/__tests__/*.test-e2e.ts"
   },
   "dependencies": {
-    "@hapi/boom": "^10.0.1",
     "@oxidezap/whatsapp-rust-bridge": "0.21.4",
-    "long": "^5.3.2",
-    "pino": "^10.3.1"
+    "long": "^5.3.2"
   },
   "devDependencies": {
     "@bufbuild/protobuf": "^2.13.0",
+    "@hapi/boom": "^10.0.1",
     "@types/node": "^26.1.1",
     "baileys": "7.0.0-rc14",
     "jimp": "^1.6.0",
@@ -96,6 +95,7 @@
     "music-metadata": "^11.14.0",
     "oxfmt": "^0.66.0",
     "oxlint": "1.81.0",
+    "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "pkg-pr-new": "^0.0.88",
     "protobufjs": "^8.8.0",
@@ -104,13 +104,18 @@
     "typescript-compat-auditor": "npm:typescript@6.0.3"
   },
   "peerDependencies": {
+    "@hapi/boom": "^9.1.0 || ^10.0.0",
     "audio-decode": "^2.1.3",
     "jimp": "^1.6.0",
     "link-preview-js": "^3.0.0",
     "music-metadata": "^11.14.0",
+    "pino": "^9.0.0 || ^10.0.0",
     "sharp": "*"
   },
   "peerDependenciesMeta": {
+    "@hapi/boom": {
+      "optional": true
+    },
     "audio-decode": {
       "optional": true
     },
@@ -121,6 +126,9 @@
       "optional": true
     },
     "music-metadata": {
+      "optional": true
+    },
+    "pino": {
       "optional": true
     },
     "sharp": {

--- a/src/Utils/boom.ts
+++ b/src/Utils/boom.ts
@@ -11,7 +11,7 @@
  * adding the dependency.
  */
 
-import { createRequire } from 'node:module'
+import { loadOptionalPeer } from './optional-peer.ts'
 
 /** Extra error data carried beside the formatted response. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -239,19 +239,7 @@ interface BoomPeerModule {
 	isBoom: (obj: unknown, statusCode?: number) => obj is Boom
 }
 
-const loadBoomPeer = (): BoomPeerModule | undefined => {
-	const requireFrom = createRequire(import.meta.url)
-	try {
-		requireFrom.resolve('@hapi/boom')
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException)?.code === 'MODULE_NOT_FOUND') return undefined
-		throw error
-	}
-	// Resolved above, so a failure here is a broken installation (e.g. a
-	// missing nested dependency), not an absent peer. Let it throw rather
-	// than silently downgrading every error in the process.
-	return requireFrom('@hapi/boom') as BoomPeerModule
-}
+const loadBoomPeer = (): BoomPeerModule | undefined => loadOptionalPeer<BoomPeerModule>('@hapi/boom')
 
 const peer = loadBoomPeer()
 

--- a/src/Utils/boom.ts
+++ b/src/Utils/boom.ts
@@ -194,11 +194,14 @@ class FallbackBoom<Data = unknown> extends Error implements Boom<Data> {
 
 	constructor(messageOrError?: string | Error, options: BoomOptions<Data> = {}) {
 		if (messageOrError instanceof Error) {
+			// Own properties are copied, the prototype is kept: a custom
+			// Error subclass still answers `instanceof` after wrapping,
+			// exactly like the peer's clone. Boom recognition does not need
+			// the fallback prototype, it goes through `isBoom`.
 			const copy = Object.create(
 				Object.getPrototypeOf(messageOrError),
 				Object.getOwnPropertyDescriptors(messageOrError)
 			) as FallbackBoom<Data>
-			Object.setPrototypeOf(copy, FallbackBoom.prototype)
 			return boomifyFallback(copy, options)
 		}
 		const { statusCode = 500, data = null, ctor = FallbackBoom } = options

--- a/src/Utils/boom.ts
+++ b/src/Utils/boom.ts
@@ -3,6 +3,262 @@
  * making `lastDisconnect.error` and `messages.media-update.error` exactly
  * assignable, this preserves the full Boom runtime contract (`reformat`,
  * `typeof`, mutable output headers and standard payload handling).
+ *
+ * `@hapi/boom` is an optional peer: when the consumer has it installed the
+ * real implementation backs the export, so `instanceof` identity is shared
+ * with the rest of their tree. Otherwise a local implementation with the
+ * same observable behavior backs it, so a fresh install works without
+ * adding the dependency.
  */
-export { Boom, boomify, isBoom } from '@hapi/boom'
-export type { Options as BoomOptions, Output as BoomOutput, Payload as BoomPayload } from '@hapi/boom'
+
+import { createRequire } from 'node:module'
+
+/** Extra error data carried beside the formatted response. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface BoomOptions<Data = any> {
+	/** The HTTP status code. Must be 400 or above. @default 500 */
+	statusCode?: number
+	/** Additional error information. @default null */
+	data?: Data
+	/** Constructor reference used to crop the exception call stack output. */
+	ctor?: Function
+	/** Replacement message applied on top of an existing error. */
+	message?: string
+	/**
+	 * When the input is already a Boom error and a statusCode or message is
+	 * provided, apply them. Pass false to leave the error untouched.
+	 * @default true
+	 */
+	override?: boolean
+	/** Extra properties assigned onto the error object. */
+	decorate?: Record<string, unknown>
+}
+
+/** The formatted object used as the response payload. */
+export interface BoomPayload {
+	/** The HTTP status code derived from error.output.statusCode. */
+	statusCode: number
+	/** The HTTP status message derived from statusCode. */
+	error: string
+	/** The error message derived from error.message. */
+	message: string
+	/** Custom properties. */
+	[key: string]: unknown
+}
+
+/** The formatted response carried on every Boom error. */
+export interface BoomOutput {
+	/** The HTTP status code. */
+	statusCode: number
+	/** HTTP headers, each key a header name. Mutable by design. */
+	headers: { [header: string]: string | string[] | number | undefined }
+	/** The formatted object used as the response payload. */
+	payload: BoomPayload
+}
+
+/** A Boom error instance. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface Boom<Data = any> extends Error {
+	/** Custom error data. Null unless the caller passed `data`. */
+	data?: Data | null
+	/** Always true on a Boom error. Checked by {@link isBoom}. */
+	isBoom: boolean
+	/** True when the status code is 500 or above. */
+	isServer: boolean
+	/** The formatted response. */
+	output: BoomOutput
+	/** The constructor used to create the error. */
+	typeof: Function
+	/**
+	 * Rebuild the payload from the current status code and message.
+	 * Returns the formatted message, matching the peer's declaration.
+	 */
+	reformat(debug?: boolean): string
+}
+
+/** The shared constructor behind the {@link Boom} export. */
+export interface BoomConstructor {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	new <Data = any>(message?: string | Error, options?: BoomOptions<Data>): Boom<Data>
+	readonly prototype: Boom<unknown>
+}
+
+/** Reason phrases per status code, matching the peer's table. */
+const STATUS_MESSAGES: ReadonlyMap<number, string> = new Map([
+	[100, 'Continue'],
+	[101, 'Switching Protocols'],
+	[102, 'Processing'],
+	[200, 'OK'],
+	[201, 'Created'],
+	[202, 'Accepted'],
+	[203, 'Non-Authoritative Information'],
+	[204, 'No Content'],
+	[205, 'Reset Content'],
+	[206, 'Partial Content'],
+	[207, 'Multi-Status'],
+	[300, 'Multiple Choices'],
+	[301, 'Moved Permanently'],
+	[302, 'Moved Temporarily'],
+	[303, 'See Other'],
+	[304, 'Not Modified'],
+	[305, 'Use Proxy'],
+	[307, 'Temporary Redirect'],
+	[400, 'Bad Request'],
+	[401, 'Unauthorized'],
+	[402, 'Payment Required'],
+	[403, 'Forbidden'],
+	[404, 'Not Found'],
+	[405, 'Method Not Allowed'],
+	[406, 'Not Acceptable'],
+	[407, 'Proxy Authentication Required'],
+	[408, 'Request Time-out'],
+	[409, 'Conflict'],
+	[410, 'Gone'],
+	[411, 'Length Required'],
+	[412, 'Precondition Failed'],
+	[413, 'Request Entity Too Large'],
+	[414, 'Request-URI Too Large'],
+	[415, 'Unsupported Media Type'],
+	[416, 'Requested Range Not Satisfiable'],
+	[417, 'Expectation Failed'],
+	[418, "I'm a teapot"],
+	[422, 'Unprocessable Entity'],
+	[423, 'Locked'],
+	[424, 'Failed Dependency'],
+	[425, 'Too Early'],
+	[426, 'Upgrade Required'],
+	[428, 'Precondition Required'],
+	[429, 'Too Many Requests'],
+	[431, 'Request Header Fields Too Large'],
+	[451, 'Unavailable For Legal Reasons'],
+	[500, 'Internal Server Error'],
+	[501, 'Not Implemented'],
+	[502, 'Bad Gateway'],
+	[503, 'Service Unavailable'],
+	[504, 'Gateway Time-out'],
+	[505, 'HTTP Version Not Supported'],
+	[506, 'Variant Also Negotiates'],
+	[507, 'Insufficient Storage'],
+	[509, 'Bandwidth Limit Exceeded'],
+	[510, 'Not Extended'],
+	[511, 'Network Authentication Required']
+])
+
+const reformatBoom = function (this: Boom, debug = false): string {
+	this.output.payload.statusCode = this.output.statusCode
+	this.output.payload.error = STATUS_MESSAGES.get(this.output.statusCode) || 'Unknown'
+	if (this.output.statusCode === 500 && debug !== true) {
+		this.output.payload.message = 'An internal server error occurred'
+	} else if (this.message) {
+		this.output.payload.message = this.message
+	}
+	return this.output.payload.message
+}
+
+const initializeBoom = (error: Boom, statusCode: number, message?: string): Boom => {
+	const code = Number.parseInt(String(statusCode), 10)
+	if (Number.isNaN(code) || code < 400) {
+		throw new Error(`First argument must be a number (400+): ${String(statusCode)}`)
+	}
+	error.isBoom = true
+	error.isServer = code >= 500
+	if (!Object.hasOwn(error, 'data')) error.data = null
+	error.output = { statusCode: code, payload: {} as BoomPayload, headers: {} }
+	Object.defineProperty(error, 'reformat', { value: reformatBoom, configurable: true })
+	if (!message && !error.message) {
+		error.reformat()
+		message = error.output.payload.error
+	}
+	if (message) {
+		error.message = message + (error.message ? `: ${error.message}` : '')
+		error.output.payload.message = error.message
+	}
+	error.reformat()
+	return error
+}
+
+/**
+ * Local stand-in used only when `@hapi/boom` is not installed. Reproduces
+ * the observable contract the rest of the package relies on: `output` with
+ * status code, payload and mutable headers, `data`, `isServer`, `reformat`,
+ * `typeof`, sanitized 500 messages, and `instanceof` recognition through
+ * `Symbol.hasInstance`.
+ */
+class FallbackBoom<Data = unknown> extends Error implements Boom<Data> {
+	data?: Data | null
+	isBoom = true
+	isServer = true
+	output!: BoomOutput
+	typeof!: Function
+	declare reformat: (debug?: boolean) => string
+
+	constructor(messageOrError?: string | Error, options: BoomOptions<Data> = {}) {
+		if (messageOrError instanceof Error) {
+			const copy = Object.create(
+				Object.getPrototypeOf(messageOrError),
+				Object.getOwnPropertyDescriptors(messageOrError)
+			) as FallbackBoom<Data>
+			Object.setPrototypeOf(copy, FallbackBoom.prototype)
+			return boomifyFallback(copy, options)
+		}
+		const { statusCode = 500, data = null, ctor = FallbackBoom } = options
+		super(messageOrError ?? undefined)
+		if (typeof Error.captureStackTrace === 'function') Error.captureStackTrace(this, ctor)
+		this.data = (data ?? null) as Data | null
+		const initialized = initializeBoom(this, statusCode)
+		Object.defineProperty(initialized, 'typeof', { value: ctor })
+		if (options.decorate) Object.assign(initialized, options.decorate)
+		return initialized as unknown as FallbackBoom<Data>
+	}
+
+	static [Symbol.hasInstance](instance: unknown): boolean {
+		return isBoomFallback(instance)
+	}
+}
+
+/** Local `isBoom`: an Error carrying the Boom marker, nothing looser. */
+const isBoomFallback = (obj: unknown, statusCode?: number): obj is Boom =>
+	obj instanceof Error &&
+	(obj as Boom).isBoom === true &&
+	(statusCode === undefined || (obj as Boom).output?.statusCode === statusCode)
+
+/** Local `boomify`: decorate an existing error in place. */
+const boomifyFallback = <Data = unknown>(error: Error, options: BoomOptions<Data> = {}): Boom<Data> => {
+	if (!(error instanceof Error)) throw new Error('Cannot wrap non-Error object')
+	const boom = error as Boom<Data>
+	if (options.data !== undefined) boom.data = options.data as Data
+	if (options.decorate) Object.assign(boom, options.decorate)
+	if (!boom.isBoom) return initializeBoom(boom, options.statusCode ?? 500, options.message) as Boom<Data>
+	if (options.override === false || (!options.statusCode && !options.message)) return boom
+	return initializeBoom(boom, options.statusCode ?? boom.output.statusCode, options.message) as Boom<Data>
+}
+
+interface BoomPeerModule {
+	Boom: BoomConstructor
+	boomify: (error: Error, options?: BoomOptions) => Boom
+	isBoom: (obj: unknown, statusCode?: number) => obj is Boom
+}
+
+const loadBoomPeer = (): BoomPeerModule | undefined => {
+	try {
+		return createRequire(import.meta.url)('@hapi/boom') as BoomPeerModule
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException)?.code === 'MODULE_NOT_FOUND') return undefined
+		throw error
+	}
+}
+
+const peer = loadBoomPeer()
+
+/**
+ * The shared error implementation. The peer's copy when installed, so error
+ * identity is shared with the rest of the consumer's tree, else the local
+ * implementation above.
+ */
+export const Boom: BoomConstructor = (peer?.Boom ?? FallbackBoom) as BoomConstructor
+
+/** Decorate an existing error with the Boom response shape. */
+export const boomify: (error: Error, options?: BoomOptions) => Boom = peer?.boomify ?? boomifyFallback
+
+/** Whether a value is a Boom error, optionally with an exact status code. */
+export const isBoom: (obj: unknown, statusCode?: number) => obj is Boom = peer?.isBoom ?? isBoomFallback

--- a/src/Utils/boom.ts
+++ b/src/Utils/boom.ts
@@ -240,12 +240,17 @@ interface BoomPeerModule {
 }
 
 const loadBoomPeer = (): BoomPeerModule | undefined => {
+	const requireFrom = createRequire(import.meta.url)
 	try {
-		return createRequire(import.meta.url)('@hapi/boom') as BoomPeerModule
+		requireFrom.resolve('@hapi/boom')
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException)?.code === 'MODULE_NOT_FOUND') return undefined
 		throw error
 	}
+	// Resolved above, so a failure here is a broken installation (e.g. a
+	// missing nested dependency), not an absent peer. Let it throw rather
+	// than silently downgrading every error in the process.
+	return requireFrom('@hapi/boom') as BoomPeerModule
 }
 
 const peer = loadBoomPeer()

--- a/src/Utils/logger.ts
+++ b/src/Utils/logger.ts
@@ -1,4 +1,4 @@
-import { createRequire } from 'node:module'
+import { loadOptionalPeer } from './optional-peer.ts'
 
 export interface ILogger {
 	level: string
@@ -307,21 +307,7 @@ const createFallbackLogger = (state: FallbackState): Logger => {
 
 type PinoFactory = (options: Record<string, unknown>) => Logger
 
-/**
- * Resolve the peer without loading it first, so a broken installation
- * (present but unloadable, e.g. a missing nested dependency) surfaces as
- * the real error instead of silently degrading to the fallback.
- */
-const loadPinoPeer = (): PinoFactory | undefined => {
-	const requireFrom = createRequire(import.meta.url)
-	try {
-		requireFrom.resolve('pino')
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException)?.code === 'MODULE_NOT_FOUND') return undefined
-		throw error
-	}
-	return requireFrom('pino') as PinoFactory
-}
+const loadPinoPeer = (): PinoFactory | undefined => loadOptionalPeer<PinoFactory>('pino')
 
 /**
  * Deferred because building pino at module evaluation cost ~10 MB of RSS in every

--- a/src/Utils/logger.ts
+++ b/src/Utils/logger.ts
@@ -1,4 +1,3 @@
-import type { ChildLoggerOptions, Logger, pino as PinoFactory } from 'pino'
 import { createRequire } from 'node:module'
 
 export interface ILogger {
@@ -9,6 +8,33 @@ export interface ILogger {
 	info(obj: unknown, msg?: string): void
 	warn(obj: unknown, msg?: string): void
 	error(obj: unknown, msg?: string): void
+}
+
+/** Options accepted by `child()`. A subset of the peer's own shape. */
+export interface ChildLoggerOptions {
+	level?: string
+	[msgPrefix: string]: unknown
+}
+
+/**
+ * The full logger surface behind the default export. Structural so both the
+ * peer logger and the local fallback satisfy it; deliberately free of any
+ * `pino` import so consumers typecheck with or without the peer installed.
+ */
+export interface Logger {
+	level: string
+	child(bindings: Record<string, unknown>, options?: ChildLoggerOptions): Logger
+	trace(...args: unknown[]): void
+	debug(...args: unknown[]): void
+	info(...args: unknown[]): void
+	warn(...args: unknown[]): void
+	error(...args: unknown[]): void
+	fatal(...args: unknown[]): void
+	silent(...args: unknown[]): void
+	flush(callback?: () => void): void
+	bindings(): Record<string, unknown>
+	levels: { values: Record<string, number>; labels: Record<number, string> }
+	isLevelEnabled(level: string): boolean
 }
 
 const DEFAULT_LEVEL = 'info'
@@ -31,6 +57,131 @@ const REDACTED_PATHS = [
 	'*.secretKey'
 ]
 
+const FALLBACK_LEVEL_VALUES: Record<string, number> = {
+	trace: 10,
+	debug: 20,
+	info: 30,
+	warn: 40,
+	error: 50,
+	fatal: 60,
+	silent: Infinity
+}
+
+const FALLBACK_LEVEL_LABELS: Record<number, string> = Object.fromEntries(
+	Object.entries(FALLBACK_LEVEL_VALUES).map(([name, value]) => [value, name])
+)
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const censorPath = (root: Record<string, unknown>, path: string): void => {
+	if (path.startsWith('*.')) {
+		const key = path.slice(2)
+		for (const value of Object.values(root)) {
+			if (isPlainObject(value) && key in value) value[key] = '[REDACTED]'
+		}
+		if (key in root) root[key] = '[REDACTED]'
+		return
+	}
+	const segments = path.split('.')
+	let current: unknown = root
+	for (let index = 0; index < segments.length - 1; index++) {
+		if (!isPlainObject(current)) return
+		current = current[segments[index]!]
+	}
+	if (isPlainObject(current)) {
+		const leaf = segments[segments.length - 1]!
+		if (leaf in current) current[leaf] = '[REDACTED]'
+	}
+}
+
+const redactForFallback = (value: unknown): unknown => {
+	if (!isPlainObject(value)) return value
+	const copy = structuredClone(value)
+	for (const path of REDACTED_PATHS) censorPath(copy, path)
+	return copy
+}
+
+interface FallbackState {
+	level: string
+	bindings: Record<string, unknown>
+}
+
+/**
+ * Console-backed logger used only when `pino` is not installed. Emits one
+ * JSON line per call with the same `level`/`time`/`msg` shape operators
+ * already parse, redacts the same credential paths, and honors `level` and
+ * `child` bindings so level-gated code keeps working.
+ */
+const createFallbackLogger = (state: FallbackState): Logger => {
+	const isEnabled = (method: string): boolean => {
+		if (state.level === 'silent') return false
+		return (FALLBACK_LEVEL_VALUES[method] ?? 60) >= (FALLBACK_LEVEL_VALUES[state.level] ?? 30)
+	}
+
+	const write = (method: string, args: unknown[]): void => {
+		if (!isEnabled(method)) return
+		let logged: unknown
+		let message: string | undefined
+		const [first, second] = args
+		if (typeof first === 'string') {
+			message = args.map(entry => (typeof entry === 'string' ? entry : JSON.stringify(entry))).join(' ')
+		} else {
+			logged = redactForFallback(first)
+			if (typeof second === 'string') message = second
+		}
+		const entry: Record<string, unknown> = {
+			level: FALLBACK_LEVEL_VALUES[method] ?? 30,
+			time: new Date().toJSON(),
+			...state.bindings
+		}
+		if (isPlainObject(logged)) Object.assign(entry, logged)
+		else if (logged !== undefined) entry.data = logged
+		if (message !== undefined) entry.msg = message
+		process.stdout.write(`${JSON.stringify(entry)}\n`)
+	}
+
+	const logger: Logger = {
+		get level() {
+			return state.level
+		},
+		set level(next: string) {
+			state.level = next
+		},
+		child: (extra: Record<string, unknown>, options?: ChildLoggerOptions): Logger =>
+			createFallbackLogger({
+				level: options?.level ?? state.level,
+				bindings: { ...state.bindings, ...extra }
+			}),
+		trace: (...args: unknown[]) => write('trace', args),
+		debug: (...args: unknown[]) => write('debug', args),
+		info: (...args: unknown[]) => write('info', args),
+		warn: (...args: unknown[]) => write('warn', args),
+		error: (...args: unknown[]) => write('error', args),
+		fatal: (...args: unknown[]) => write('fatal', args),
+		silent: () => {},
+		flush: (callback?: () => void) => callback?.(),
+		bindings: () => ({ ...state.bindings }),
+		levels: { values: { ...FALLBACK_LEVEL_VALUES }, labels: { ...FALLBACK_LEVEL_LABELS } },
+		isLevelEnabled: (level: string) => {
+			if (state.level === 'silent') return false
+			return (FALLBACK_LEVEL_VALUES[level] ?? Infinity) >= (FALLBACK_LEVEL_VALUES[state.level] ?? 30)
+		}
+	}
+	return logger
+}
+
+type PinoFactory = (options: Record<string, unknown>) => Logger
+
+const loadPinoPeer = (): PinoFactory | undefined => {
+	try {
+		return createRequire(import.meta.url)('pino') as PinoFactory
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException)?.code === 'MODULE_NOT_FOUND') return undefined
+		throw error
+	}
+}
+
 /**
  * Deferred because building pino at module evaluation cost ~10 MB of RSS in every
  * importing process: ~4.5 MB for pino's module graph, the rest for the Date/ICU
@@ -45,30 +196,32 @@ let rootLogger: Logger | undefined
 
 const resolveRootLogger = (): Logger => {
 	if (!rootLogger) {
-		const requireFrom = createRequire(import.meta.url)
-		const pino = requireFrom('pino') as typeof PinoFactory
-		rootLogger = pino({
-			name: 'baileyrs',
-			level: process.env.BAILEYRS_LOG_LEVEL || DEFAULT_LEVEL,
-			timestamp: () => `,"time":"${new Date().toJSON()}"`,
-			redact: { paths: REDACTED_PATHS, censor: '[REDACTED]' }
-		})
+		const configuredLevel = process.env.BAILEYRS_LOG_LEVEL || DEFAULT_LEVEL
+		const peer = loadPinoPeer()
+		rootLogger = peer
+			? peer({
+					name: 'baileyrs',
+					level: configuredLevel,
+					timestamp: () => `,"time":"${new Date().toJSON()}"`,
+					redact: { paths: REDACTED_PATHS, censor: '[REDACTED]' }
+				})
+			: createFallbackLogger({ level: configuredLevel, bindings: { name: 'baileyrs' } })
 	}
 	return rootLogger
 }
 
 /**
- * Stands in for the pino logger without building it.
+ * Stands in for the built logger without building it.
  *
  * A Proxy rather than a hand-written shim, because the default export is public
- * API (`@oxidezap/baileyrs/logger`) and must keep pino's whole surface — `fatal`,
+ * API (`@oxidezap/baileyrs/logger`) and must keep the whole surface — `fatal`,
  * `silent`, `flush`, `bindings`, `levels` — not just the six members ILogger
  * declares. Members are cached so a hot logging path costs a map lookup instead
  * of a fresh bound function per call.
  *
  * `child()` and reading `level` are answered without resolving, which is what
  * lets `DEFAULT_CONNECTION_CONFIG.logger` and `logger.level === 'trace'` guards
- * work while pino stays unbuilt until something actually logs.
+ * work while the underlying logger stays unbuilt until something actually logs.
  *
  * A child defers to its *parent* rather than to the root, so a level assigned to
  * the parent before either has resolved still reaches it — pino children inherit
@@ -108,8 +261,8 @@ const createDeferredLogger = (
 	const child = (extra: Record<string, unknown>, options?: ChildLoggerOptions): Logger =>
 		createDeferredLogger(extra, self, options)
 
-	// Typed as pino's Logger, not ILogger: narrowing would reject `logger.fatal(...)`
-	// at compile time even though the proxy forwards it.
+	// Typed as the full Logger, not ILogger: narrowing would reject
+	// `logger.fatal(...)` at compile time even though the proxy forwards it.
 	const target = {} as Logger
 	return new Proxy(target, {
 		get(_target, property) {
@@ -130,7 +283,7 @@ const createDeferredLogger = (
 				return true
 			}
 			;(resolve() as unknown as Record<PropertyKey, unknown>)[property] = value
-			// Whole cache, not just this key: pino swaps its log methods for noops
+			// Whole cache, not just this key: the peer swaps its log methods for noops
 			// when `level` changes, so a cached `info` would stay silent forever.
 			members.clear()
 			return true

--- a/src/Utils/logger.ts
+++ b/src/Utils/logger.ts
@@ -10,10 +10,11 @@ export interface ILogger {
 	error(obj: unknown, msg?: string): void
 }
 
-/** Options accepted by `child()`. A subset of the peer's own shape. */
+/** Options accepted by `child()`. The fallback honors `level`; anything else
+ * is accepted for signature compatibility and ignored there. */
 export interface ChildLoggerOptions {
 	level?: string
-	[msgPrefix: string]: unknown
+	[option: string]: unknown
 }
 
 /**
@@ -33,6 +34,10 @@ export interface Logger {
 	silent(...args: unknown[]): void
 	flush(callback?: () => void): void
 	bindings(): Record<string, unknown>
+	/** Replace the bindings carried on every line from here on. */
+	setBindings(bindings: Record<string, unknown>): void
+	/** Numeric value of the current level. Mirrors the peer. */
+	readonly levelVal: number
 	levels: { values: Record<string, number>; labels: Record<number, string> }
 	isLevelEnabled(level: string): boolean
 }
@@ -74,6 +79,59 @@ const FALLBACK_LEVEL_LABELS: Record<number, string> = Object.fromEntries(
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
 	typeof value === 'object' && value !== null && !Array.isArray(value)
 
+const CIRCULAR_SENTINEL = '[Circular]'
+const UNSERIALIZABLE_SENTINEL = '[Unserializable]'
+
+const readProperty = (holder: Record<string, unknown>, key: string): unknown => {
+	try {
+		return holder[key]
+	} catch {
+		return UNSERIALIZABLE_SENTINEL
+	}
+}
+
+/** An Error as plain data: type, message and stack survive serialization. */
+const errorToRecord = (error: Error): Record<string, unknown> => {
+	const record: Record<string, unknown> = { type: error.name, message: error.message }
+	if (typeof error.stack === 'string') record.stack = error.stack
+	const fields = error as unknown as Record<string, unknown>
+	for (const key of Object.keys(error)) record[key] = readProperty(fields, key)
+	if ('cause' in error) record.cause = readProperty(fields, 'cause')
+	return record
+}
+
+/**
+ * Deep-clone a logged value into JSON-safe data. Circular references become
+ * `[Circular]`, `BigInt` its string form, `Error` a record carrying message
+ * and stack. Never throws: logging must not crash the process it observes.
+ */
+const cloneForLog = (value: unknown, seen = new Set<object>()): unknown => {
+	try {
+		if (typeof value === 'bigint') return String(value)
+		if (value instanceof Error) return cloneForLog(errorToRecord(value), seen)
+		if (Array.isArray(value)) {
+			if (seen.has(value)) return CIRCULAR_SENTINEL
+			seen.add(value)
+			const copy = value.map(entry => cloneForLog(entry, seen))
+			seen.delete(value)
+			return copy
+		}
+		if (isPlainObject(value)) {
+			if (seen.has(value)) return CIRCULAR_SENTINEL
+			seen.add(value)
+			const copy: Record<string, unknown> = {}
+			for (const key of Object.keys(value)) copy[key] = cloneForLog(readProperty(value, key), seen)
+			seen.delete(value)
+			return copy
+		}
+		return value
+	} catch {
+		return UNSERIALIZABLE_SENTINEL
+	}
+}
+
+const safeStringify = (value: unknown): string => JSON.stringify(cloneForLog(value)) ?? UNSERIALIZABLE_SENTINEL
+
 const censorPath = (root: Record<string, unknown>, path: string): void => {
 	if (path.startsWith('*.')) {
 		const key = path.slice(2)
@@ -97,9 +155,76 @@ const censorPath = (root: Record<string, unknown>, path: string): void => {
 
 const redactForFallback = (value: unknown): unknown => {
 	if (!isPlainObject(value)) return value
-	const copy = structuredClone(value)
+	const copy = cloneForLog(value) as Record<string, unknown>
 	for (const path of REDACTED_PATHS) censorPath(copy, path)
 	return copy
+}
+
+/**
+ * Minimal `%s`/`%d`/`%i`/`%f`/`%j`/`%o`/`%O` interpolation for the fallback,
+ * mirroring the peer's printf-style messages without adding a dependency.
+ * Leftover arguments are appended rather than dropped so no detail is lost.
+ */
+const formatFallbackMessage = (message: string, args: unknown[]): string => {
+	let index = 0
+	const formatted = message.replace(/%[sdifjoO%]/g, match => {
+		if (match === '%%') return '%'
+		if (index >= args.length) return match
+		const arg = args[index++]
+		switch (match) {
+			case '%s':
+				return String(arg)
+			case '%d':
+			case '%i':
+			case '%f':
+				return String(Number(arg))
+			default:
+				return safeStringify(arg)
+		}
+	})
+	const rest = args.slice(index).map(entry => (typeof entry === 'string' ? entry : safeStringify(entry)))
+	return rest.length > 0 ? `${formatted} ${rest.join(' ')}` : formatted
+}
+
+const levelValue = (level: string, fallback: number): number => FALLBACK_LEVEL_VALUES[level] ?? fallback
+
+export interface FallbackLineInput {
+	method: string
+	currentLevel: string
+	bindings: Record<string, unknown>
+	args: unknown[]
+}
+
+/**
+ * Render one fallback log line, or `undefined` when the level disables it.
+ * Pure so tests can exercise redaction, Error handling and formatting
+ * without hiding the `pino` peer. Never throws.
+ */
+export const formatFallbackLine = ({ method, currentLevel, bindings, args }: FallbackLineInput): string | undefined => {
+	if (currentLevel === 'silent' || levelValue(method, 60) < levelValue(currentLevel, 30)) return undefined
+	let logged: unknown
+	let message: string | undefined
+	const [first, second, ...rest] = args
+	if (typeof first === 'string') {
+		message = formatFallbackMessage(first, second === undefined ? rest : [second, ...rest])
+	} else if (args.length > 0) {
+		logged = redactForFallback(first)
+		if (typeof second === 'string') message = formatFallbackMessage(second, rest)
+		else if (second !== undefined) logged = [logged, cloneForLog(second), ...rest.map(entry => cloneForLog(entry))]
+	}
+	const entry: Record<string, unknown> = {
+		level: levelValue(method, 30),
+		time: new Date().toJSON(),
+		...(redactForFallback(bindings) as Record<string, unknown>)
+	}
+	if (isPlainObject(logged)) Object.assign(entry, logged)
+	else if (logged !== undefined) entry.data = logged
+	if (message !== undefined) entry.msg = message
+	try {
+		return JSON.stringify(entry)
+	} catch {
+		return JSON.stringify({ level: entry.level, time: entry.time, msg: UNSERIALIZABLE_SENTINEL })
+	}
 }
 
 interface FallbackState {
@@ -110,35 +235,15 @@ interface FallbackState {
 /**
  * Console-backed logger used only when `pino` is not installed. Emits one
  * JSON line per call with the same `level`/`time`/`msg` shape operators
- * already parse, redacts the same credential paths, and honors `level` and
- * `child` bindings so level-gated code keeps working.
+ * already parse, redacts the same credential paths from both per-call
+ * objects and child bindings, serializes `Error` values with their message
+ * and stack, and honors `level` and `child` bindings so level-gated code
+ * keeps working. A documented step down from the peer, never a crash.
  */
 const createFallbackLogger = (state: FallbackState): Logger => {
-	const isEnabled = (method: string): boolean => {
-		if (state.level === 'silent') return false
-		return (FALLBACK_LEVEL_VALUES[method] ?? 60) >= (FALLBACK_LEVEL_VALUES[state.level] ?? 30)
-	}
-
 	const write = (method: string, args: unknown[]): void => {
-		if (!isEnabled(method)) return
-		let logged: unknown
-		let message: string | undefined
-		const [first, second] = args
-		if (typeof first === 'string') {
-			message = args.map(entry => (typeof entry === 'string' ? entry : JSON.stringify(entry))).join(' ')
-		} else {
-			logged = redactForFallback(first)
-			if (typeof second === 'string') message = second
-		}
-		const entry: Record<string, unknown> = {
-			level: FALLBACK_LEVEL_VALUES[method] ?? 30,
-			time: new Date().toJSON(),
-			...state.bindings
-		}
-		if (isPlainObject(logged)) Object.assign(entry, logged)
-		else if (logged !== undefined) entry.data = logged
-		if (message !== undefined) entry.msg = message
-		process.stdout.write(`${JSON.stringify(entry)}\n`)
+		const line = formatFallbackLine({ method, currentLevel: state.level, bindings: state.bindings, args })
+		if (line !== undefined) process.stdout.write(`${line}\n`)
 	}
 
 	const logger: Logger = {
@@ -147,6 +252,9 @@ const createFallbackLogger = (state: FallbackState): Logger => {
 		},
 		set level(next: string) {
 			state.level = next
+		},
+		get levelVal() {
+			return levelValue(state.level, 30)
 		},
 		child: (extra: Record<string, unknown>, options?: ChildLoggerOptions): Logger =>
 			createFallbackLogger({
@@ -162,10 +270,13 @@ const createFallbackLogger = (state: FallbackState): Logger => {
 		silent: () => {},
 		flush: (callback?: () => void) => callback?.(),
 		bindings: () => ({ ...state.bindings }),
+		setBindings: (extra: Record<string, unknown>) => {
+			Object.assign(state.bindings, extra)
+		},
 		levels: { values: { ...FALLBACK_LEVEL_VALUES }, labels: { ...FALLBACK_LEVEL_LABELS } },
 		isLevelEnabled: (level: string) => {
 			if (state.level === 'silent') return false
-			return (FALLBACK_LEVEL_VALUES[level] ?? Infinity) >= (FALLBACK_LEVEL_VALUES[state.level] ?? 30)
+			return levelValue(level, Infinity) >= levelValue(state.level, 30)
 		}
 	}
 	return logger
@@ -173,13 +284,20 @@ const createFallbackLogger = (state: FallbackState): Logger => {
 
 type PinoFactory = (options: Record<string, unknown>) => Logger
 
+/**
+ * Resolve the peer without loading it first, so a broken installation
+ * (present but unloadable, e.g. a missing nested dependency) surfaces as
+ * the real error instead of silently degrading to the fallback.
+ */
 const loadPinoPeer = (): PinoFactory | undefined => {
+	const requireFrom = createRequire(import.meta.url)
 	try {
-		return createRequire(import.meta.url)('pino') as PinoFactory
+		requireFrom.resolve('pino')
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException)?.code === 'MODULE_NOT_FOUND') return undefined
 		throw error
 	}
+	return requireFrom('pino') as PinoFactory
 }
 
 /**

--- a/src/Utils/logger.ts
+++ b/src/Utils/logger.ts
@@ -10,10 +10,11 @@ export interface ILogger {
 	error(obj: unknown, msg?: string): void
 }
 
-/** Options accepted by `child()`. The fallback honors `level`; anything else
- * is accepted for signature compatibility and ignored there. */
+/** Options accepted by `child()`. The fallback honors `level` and `msgPrefix`;
+ * anything else is accepted for signature compatibility and ignored there. */
 export interface ChildLoggerOptions {
 	level?: string
+	msgPrefix?: string
 	[option: string]: unknown
 }
 
@@ -38,6 +39,8 @@ export interface Logger {
 	setBindings(bindings: Record<string, unknown>): void
 	/** Numeric value of the current level. Mirrors the peer. */
 	readonly levelVal: number
+	/** Prefix prepended to every message. Mirrors the peer. */
+	readonly msgPrefix: string | undefined
 	levels: { values: Record<string, number>; labels: Record<number, string> }
 	isLevelEnabled(level: string): boolean
 }
@@ -192,6 +195,7 @@ export interface FallbackLineInput {
 	method: string
 	currentLevel: string
 	bindings: Record<string, unknown>
+	msgPrefix?: string
 	args: unknown[]
 }
 
@@ -200,7 +204,13 @@ export interface FallbackLineInput {
  * Pure so tests can exercise redaction, Error handling and formatting
  * without hiding the `pino` peer. Never throws.
  */
-export const formatFallbackLine = ({ method, currentLevel, bindings, args }: FallbackLineInput): string | undefined => {
+export const formatFallbackLine = ({
+	method,
+	currentLevel,
+	bindings,
+	msgPrefix,
+	args
+}: FallbackLineInput): string | undefined => {
 	if (currentLevel === 'silent' || levelValue(method, 60) < levelValue(currentLevel, 30)) return undefined
 	let logged: unknown
 	let message: string | undefined
@@ -212,6 +222,7 @@ export const formatFallbackLine = ({ method, currentLevel, bindings, args }: Fal
 		if (typeof second === 'string') message = formatFallbackMessage(second, rest)
 		else if (second !== undefined) logged = [logged, cloneForLog(second), ...rest.map(entry => cloneForLog(entry))]
 	}
+	if (msgPrefix) message = `${msgPrefix}${message ?? ''}`
 	const entry: Record<string, unknown> = {
 		level: levelValue(method, 30),
 		time: new Date().toJSON(),
@@ -229,6 +240,7 @@ export const formatFallbackLine = ({ method, currentLevel, bindings, args }: Fal
 
 interface FallbackState {
 	level: string
+	msgPrefix?: string
 	bindings: Record<string, unknown>
 }
 
@@ -242,7 +254,13 @@ interface FallbackState {
  */
 const createFallbackLogger = (state: FallbackState): Logger => {
 	const write = (method: string, args: unknown[]): void => {
-		const line = formatFallbackLine({ method, currentLevel: state.level, bindings: state.bindings, args })
+		const line = formatFallbackLine({
+			method,
+			currentLevel: state.level,
+			bindings: state.bindings,
+			msgPrefix: state.msgPrefix,
+			args
+		})
 		if (line !== undefined) process.stdout.write(`${line}\n`)
 	}
 
@@ -256,9 +274,14 @@ const createFallbackLogger = (state: FallbackState): Logger => {
 		get levelVal() {
 			return levelValue(state.level, 30)
 		},
+		get msgPrefix() {
+			return state.msgPrefix
+		},
 		child: (extra: Record<string, unknown>, options?: ChildLoggerOptions): Logger =>
 			createFallbackLogger({
 				level: options?.level ?? state.level,
+				msgPrefix:
+					`${state.msgPrefix ?? ''}${typeof options?.msgPrefix === 'string' ? options.msgPrefix : ''}` || undefined,
 				bindings: { ...state.bindings, ...extra }
 			}),
 		trace: (...args: unknown[]) => write('trace', args),

--- a/src/Utils/logger.ts
+++ b/src/Utils/logger.ts
@@ -41,6 +41,8 @@ export interface Logger {
 	readonly levelVal: number
 	/** Prefix prepended to every message. Mirrors the peer. */
 	readonly msgPrefix: string | undefined
+	/** Callback run on creation of a child. Assignable, like the peer. */
+	onChild: (child: Logger) => void
 	levels: { values: Record<string, number>; labels: Record<number, string> }
 	isLevelEnabled(level: string): boolean
 }
@@ -157,9 +159,17 @@ const censorPath = (root: Record<string, unknown>, path: string): void => {
 }
 
 const redactForFallback = (value: unknown): unknown => {
-	if (!isPlainObject(value)) return value
-	const copy = cloneForLog(value) as Record<string, unknown>
-	for (const path of REDACTED_PATHS) censorPath(copy, path)
+	const copy = cloneForLog(value)
+	if (isPlainObject(copy)) {
+		for (const path of REDACTED_PATHS) censorPath(copy, path)
+	} else if (Array.isArray(copy)) {
+		// Arrays skip the per-call object branch downstream and land under
+		// `data`, so redact each element the same way. Without this a
+		// `[{ privateKey }]` payload leaks while `{ privateKey }` does not.
+		for (const entry of copy) {
+			if (isPlainObject(entry)) for (const path of REDACTED_PATHS) censorPath(entry, path)
+		}
+	}
 	return copy
 }
 
@@ -241,7 +251,34 @@ export const formatFallbackLine = ({
 interface FallbackState {
 	level: string
 	msgPrefix?: string
+	onChild: (child: Logger) => void
 	bindings: Record<string, unknown>
+}
+
+/** Stdout is process-global, so pending-write tracking is too. */
+let fallbackPendingWrites = 0
+const fallbackFlushWaiters: Array<() => void> = []
+
+const noteFallbackDelivered = (): void => {
+	fallbackPendingWrites--
+	if (fallbackPendingWrites === 0) {
+		for (const resume of fallbackFlushWaiters.splice(0, fallbackFlushWaiters.length)) resume()
+	}
+}
+
+const writeFallbackLine = (line: string): void => {
+	fallbackPendingWrites++
+	let settled = false
+	const delivered = (): void => {
+		if (settled) return
+		settled = true
+		noteFallbackDelivered()
+	}
+	try {
+		process.stdout.write(`${line}\n`, delivered)
+	} catch {
+		delivered()
+	}
 }
 
 /**
@@ -261,7 +298,7 @@ const createFallbackLogger = (state: FallbackState): Logger => {
 			msgPrefix: state.msgPrefix,
 			args
 		})
-		if (line !== undefined) process.stdout.write(`${line}\n`)
+		if (line !== undefined) writeFallbackLine(line)
 	}
 
 	const logger: Logger = {
@@ -277,13 +314,23 @@ const createFallbackLogger = (state: FallbackState): Logger => {
 		get msgPrefix() {
 			return state.msgPrefix
 		},
-		child: (extra: Record<string, unknown>, options?: ChildLoggerOptions): Logger =>
-			createFallbackLogger({
+		get onChild() {
+			return state.onChild
+		},
+		set onChild(callback: (child: Logger) => void) {
+			state.onChild = callback
+		},
+		child: (extra: Record<string, unknown>, options?: ChildLoggerOptions): Logger => {
+			const created = createFallbackLogger({
 				level: options?.level ?? state.level,
 				msgPrefix:
 					`${state.msgPrefix ?? ''}${typeof options?.msgPrefix === 'string' ? options.msgPrefix : ''}` || undefined,
+				onChild: state.onChild,
 				bindings: { ...state.bindings, ...extra }
-			}),
+			})
+			state.onChild(created)
+			return created
+		},
 		trace: (...args: unknown[]) => write('trace', args),
 		debug: (...args: unknown[]) => write('debug', args),
 		info: (...args: unknown[]) => write('info', args),
@@ -291,7 +338,13 @@ const createFallbackLogger = (state: FallbackState): Logger => {
 		error: (...args: unknown[]) => write('error', args),
 		fatal: (...args: unknown[]) => write('fatal', args),
 		silent: () => {},
-		flush: (callback?: () => void) => callback?.(),
+		flush: (callback?: () => void) => {
+			// Drain-aware: when stdout is a pipe, earlier lines may still be
+			// queued, and exiting from the callback would lose them.
+			if (!callback) return
+			if (fallbackPendingWrites === 0) callback()
+			else fallbackFlushWaiters.push(callback)
+		},
 		bindings: () => ({ ...state.bindings }),
 		setBindings: (extra: Record<string, unknown>) => {
 			Object.assign(state.bindings, extra)
@@ -332,7 +385,7 @@ const resolveRootLogger = (): Logger => {
 					timestamp: () => `,"time":"${new Date().toJSON()}"`,
 					redact: { paths: REDACTED_PATHS, censor: '[REDACTED]' }
 				})
-			: createFallbackLogger({ level: configuredLevel, bindings: { name: 'baileyrs' } })
+			: createFallbackLogger({ level: configuredLevel, onChild: () => {}, bindings: { name: 'baileyrs' } })
 	}
 	return rootLogger
 }
@@ -366,6 +419,7 @@ const createDeferredLogger = (
 ): Logger => {
 	let resolved: Logger | undefined
 	let pendingLevel: string | undefined
+	let pendingOnChild: ((child: Logger) => void) | undefined
 	const members = new Map<PropertyKey, unknown>()
 
 	const resolve = (): Logger => {
@@ -373,6 +427,7 @@ const createDeferredLogger = (
 			const source = parent ? parent.resolve() : resolveRootLogger()
 			resolved = bindings ? source.child(bindings, childOptions) : source
 			if (pendingLevel !== undefined) resolved.level = pendingLevel
+			if (pendingOnChild !== undefined) resolved.onChild = pendingOnChild
 		}
 		return resolved
 	}
@@ -395,6 +450,7 @@ const createDeferredLogger = (
 		get(_target, property) {
 			if (property === 'child') return child
 			if (property === 'level' && !resolved) return peekLevel()
+			if (property === 'onChild' && !resolved && pendingOnChild !== undefined) return pendingOnChild
 			const cached = members.get(property)
 			if (cached !== undefined) return cached
 			const logger = resolve()
@@ -407,6 +463,12 @@ const createDeferredLogger = (
 		set(_target, property, value) {
 			if (property === 'level' && !resolved) {
 				pendingLevel = value as string
+				return true
+			}
+			if (property === 'onChild' && !resolved) {
+				// Stored like `level`: assigning a hook must not build the
+				// logger the hook observes.
+				pendingOnChild = value as (child: Logger) => void
 				return true
 			}
 			;(resolve() as unknown as Record<PropertyKey, unknown>)[property] = value

--- a/src/Utils/logger.ts
+++ b/src/Utils/logger.ts
@@ -201,6 +201,18 @@ const formatFallbackMessage = (message: string, args: unknown[]): string => {
 
 const levelValue = (level: string, fallback: number): number => FALLBACK_LEVEL_VALUES[level] ?? fallback
 
+/**
+ * Whether a log call at `method` emits under `currentLevel`. Unknown
+ * requested levels are disabled, matching the peer: without the check a
+ * misspelled level maps to Infinity and wrongly enables guarded work.
+ */
+export const isFallbackLevelEnabled = (method: string, currentLevel: string): boolean => {
+	if (currentLevel === 'silent') return false
+	const want = FALLBACK_LEVEL_VALUES[method]
+	if (want === undefined) return false
+	return want >= levelValue(currentLevel, 30)
+}
+
 export interface FallbackLineInput {
 	method: string
 	currentLevel: string
@@ -221,7 +233,7 @@ export const formatFallbackLine = ({
 	msgPrefix,
 	args
 }: FallbackLineInput): string | undefined => {
-	if (currentLevel === 'silent' || levelValue(method, 60) < levelValue(currentLevel, 30)) return undefined
+	if (!isFallbackLevelEnabled(method, currentLevel)) return undefined
 	let logged: unknown
 	let message: string | undefined
 	const [first, second, ...rest] = args
@@ -350,10 +362,7 @@ const createFallbackLogger = (state: FallbackState): Logger => {
 			Object.assign(state.bindings, extra)
 		},
 		levels: { values: { ...FALLBACK_LEVEL_VALUES }, labels: { ...FALLBACK_LEVEL_LABELS } },
-		isLevelEnabled: (level: string) => {
-			if (state.level === 'silent') return false
-			return levelValue(level, Infinity) >= levelValue(state.level, 30)
-		}
+		isLevelEnabled: (level: string) => isFallbackLevelEnabled(level, state.level)
 	}
 	return logger
 }

--- a/src/Utils/optional-peer.ts
+++ b/src/Utils/optional-peer.ts
@@ -1,0 +1,50 @@
+import { createRequire } from 'node:module'
+
+/** Resolution and loading behind {@link loadOptionalPeer}. Injected in tests. */
+export interface PeerLoader {
+	resolveSpecifier(specifier: string): string
+	requireSpecifier(specifier: string): unknown
+}
+
+/** Filesystem-backed loader, rooted at the importing module. */
+export const nodePeerLoader = (baseUrl: string): PeerLoader => {
+	const requireFrom = createRequire(baseUrl)
+	return {
+		resolveSpecifier: specifier => requireFrom.resolve(specifier),
+		requireSpecifier: specifier => requireFrom(specifier)
+	}
+}
+
+const isAbsent = (error: unknown): boolean => (error as NodeJS.ErrnoException)?.code === 'MODULE_NOT_FOUND'
+
+/**
+ * Load an optional peer, distinguishing "not installed" from
+ * "installed but broken".
+ *
+ * Presence is probed through the package manifest, which resolves whenever
+ * the package is installed regardless of the state of its entry point. Only
+ * a missing manifest falls back. Anything else — a broken entry point, a
+ * missing nested dependency — surfaces as an explicit error naming the
+ * peer, so a damaged installation is never silently hidden behind the
+ * fallback.
+ */
+export const loadOptionalPeer = <Module>(
+	specifier: string,
+	loader: PeerLoader = nodePeerLoader(import.meta.url)
+): Module | undefined => {
+	try {
+		loader.resolveSpecifier(`${specifier}/package.json`)
+	} catch (error) {
+		if (isAbsent(error)) return undefined
+		throw error
+	}
+	try {
+		return loader.requireSpecifier(specifier) as Module
+	} catch (error) {
+		throw new Error(
+			`Failed to load optional peer '${specifier}': it is installed but broken. ` +
+				`Reinstall it, or remove it to use the built-in fallback.`,
+			{ cause: error }
+		)
+	}
+}

--- a/src/__tests__/logger-deferred.test.ts
+++ b/src/__tests__/logger-deferred.test.ts
@@ -138,6 +138,19 @@ describe('deferred logger', () => {
 		expect(JSON.parse(lines[0]!)).toMatchObject({ level: 20, scope: 'fresh', msg: 'inherited' })
 	})
 
+	it('holds an assigned onChild, then fires it when the child resolves', async () => {
+		const fresh = (await import(`${'../Utils/logger.ts'}?onchild-instance`)).default as typeof logger
+		const seen: unknown[] = []
+		fresh.onChild = child => {
+			seen.push(child)
+		}
+		const child = fresh.child({ scope: 'lazy' })
+		expect(seen).toHaveLength(0)
+		fresh.level = 'silent'
+		child.info('resolves the child')
+		expect(seen).toHaveLength(1)
+	})
+
 	it('keeps the configured redaction and timestamp format', () => {
 		logger.level = 'info'
 		let lines: string[] = []

--- a/src/__tests__/logger-fallback.test.ts
+++ b/src/__tests__/logger-fallback.test.ts
@@ -110,6 +110,18 @@ describe('fallback log lines', () => {
 		expect(formatFallbackLine(silenced)).toBeUndefined()
 	})
 
+	it('redacts credential paths inside array payloads too', () => {
+		const line = formatFallbackLine({
+			method: 'info',
+			currentLevel: 'info',
+			bindings: {},
+			args: [[{ privateKey: 'shh', keep: 'visible' }]]
+		})
+		const entry = parse(line) as { data: Array<{ privateKey: string; keep: string }> }
+		expect(entry.data[0]?.privateKey).toBe('[REDACTED]')
+		expect(entry.data[0]?.keep).toBe('visible')
+	})
+
 	it('prepends msgPrefix to messages', () => {
 		const line = formatFallbackLine({
 			method: 'info',

--- a/src/__tests__/logger-fallback.test.ts
+++ b/src/__tests__/logger-fallback.test.ts
@@ -109,4 +109,15 @@ describe('fallback log lines', () => {
 		const silenced = { method: 'fatal', currentLevel: 'silent', bindings: {}, args: ['hidden'] }
 		expect(formatFallbackLine(silenced)).toBeUndefined()
 	})
+
+	it('prepends msgPrefix to messages', () => {
+		const line = formatFallbackLine({
+			method: 'info',
+			currentLevel: 'info',
+			bindings: {},
+			msgPrefix: 'worker: ',
+			args: ['started']
+		})
+		expect(parse(line).msg).toBe('worker: started')
+	})
 })

--- a/src/__tests__/logger-fallback.test.ts
+++ b/src/__tests__/logger-fallback.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'node:test'
-import { formatFallbackLine } from '../Utils/logger.ts'
+import { formatFallbackLine, isFallbackLevelEnabled } from '../Utils/logger.ts'
 import { expect } from './expect.ts'
 
 const parse = (line: string | undefined): Record<string, unknown> =>
@@ -131,5 +131,14 @@ describe('fallback log lines', () => {
 			args: ['started']
 		})
 		expect(parse(line).msg).toBe('worker: started')
+	})
+
+	it('reports unknown levels as disabled, like the peer', () => {
+		expect(isFallbackLevelEnabled('typo', 'info')).toBe(false)
+		expect(isFallbackLevelEnabled('TRACE', 'info')).toBe(false)
+		expect(isFallbackLevelEnabled('debug', 'info')).toBe(false)
+		expect(isFallbackLevelEnabled('info', 'info')).toBe(true)
+		expect(isFallbackLevelEnabled('silent', 'info')).toBe(true)
+		expect(isFallbackLevelEnabled('fatal', 'silent')).toBe(false)
 	})
 })

--- a/src/__tests__/logger-fallback.test.ts
+++ b/src/__tests__/logger-fallback.test.ts
@@ -1,0 +1,112 @@
+import { describe, it } from 'node:test'
+import { formatFallbackLine } from '../Utils/logger.ts'
+import { expect } from './expect.ts'
+
+const parse = (line: string | undefined): Record<string, unknown> =>
+	JSON.parse(line as string) as Record<string, unknown>
+
+describe('fallback log lines', () => {
+	it('redacts credential paths in child bindings, not just per-call objects', () => {
+		const line = formatFallbackLine({
+			method: 'info',
+			currentLevel: 'info',
+			bindings: { name: 'baileyrs', session: { secretKey: 'shh' }, keep: 'visible' },
+			args: [{ event: 'test' }]
+		})
+		expect(parse(line)).toMatchObject({
+			session: { secretKey: '[REDACTED]' },
+			keep: 'visible',
+			event: 'test'
+		})
+	})
+
+	it('redacts per-call credential objects and wildcards one level deep', () => {
+		const line = formatFallbackLine({
+			method: 'info',
+			currentLevel: 'info',
+			bindings: {},
+			args: [{ creds: { noiseKey: 'shh' }, nested: { privateKey: 'shh' }, keep: 'visible' }]
+		})
+		const entry = parse(line)
+		expect(entry.creds).toBe('[REDACTED]')
+		expect(entry).toMatchObject({ nested: { privateKey: '[REDACTED]' }, keep: 'visible' })
+	})
+
+	it('never mutates the caller object while redacting', () => {
+		const logged = { creds: { noiseKey: 'shh' } }
+		formatFallbackLine({ method: 'info', currentLevel: 'info', bindings: {}, args: [logged] })
+		expect(logged).toEqual({ creds: { noiseKey: 'shh' } })
+	})
+
+	it('serializes Error values with message and stack instead of dropping them', () => {
+		const error = new Error('boom')
+		const line = formatFallbackLine({
+			method: 'error',
+			currentLevel: 'info',
+			bindings: {},
+			args: [{ err: error }, 'failed']
+		})
+		const entry = parse(line) as { err: { type: string; message: string; stack: string }; msg: string }
+		expect(entry.err.type).toBe('Error')
+		expect(entry.err.message).toBe('boom')
+		expect(typeof entry.err.stack).toBe('string')
+		expect(entry.msg).toBe('failed')
+	})
+
+	it('survives circular structures, BigInt values and functions without throwing', () => {
+		const circular: Record<string, unknown> = { keep: 'visible', big: 10n, fn: () => {} }
+		circular.self = circular
+		const line = formatFallbackLine({ method: 'info', currentLevel: 'info', bindings: {}, args: [circular] })
+		const entry = parse(line) as { keep: string; big: string; self: string }
+		expect(entry.keep).toBe('visible')
+		expect(entry.big).toBe('10')
+		expect(entry.self).toBe('[Circular]')
+		expect('fn' in entry).toBe(false)
+	})
+
+	it('interpolates printf-style placeholders and keeps leftover arguments', () => {
+		const line = formatFallbackLine({
+			method: 'info',
+			currentLevel: 'info',
+			bindings: {},
+			args: ['hello %s, %d left', 'world', 3, { extra: true }]
+		})
+		expect(parse(line).msg).toBe('hello world, 3 left {"extra":true}')
+	})
+
+	it('escapes %% and leaves unmatched placeholders in place', () => {
+		const line = formatFallbackLine({
+			method: 'info',
+			currentLevel: 'info',
+			bindings: {},
+			args: ['100%% sure %s']
+		})
+		expect(parse(line).msg).toBe('100% sure %s')
+	})
+
+	it('interpolates the message of object-first calls', () => {
+		const line = formatFallbackLine({
+			method: 'warn',
+			currentLevel: 'info',
+			bindings: {},
+			args: [{ scope: 'retry' }, 'attempt %d', 2]
+		})
+		const entry = parse(line)
+		expect(entry).toMatchObject({ scope: 'retry', msg: 'attempt 2' })
+	})
+
+	it('emits level, time and msg on string-first calls', () => {
+		const line = formatFallbackLine({ method: 'debug', currentLevel: 'debug', bindings: {}, args: ['hi'] })
+		const entry = parse(line)
+		expect(entry.level).toBe(20)
+		expect(entry.msg).toBe('hi')
+		expect(typeof entry.time).toBe('string')
+	})
+
+	it('stays silent below the configured level and on silent', () => {
+		const quiet = { method: 'debug', currentLevel: 'info', bindings: {}, args: ['hidden'] }
+		expect(formatFallbackLine(quiet)).toBeUndefined()
+		const silenced = { method: 'fatal', currentLevel: 'silent', bindings: {}, args: ['hidden'] }
+		expect(formatFallbackLine(silenced)).toBeUndefined()
+	})
+})

--- a/src/__tests__/optional-peer.test.ts
+++ b/src/__tests__/optional-peer.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test'
+import { loadOptionalPeer, type PeerLoader } from '../Utils/optional-peer.ts'
+import { expect } from './expect.ts'
+
+const absent = (): PeerLoader => ({
+	resolveSpecifier: () => {
+		throw Object.assign(new Error('Cannot find module missing-peer/package.json'), { code: 'MODULE_NOT_FOUND' })
+	},
+	requireSpecifier: () => {
+		throw new Error('must not be called')
+	}
+})
+
+const broken = (failure: unknown): PeerLoader => ({
+	resolveSpecifier: () => '/node_modules/broken-peer/package.json',
+	requireSpecifier: () => {
+		throw failure
+	}
+})
+
+const present = (module: unknown): PeerLoader => ({
+	resolveSpecifier: () => '/node_modules/peer/package.json',
+	requireSpecifier: () => module
+})
+
+describe('optional peer loading', () => {
+	it('falls back only when the package manifest is missing', () => {
+		expect(loadOptionalPeer('missing-peer', absent())).toBeUndefined()
+	})
+
+	it('rethrows resolution failures that are not absence', () => {
+		const permission: PeerLoader = {
+			resolveSpecifier: () => {
+				throw Object.assign(new Error('denied'), { code: 'EACCES' })
+			},
+			requireSpecifier: () => {
+				throw new Error('must not be called')
+			}
+		}
+		expect(() => loadOptionalPeer('peer', permission)).toThrow(/denied/)
+	})
+
+	it('surfaces a broken entry point instead of silently falling back', () => {
+		const nested = Object.assign(new Error("Cannot find module './missing'"), { code: 'MODULE_NOT_FOUND' })
+		let caught: unknown
+		try {
+			loadOptionalPeer('broken-peer', broken(nested))
+		} catch (error) {
+			caught = error
+		}
+		expect(caught).toBeInstanceOf(Error)
+		expect((caught as Error).message).toBe(
+			"Failed to load optional peer 'broken-peer': it is installed but broken. " +
+				'Reinstall it, or remove it to use the built-in fallback.'
+		)
+		expect((caught as Error & { cause?: unknown }).cause).toBe(nested)
+	})
+
+	it('returns the peer module when it loads', () => {
+		const module = { version: 'peer' }
+		expect(loadOptionalPeer('peer', present(module))).toBe(module)
+	})
+})


### PR DESCRIPTION
Fresh installs of this package used to pull four runtime dependencies. Two of them were only there for convenience, and old Baileys projects already carry their own copies. This change moves those two to optional peers. The API does not change.

What changed

- **Fewer hard dependencies.** `dependencies` is now the Rust bridge (the engine) plus `long` (64-bit fields are `Long` objects in the types and at runtime).
- **Boom and pino are optional peers.** Both accept the v9 lines that Baileys projects already have as well as v10. They moved to `devDependencies` here so tests and examples keep running.
- **Boom uses your copy when you have one.** `src/Utils/boom.ts` re-exports the peer when it resolves, so `instanceof` is shared with the rest of your tree. Without it, a built-in implementation backs the export with the same constructor, `output`, `data`, `isServer`, `reformat`, `typeof`, `boomify`, and `isBoom`.
- **The logger already loaded pino lazily.** It now falls back to a console logger that writes one JSON line per call with the same redaction when the peer is missing. The `./logger` subpath keeps working either way.
- **Published types no longer name the peers.** Consumers compile with or without them installed.
- **README documents the install contract.** A new "What gets installed" section says what to install for which setup.

Why long stays

I tried to drop it. A consumer typecheck without `long` fails in four of our declaration files even when the consumer never imports it, and importing the package without it fails at runtime. The captain's suspicion was right.

Evidence

- **Repo checks.** `npm run lint`, `npm run format:check`, `npm test` (1534 pass, 1 skipped, the same skip as base), `npm run build`, `node scripts/check-pack.ts`. All green.
- **Audits.** Declaration, proto, wire, and lifecycle audits give identical results on base and head. Zero new divergences. One thing I learned along the way. The declaration audit compares types by mutual assignability rather than printed text, so the fallback `Boom` had to match the peer member for member. The `reformat` return type caught me once. Fixed it, re-ran, identical.
- **Consumer typechecks.** A fixture using `Boom`, `boomify`, `isBoom`, the logger subpath, `Long`-typed fields, and the socket factory compiles with peers present and with them absent. Against the base build, the same fixture without peers fails on the `boom` and `pino` imports. That contrast is the point of the change, shown both ways.
- **Runtime probes.** I imported the built package with `boom` removed, with `pino` removed, and with both removed. The `boom.test.ts` assertions hold against the fallback, the logger writes redacted JSON and honors `silent`, and the full entry point loads.
- **Blocked, not skipped.** The E2E suite needs the private Bartender mock (nothing listening on 127.0.0.1:8080 here) and `compat:layers` needs sibling core and bridge checkouts. Both are CI matters now.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `@hapi/boom` and `pino` from hard dependencies to optional peers so fresh installs pull fewer packages and existing Baileys projects reuse their own copies. The API is unchanged; built-in fallbacks provide the same behavior when the peers aren't installed.

**Dependencies**

- `dependencies` now only holds the Rust bridge and `long`; `@hapi/boom` and `pino` move to optional peers (v9 or v10) and to `devDependencies` for tests and examples.

**Fallbacks**

- Presence is probed via the peer's manifest: a missing install falls back, while a present-but-broken install throws a clear error.
- The fallback logger redacts credential paths in child bindings, per-call objects, and array payloads; serializes `Error`/circular/`BigInt` values; supports printf-style interpolation; drains pending stdout writes on `flush()`; and disables unknown levels like the peer, with unit tests added.
- The fallback `Boom` matches the peer member-for-member, keeps the original prototype when wrapping an `Error`, and re-exports the peer when present so `instanceof` identity is shared.
- Published `.d.ts` files avoid importing the peers; README and `AGENTS.md` document the install contract and fallback pattern.

<sup>Written for commit a30ec44667bcf3daebf744821ef0309ec9ce49ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The package now works without optional logging and error-handling packages by using built-in fallbacks.
  - Installed compatible logging and error-handling packages continue to be used when available.
  - Optional media integrations retain documented fallback behavior.

- **Documentation**
  - Clarified required and optional packages and installation behavior.
  - Documented fallback behavior for logging, error handling, and media features.
  - Added guidance for maintaining project instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->