### PR TITLE
feat(calls): consume the bridge encoded-audio domain with JS pumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,22 @@ A few behaviors that differ from upstream — almost always to your advantage:
   other media peers (`sharp`, `jimp`, `audio-decode`, `link-preview-js`).
   Without it, audio messages still send — they just carry no `seconds`
   value. Install `music-metadata` if you want durations computed.
+- **Voice calls ride the bridge calls preview, not the release bridge.**
+  `sock.dialCall(peerJid)` / `sock.acceptCall(callId)` open an encoded-audio
+  call (`'mlow'` by default, `'opus'` for the in-profile escape);
+  `sock.pushCallAudio(callId, bytes)` queues one packet and resolves `false`
+  when the engine shed it under backpressure — that is the normal
+  loss-tolerant answer, not an error. Decoded packets arrive through
+  per-call `sock.onCallAudio(callId, sink)` sinks, lifecycle steps
+  (`relay-allocated`, …, `ended`) on the `call.media` event, and
+  `sock.endCall` / `setCallMuted` / `getCallMediaStats` / `getActiveCalls`
+  round out the surface. There is no watermark readout: the bridge names the
+  `false` return as the pacing signal, with the shed counters in the stats
+  for the rest. `startCallAudioPump(callId, source)` wires a packet source
+  to the push; the built-in silence (`0x90` MLOW SID) and file-chunk sources
+  need no microphone, codec, or ffmpeg and are meant for tests. Calls need a
+  bridge with the `client-calls-audio` domain — a preview build, not a
+  release — and without one every method above throws `501` naming it.
 - **Your key store also holds bridge state, so "empty" is not "unpaired".**
   See [Bridge state in your key store](#bridge-state-in-your-key-store) — this
   one can break a boot path, so it has its own section.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
-        "@oxidezap/whatsapp-rust-bridge": "0.21.4",
+        "@oxidezap/whatsapp-rust-bridge": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@115",
         "long": "^5.3.2",
         "pino": "^10.3.1"
       },
@@ -980,9 +980,9 @@
       }
     },
     "node_modules/@oxidezap/whatsapp-rust-bridge": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@oxidezap/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.21.4.tgz",
-      "integrity": "sha512-+WNLxNuN3wBbsH7WlAE+b2ciLhJ+iahctxuadm8ue5xxOMoqI5RjTK/wZLs6eOi4FoKMV+bXgQEW77msCRzvfA==",
+      "version": "0.0.0-preview-2071901",
+      "resolved": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@115",
+      "integrity": "sha512-gNF9PqQvgtWzhl1+B66GeSYVfTUoiGgcGgn+D6k7aRMk7D8tnqoirEqvsVpK8VmY/qBf+pTIAQKacgIM9kQ5Vw==",
       "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",
-    "@oxidezap/whatsapp-rust-bridge": "0.21.4",
+    "@oxidezap/whatsapp-rust-bridge": "https://pkg.pr.new/@oxidezap/whatsapp-rust-bridge@115",
     "long": "^5.3.2",
     "pino": "^10.3.1"
   },

--- a/src/Socket/calls.ts
+++ b/src/Socket/calls.ts
@@ -1,0 +1,555 @@
+/**
+ * Encoded-audio voice calls over the bridge `client-calls-audio` domain.
+ *
+ * The bridge owns the media engine (accept/dial/push/stats/hangup plus the
+ * relay transport); this layer owns JS ergonomics on top of it: per-call
+ * audio sinks, a source pump with shed accounting, and socket-independent
+ * silence/file sources for tests that have no microphone.
+ *
+ * Upstream Baileys has no audio media surface — only the `call` event — so
+ * nothing here translates an upstream shape. The types live in
+ * `../Types/Call.ts` under bridge names, and the one new socket event,
+ * `call.media`, carries the bridge `CallMediaEvent` unchanged.
+ *
+ * Backpressure is loss-tolerant end to end: `callPushAudio` resolves `false`
+ * when the engine queue is full and the packet is shed, which the pump counts
+ * rather than treating as an error. The bridge exposes no watermark readout
+ * (its docs name the `false` return as the pacing signal in place of one),
+ * so pacing sources read the shed count and the `audioSinkDropped` /
+ * `inboundPipeDropped` stats counters instead.
+ */
+
+import { Boom } from '../Utils/boom.ts'
+import { assertArgumentDomain } from '../Utils/argument-domain.ts'
+import type {
+	ActiveCall,
+	CallAudioFormat,
+	CallAudioFrame,
+	CallAudioPacketSource,
+	CallAudioPumpStats,
+	CallAudioSink,
+	CallEndResult,
+	CallMediaEvent,
+	CallMediaStats
+} from '../Types/Call.ts'
+import type { SocketContext } from './types.ts'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bridge surface (structural)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The `client-calls-audio` half of `WasmWhatsAppClient`, written down here
+ * rather than imported: the release bridge has no audio domain, so naming its
+ * types would not compile under it. The shapes come from the bridge calls PR
+ * head (`src/wasm_client/calls_audio.rs` plus the `CallAudioFrame` /
+ * `CallMediaEvent` / stats result types); `call-audio-surface.test.ts` proves
+ * the preview client satisfies this interface at runtime.
+ */
+export interface CallAudioBridgeClient {
+	acceptCall(callId: string, audioFormat?: CallAudioFormat | null): Promise<string>
+	dialCall(peer: string, audioFormat?: CallAudioFormat | null): Promise<string>
+	callPushAudio(callId: string, data: Uint8Array): boolean
+	endCall(callId: string): Promise<CallEndResult>
+	setCallMuted(callId: string, muted: boolean): Promise<void>
+	getCallMediaStats(callId: string): CallMediaStats
+	getActiveCalls(): ActiveCall[]
+	setRelayTransportProvider(provider: CallRelayTransportProvider): void
+}
+
+/** Host-owned relay media channel for one call, behind `setRelayTransportProvider`. */
+export interface CallRelayConnectionEvents {
+	onPacket(data: Uint8Array): void
+	onOpen(): void
+	onClose(reason?: string): void
+}
+
+export interface CallRelayConnectionHandle {
+	send(data: Uint8Array): void | Promise<void>
+	close(): void | Promise<void>
+}
+
+export interface CallRelayConnectionParams {
+	address: string
+	port: number
+	iceUfrag: string
+	icePwd: string
+}
+
+export interface CallRelayTransportProvider {
+	createRelayConnection(
+		params: CallRelayConnectionParams,
+		events: CallRelayConnectionEvents
+	): Promise<CallRelayConnectionHandle>
+}
+
+const AUDIO_FORMATS = ['mlow', 'opus', undefined] as const
+
+/**
+ * Narrow a bridge client to the audio domain. A release bridge (or any build
+ * without `client-calls-audio`) fails here with a 501 naming the capability,
+ * rather than throwing `not a function` off the first call.
+ */
+export const asCallAudioClient = (client: object, method: keyof CallAudioBridgeClient): CallAudioBridgeClient => {
+	const candidate = client as Partial<Record<keyof CallAudioBridgeClient, unknown>>
+	if (typeof candidate[method] !== 'function') {
+		throw new Boom(
+			`${method} needs a bridge with the client-calls-audio domain (bridge calls preview or newer); the installed bridge has no ${method}`,
+			{ statusCode: 501 }
+		)
+	}
+	return candidate as CallAudioBridgeClient
+}
+
+const assertCallId = (method: string, callId: string): void => {
+	if (typeof callId !== 'string' || callId.length === 0) {
+		throw new Boom(`${method}: callId must be a non-empty string`, { statusCode: 400 })
+	}
+}
+
+const assertAudioPacket = (method: string, data: Uint8Array): void => {
+	if (!(data instanceof Uint8Array) || data.length === 0) {
+		throw new Boom(`${method}: data must be a non-empty Uint8Array`, { statusCode: 400 })
+	}
+}
+
+/**
+ * Sleep between source packets without keeping the process alive for a call
+ * nobody is listening to anymore — same `unref` treatment as the socket's own
+ * query timeouts.
+ */
+const paceDelay = (intervalMs: number): Promise<void> =>
+	new Promise(resolve => {
+		setTimeout(resolve, intervalMs).unref()
+	})
+
+const STAT_FIELDS = [
+	'rtpReceived',
+	'rtpPayloadTypeUnexpected',
+	'srtpUnprotectFailed',
+	'sframeDecryptFailed',
+	'audioFramesDecoded',
+	'audioFramesDelivered',
+	'audioFramesConcealed',
+	'mlowOffPointDropped',
+	'mlowInactiveOrSid',
+	'foreignFramesDecoded',
+	'audioFramesWithoutDecoder',
+	'outboundFramesWithoutEncoder',
+	'playoutTrimmedSamples',
+	'inboundPipeDropped',
+	'audioSinkDropped',
+	'videoSinkDropped',
+	'peerKeyframeRequests',
+	'relayPacketUnclassified',
+	'forwardingEnvelopeRejected',
+	'codecSwitches'
+] as const satisfies readonly (keyof CallMediaStats)[]
+
+/** Reject a stats object the bridge shaped unexpectedly instead of forwarding NaNs. */
+const normalizeCallMediaStats = (method: string, raw: unknown): CallMediaStats => {
+	if (typeof raw !== 'object' || raw === null) {
+		throw new Boom(`${method}: bridge returned no media stats object`, { statusCode: 500 })
+	}
+	const record = raw as Record<string, unknown>
+	const stats = {} as Record<string, number>
+	for (const field of STAT_FIELDS) {
+		const value = record[field]
+		if (typeof value !== 'number' || !Number.isFinite(value)) {
+			throw new Boom(`${method}: bridge media stats field ${field} is not a number`, { statusCode: 500 })
+		}
+		stats[field] = value
+	}
+	return stats as CallMediaStats
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Media router: bridge callbacks in, per-call sinks and socket events out
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CallMediaRouterDeps {
+	emitMediaEvent: (event: CallMediaEvent) => void
+	reportError: (err: unknown, msg: string) => void
+}
+
+export interface CallMediaRouter {
+	/** Register a per-call audio sink; the returned function unregisters it. */
+	addAudioSink(callId: string, sink: CallAudioSink): () => void
+	/** Bridge `onCallAudio` entry point. Never throws: a throw here would stop the bridge pump. */
+	routeAudioFrame(frame: CallAudioFrame): void
+	/** Bridge `onCallEvent` entry point. Emits `call.media`; `ended` also stops the call. */
+	routeMediaEvent(event: CallMediaEvent): void
+	/** Track a pump stopper so `ended` / teardown ends it with the call. */
+	trackPump(callId: string, stop: () => void): void
+	/** Stop a call's pumps and drop its sinks. */
+	stopCall(callId: string): void
+	/** Stop everything; socket teardown calls this while the client is still usable. */
+	stopAll(): void
+}
+
+const isAudioFrame = (frame: unknown): frame is CallAudioFrame => {
+	if (typeof frame !== 'object' || frame === null) return false
+	const record = frame as Record<string, unknown>
+	return (
+		typeof record.callId === 'string' &&
+		record.data instanceof Uint8Array &&
+		(record.codec === 'mlow' || record.codec === 'opus')
+	)
+}
+
+const isMediaEvent = (event: unknown): event is CallMediaEvent => {
+	if (typeof event !== 'object' || event === null) return false
+	const record = event as Record<string, unknown>
+	return typeof record.callId === 'string' && typeof record.kind === 'string'
+}
+
+export const makeCallMediaRouter = ({ emitMediaEvent, reportError }: CallMediaRouterDeps): CallMediaRouter => {
+	const sinks = new Map<string, Set<CallAudioSink>>()
+	const pumps = new Map<string, Set<() => void>>()
+
+	const stopCall = (callId: string): void => {
+		const tracked = pumps.get(callId)
+		if (tracked) {
+			pumps.delete(callId)
+			for (const stop of tracked) {
+				try {
+					stop()
+				} catch (err) {
+					reportError(err, `stopping a call audio pump for ${callId}`)
+				}
+			}
+		}
+		sinks.delete(callId)
+	}
+
+	return {
+		addAudioSink(callId, sink) {
+			let set = sinks.get(callId)
+			if (!set) {
+				set = new Set()
+				sinks.set(callId, set)
+			}
+			set.add(sink)
+			return () => {
+				const live = sinks.get(callId)
+				if (!live) return
+				live.delete(sink)
+				if (live.size === 0) sinks.delete(callId)
+			}
+		},
+		routeAudioFrame(frame) {
+			if (!isAudioFrame(frame)) {
+				reportError(new Error('bridge delivered a malformed call audio frame'), 'call audio frame dropped')
+				return
+			}
+			const live = sinks.get(frame.callId)
+			if (!live) return
+			// The frame is handed through, never copied: the bridge already
+			// paid the one copy out of linear memory, and a sink that needs to
+			// keep bytes copies them itself before returning.
+			for (const sink of live) {
+				try {
+					sink(frame)
+				} catch (err) {
+					reportError(err, `call audio sink for ${frame.callId}`)
+				}
+			}
+		},
+		routeMediaEvent(event) {
+			if (!isMediaEvent(event)) {
+				reportError(new Error('bridge delivered a malformed call media event'), 'call media event dropped')
+				return
+			}
+			if (event.kind === 'ended') stopCall(event.callId)
+			emitMediaEvent(event)
+		},
+		trackPump(callId, stop) {
+			let set = pumps.get(callId)
+			if (!set) {
+				set = new Set()
+				pumps.set(callId, set)
+			}
+			set.add(stop)
+		},
+		stopCall,
+		stopAll() {
+			// Deleting the current key while iterating a Map is safe; each
+			// stopCall removes exactly the key being visited.
+			for (const callId of pumps.keys()) stopCall(callId)
+			sinks.clear()
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sources: silence and file, no microphone or ffmpeg in the package
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The MLOW silence token: one `0x90` byte. The core accepts it as an encoded
+ * payload under both the `mlow` and `opus` promises
+ * (`AudioFormat::accepts_encoded_payload` in `wacore/src/voip/audio.rs`), and
+ * its own packetizer maps Opus DTX/silence to the same byte
+ * (`packetize_opus_for_mlow`), so the peer decodes it as silence rather than
+ * noise. For pump and backpressure tests without a microphone.
+ */
+export const MLOW_SILENCE_PACKET: Uint8Array = new Uint8Array([0x90])
+
+export interface SilenceCallAudioSourceOptions {
+	/** Gap between packets. Defaults to 60 ms, the MLOW frame cadence. */
+	intervalMs?: number
+	/** Total packets before the source is spent; default runs until stopped. */
+	packets?: number
+	/** Packet bytes; defaults to the MLOW silence token above. */
+	packet?: Uint8Array
+}
+
+export const makeSilenceCallAudioSource = (options: SilenceCallAudioSourceOptions = {}): CallAudioPacketSource => {
+	const intervalMs = options.packets === 0 ? 0 : (options.intervalMs ?? 60)
+	const total = options.packets ?? Number.POSITIVE_INFINITY
+	const packet = options.packet ?? MLOW_SILENCE_PACKET
+	if (!(packet instanceof Uint8Array) || packet.length === 0) {
+		throw new Boom('makeSilenceCallAudioSource: packet must be a non-empty Uint8Array', { statusCode: 400 })
+	}
+	if (!Number.isFinite(intervalMs) || intervalMs < 0) {
+		throw new Boom('makeSilenceCallAudioSource: intervalMs must be a finite number >= 0', { statusCode: 400 })
+	}
+	let sent = 0
+	return {
+		next: async () => {
+			if (sent >= total) return null
+			if (intervalMs > 0 && sent > 0) await paceDelay(intervalMs)
+			sent++
+			// A fresh view per tick: the push copies synchronously, but the
+			// caller owns the packet afterwards and must not see later ticks
+			// overwrite it.
+			return packet.slice()
+		}
+	}
+}
+
+export interface FileCallAudioSourceOptions {
+	/** Packet size in bytes. Raw chunking, not transcoding: no ffmpeg involved. */
+	packetBytes?: number
+	/** Gap between packets. Defaults to 60 ms, the MLOW frame cadence. */
+	intervalMs?: number
+	/** Maximum packets to read; default reads the whole file. */
+	packets?: number
+}
+
+/**
+ * Chunk a file into fixed-size encoded packets for tests. Reads the file
+ * once up front and serves slices of it — no microphone, no codec, no
+ * ffmpeg — so the bytes are whatever the fixture carries, and a live peer
+ * decodes them as whatever grammar they are in.
+ */
+export const makeFileCallAudioSource = async (
+	path: string,
+	options: FileCallAudioSourceOptions = {}
+): Promise<CallAudioPacketSource> => {
+	const { readFile } = await import('node:fs/promises')
+	const packetBytes = options.packetBytes ?? 160
+	if (!Number.isInteger(packetBytes) || packetBytes <= 0) {
+		throw new Boom('makeFileCallAudioSource: packetBytes must be a positive integer', { statusCode: 400 })
+	}
+	const intervalMs = options.intervalMs ?? 60
+	if (!Number.isFinite(intervalMs) || intervalMs < 0) {
+		throw new Boom('makeFileCallAudioSource: intervalMs must be a finite number >= 0', { statusCode: 400 })
+	}
+	const bytes = await readFile(path)
+	const total = options.packets ?? Number.POSITIVE_INFINITY
+	let offset = 0
+	let sent = 0
+	return {
+		next: async () => {
+			if (sent >= total || offset >= bytes.length) return null
+			if (intervalMs > 0 && sent > 0) await paceDelay(intervalMs)
+			const chunk = bytes.subarray(offset, offset + packetBytes)
+			offset += chunk.length
+			sent++
+			return new Uint8Array(chunk)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pump: source in, bridge push out, shed counted
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CallAudioPumpOptions {
+	/** AbortSignal that stops the pump; stopping is silent, never an error. */
+	signal?: AbortSignal
+	/** Called per shed packet with the running shed total. */
+	onShed?: (shedTotal: number) => void
+}
+
+export interface CallAudioPump {
+	/** Resolves with the moved totals when the source is spent or the pump stops. */
+	done: Promise<CallAudioPumpStats>
+	/** Stop pulling; in-flight `done` resolves with the totals so far. */
+	stop: () => void
+}
+
+/**
+ * Pull packets from a source and push them through `push` until the source is
+ * spent, the signal aborts, or `stop()` runs. A `false` push is shed audio —
+ * counted (and reported via `onShed`), never an error. A throwing push ends
+ * the pump and rejects `done`, so an ended call surfaces instead of spinning.
+ */
+export const startCallAudioPump = (
+	push: (data: Uint8Array) => boolean | Promise<boolean>,
+	source: CallAudioPacketSource,
+	options: CallAudioPumpOptions = {}
+): CallAudioPump => {
+	let stopped = false
+	let onAbort: (() => void) | undefined
+	const stats: CallAudioPumpStats = { pushed: 0, shed: 0 }
+
+	const stop = (): void => {
+		stopped = true
+		options.signal?.removeEventListener('abort', onAbort as () => void)
+	}
+	if (options.signal?.aborted) stopped = true
+	if (!stopped && options.signal) {
+		onAbort = () => stop()
+		options.signal.addEventListener('abort', onAbort, { once: true })
+	}
+
+	const done = (async (): Promise<CallAudioPumpStats> => {
+		for (;;) {
+			const packet = await source.next()
+			if (packet === null || stopped) break
+			assertAudioPacket('startCallAudioPump: source', packet)
+			if (await push(packet)) {
+				stats.pushed++
+			} else {
+				stats.shed++
+				options.onShed?.(stats.shed)
+			}
+		}
+		stop()
+		return { ...stats }
+	})()
+
+	return { done, stop }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Socket methods
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const makeCallAudioMethods = (ctx: SocketContext, media: CallMediaRouter) => {
+	/** Resolve the client once and push directly: per-packet `withClient` hops cost a tick each. */
+	const withAudioClient = async <T>(
+		bridgeMethod: keyof CallAudioBridgeClient,
+		operation: (client: CallAudioBridgeClient) => T | Promise<T>
+	): Promise<T> => ctx.withClient(client => operation(asCallAudioClient(client, bridgeMethod)))
+
+	return {
+		/**
+		 * Dial a peer with encoded audio. Returns the new call id; the handle
+		 * stays dormant until the server acks the offer with a relay.
+		 */
+		dialCall: async (peerJid: string, audioFormat?: CallAudioFormat): Promise<string> => {
+			if (typeof peerJid !== 'string' || peerJid.length === 0) {
+				throw new Boom('dialCall: peerJid must be a non-empty string', { statusCode: 400 })
+			}
+			assertArgumentDomain('dialCall', 'audioFormat', audioFormat, AUDIO_FORMATS)
+			return withAudioClient('dialCall', client => client.dialCall(peerJid, audioFormat ?? null))
+		},
+		/**
+		 * Answer a ringing call with encoded audio. The offer arrives on the
+		 * `call` event; the bridge holds it until it is answered, superseded,
+		 * or missed.
+		 */
+		acceptCall: async (callId: string, audioFormat?: CallAudioFormat): Promise<string> => {
+			assertCallId('acceptCall', callId)
+			assertArgumentDomain('acceptCall', 'audioFormat', audioFormat, AUDIO_FORMATS)
+			return withAudioClient('acceptCall', client => client.acceptCall(callId, audioFormat ?? null))
+		},
+		/**
+		 * Push one encoded packet toward the peer. Resolves `true` when the
+		 * packet entered the engine queue, `false` when it was shed under
+		 * backpressure — the normal loss-tolerant answer, not an error.
+		 */
+		pushCallAudio: async (callId: string, data: Uint8Array): Promise<boolean> => {
+			assertCallId('pushCallAudio', callId)
+			assertAudioPacket('pushCallAudio', data)
+			return withAudioClient('callPushAudio', client => client.callPushAudio(callId, data))
+		},
+		/** End a live call. The local side is down whatever comes back. */
+		endCall: (callId: string): Promise<CallEndResult> => {
+			assertCallId('endCall', callId)
+			return withAudioClient('endCall', client => client.endCall(callId)).finally(() => media.stopCall(callId))
+		},
+		/** Mute or unmute the mic on a live call. */
+		setCallMuted: (callId: string, muted: boolean): Promise<void> => {
+			assertCallId('setCallMuted', callId)
+			return withAudioClient('setCallMuted', client => client.setCallMuted(callId, muted))
+		},
+		/** Media counters for one call; readable after the call ends. */
+		getCallMediaStats: (callId: string): Promise<CallMediaStats> => {
+			assertCallId('getCallMediaStats', callId)
+			return withAudioClient('getCallMediaStats', client =>
+				normalizeCallMediaStats('getCallMediaStats', client.getCallMediaStats(callId))
+			)
+		},
+		/** Every call the bridge currently holds a handle for. */
+		getActiveCalls: (): Promise<ActiveCall[]> => withAudioClient('getActiveCalls', client => client.getActiveCalls()),
+		/**
+		 * Install the host's relay channel constructor. The bridge implements
+		 * the core's relay transport over it and never touches WebRTC itself;
+		 * pass the bridge's own `createRtcRelayTransportProvider` result or a
+		 * custom constructor keeping the same contract.
+		 */
+		setRelayTransportProvider: (provider: CallRelayTransportProvider): Promise<void> => {
+			if (typeof provider !== 'object' || provider === null || typeof provider.createRelayConnection !== 'function') {
+				throw new Boom('setRelayTransportProvider: provider must carry createRelayConnection', {
+					statusCode: 400
+				})
+			}
+			return withAudioClient('setRelayTransportProvider', client => {
+				client.setRelayTransportProvider(provider)
+			})
+		},
+		/**
+		 * Register a per-call decoded-audio sink. Frames arrive at voice
+		 * cadence on the bridge pump: decode or copy before returning, and
+		 * never retain the view. The returned function unregisters the sink;
+		 * `ended` and socket teardown unregister it automatically.
+		 */
+		onCallAudio: (callId: string, sink: CallAudioSink): (() => void) => {
+			assertCallId('onCallAudio', callId)
+			if (typeof sink !== 'function') {
+				throw new Boom('onCallAudio: sink must be a function', { statusCode: 400 })
+			}
+			return media.addAudioSink(callId, sink)
+		},
+		/**
+		 * Run a packet source into a live call until it is spent, aborted, or
+		 * the call ends. Resolves the client once, then pushes directly; the
+		 * pump stops with the call on `ended` or socket teardown.
+		 */
+		startCallAudioPump: async (
+			callId: string,
+			source: CallAudioPacketSource,
+			options: CallAudioPumpOptions = {}
+		): Promise<CallAudioPump> => {
+			assertCallId('startCallAudioPump', callId)
+			if (typeof source !== 'object' || source === null || typeof source.next !== 'function') {
+				throw new Boom('startCallAudioPump: source must carry next()', { statusCode: 400 })
+			}
+			const client = await ctx.withClient(c => asCallAudioClient(c, 'callPushAudio'))
+			const pump = startCallAudioPump(data => client.callPushAudio(callId, data), source, options)
+			media.trackPump(callId, pump.stop)
+			// A spent or failed pump holds no call resources: drop its
+			// tracking either way. Both branches stop the call's pumps, and
+			// the rejection stays on `pump.done` for the caller.
+			void pump.done.then(
+				() => media.stopCall(callId),
+				() => media.stopCall(callId)
+			)
+			return pump
+		}
+	}
+}

--- a/src/Socket/index.ts
+++ b/src/Socket/index.ts
@@ -24,6 +24,8 @@ import { DEFAULT_CONNECTION_CONFIG, MEDIA_TYPES, type MediaType } from '../Defau
 import type {
 	BinaryNode,
 	AuthenticationCreds,
+	CallAudioFrame,
+	CallMediaEvent,
 	ConnectionState,
 	Contact,
 	ReachoutTimelockState,
@@ -53,6 +55,7 @@ import { assertNodeErrorFree } from '../WABinary/generic-utils.ts'
 import type { proto } from '../WAProto/runtime.ts'
 import { makeBlockingMethods } from './blocking.ts'
 import { makeBusinessMethods } from './business.ts'
+import { makeCallAudioMethods, makeCallMediaRouter } from './calls.ts'
 import { makeChatActionMethods } from './chat-actions.ts'
 import { makeContactMethods } from './contacts.ts'
 import { makeCommunityMethods } from './communities.ts'
@@ -422,6 +425,19 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 	const notificationMutex = makeMutex()
 	const activeCallContexts = new Map<string, { peer: string; callCreator: string }>()
 	socketEndHandlers.push(() => activeCallContexts.clear())
+	/**
+	 * Encoded-audio call media routing. The bridge fires `onCallAudio` per
+	 * decoded packet and `onCallEvent` per lifecycle step off the same
+	 * callbacks object it reads for everything else; assigning them here
+	 * (rather than inside `makeEventHandlers`) keeps the media routing next
+	 * to the methods that consume it. A release bridge ignores the extra
+	 * properties, so this is inert until the audio domain exists.
+	 */
+	const callMedia = makeCallMediaRouter({
+		emitMediaEvent: event => ev.emit('call.media', event),
+		reportError: (err, msg) => unexpectedErrors.report(err, msg)
+	})
+	socketEndHandlers.push(() => callMedia.stopAll())
 	const groupMethods = makeGroupMethods(ctx)
 	const communityMethods = makeCommunityMethods(ctx, groupMethods)
 	const refreshParticipating = makeParticipatingRefreshHandler(ctx, {
@@ -476,6 +492,15 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		// way — `sock.end()`, an `await using` scope exiting — has to as well,
 		// or one fires from a socket whose client is already freed.
 		onCleanup: cleanup => socketEndHandlers.push(cleanup)
+	})
+	// The audio domain reads these off the callbacks object before it moves
+	// into the parsed form. `Object.assign` rather than a literal: the
+	// release `.d.ts` does not declare the members, and a literal would fail
+	// its excess-property check there. This keeps the wiring compiling under
+	// both the release bridge and the preview.
+	Object.assign(eventHandlers, {
+		onCallAudio: (frame: CallAudioFrame) => callMedia.routeAudioFrame(frame),
+		onCallEvent: (event: CallMediaEvent) => callMedia.routeMediaEvent(event)
 	})
 
 	const init = async () => {
@@ -1066,6 +1091,7 @@ const makeWASocket = (config: UserFacingSocketConfig) => {
 		...makeBlockingMethods(ctx),
 		...makeNewsletterMethods(ctx),
 		...makeBusinessMethods(ctx),
+		...makeCallAudioMethods(ctx, callMedia),
 		...makeServerQueryMethods(ctx),
 		downloadMedia: async <T extends MediaDownloadType>(
 			message: WAMessage,

--- a/src/Types/Call.ts
+++ b/src/Types/Call.ts
@@ -48,3 +48,120 @@ export type WACallEvent = {
 	/** WhatsApp client version on the caller side. */
 	version?: string
 }
+
+/**
+ * Encoded-audio codec promise for a call.
+ *
+ * A promise about the bytes pushed through `pushCallAudio`, and what the call
+ * negotiates against: answering an offer that only speaks the other codec
+ * fails naming `audioFormat` so the caller can retry with the other one.
+ * `opus` is the in-profile escape on the same 16 kHz clock as `mlow`, not
+ * native RFC 7587 Opus. Spelled after the bridge `CallAudioFormat`.
+ */
+export type CallAudioFormat = 'mlow' | 'opus'
+
+/** One decoded audio packet for a live call, as the engine received it. */
+export type CallAudioFrame = {
+	callId: string
+	data: Uint8Array
+	codec: 'mlow' | 'opus'
+	payloadType: number
+	sequenceNumber: number
+	timestamp: number
+	marker: boolean
+}
+
+/**
+ * Lifecycle and media diagnostics for one live call. Only the encoded-audio
+ * 1:1 subset crosses in this slice; group, video, reaction and RTCP events
+ * belong to later slices.
+ */
+export type CallMediaEventKind =
+	| 'relay-allocated'
+	| 'relay-allocate-failed'
+	| 'relay-allocate-timed-out'
+	| 'media-setup-failed'
+	| 'audio-codec-switched'
+	| 'audio-codec-source-fixed'
+	| 'ended'
+
+export type CallMediaEvent = {
+	callId: string
+	kind: CallMediaEventKind
+	/** `relay-allocate-failed`: the STUN error code. */
+	code?: number
+	/** `media-setup-failed`: why the media plane never built. */
+	detail?: string
+	/** `audio-codec-switched`: the grammar in use before the switch. */
+	from?: string
+	/** `audio-codec-switched`: the grammar now in use. */
+	to?: string
+	/** `audio-codec-source-fixed`: what the application keeps sending. */
+	sending?: string
+	/** `audio-codec-source-fixed`: what the peer says it speaks. */
+	peerExpects?: string
+}
+
+/**
+ * How ending a call through its handle went. The local side is down in every
+ * case; this reports how much of the peer was told.
+ */
+export type CallEndResult =
+	| { outcome: 'peer-notified' }
+	| { outcome: 'partly-notified'; notified: number; unconfirmed: number }
+	| { outcome: 'local-only'; failure: string }
+	| { outcome: 'already-ended' }
+
+/** One live call the bridge currently holds a handle for. */
+export type ActiveCall = {
+	callId: string
+	peerJid: string
+}
+
+/**
+ * Media counters for one call, mirroring the core's `CallMediaStats`.
+ * All-zero until the media plane attaches, additive after that; sample twice
+ * and subtract for a rate. Readable after the call ends.
+ */
+export type CallMediaStats = {
+	rtpReceived: number
+	rtpPayloadTypeUnexpected: number
+	srtpUnprotectFailed: number
+	sframeDecryptFailed: number
+	audioFramesDecoded: number
+	audioFramesDelivered: number
+	audioFramesConcealed: number
+	mlowOffPointDropped: number
+	mlowInactiveOrSid: number
+	foreignFramesDecoded: number
+	audioFramesWithoutDecoder: number
+	outboundFramesWithoutEncoder: number
+	playoutTrimmedSamples: number
+	inboundPipeDropped: number
+	audioSinkDropped: number
+	videoSinkDropped: number
+	peerKeyframeRequests: number
+	relayPacketUnclassified: number
+	forwardingEnvelopeRejected: number
+	codecSwitches: number
+}
+
+/**
+ * A pull source of encoded audio packets for one live call. `next()` resolves
+ * with the next packet to push, or `null` when the source is spent — the pump
+ * then stops, leaving the call itself up.
+ */
+export type CallAudioPacketSource = {
+	next(): Promise<Uint8Array | null>
+}
+
+/** Per-packet sink for one live call's decoded audio. */
+export type CallAudioSink = (frame: CallAudioFrame) => void
+
+/** What one `startCallAudioPump` run moved. */
+export type CallAudioPumpStats = {
+	/** Packets the engine queue accepted. */
+	pushed: number
+	/** Packets shed under backpressure — the loss-tolerant answer, not an error. */
+	shed: number
+}

--- a/src/Types/Events.ts
+++ b/src/Types/Events.ts
@@ -1,7 +1,7 @@
 import type { proto } from '../WAProto/runtime.ts'
 import type { Boom } from '../Utils/boom.ts'
 import type { AuthenticationCreds, LIDMapping } from './Auth.ts'
-import type { WACallEvent } from './Call.ts'
+import type { CallMediaEvent, WACallEvent } from './Call.ts'
 import type { Chat, ChatUpdate, PresenceData } from './Chat.ts'
 import type { Contact } from './Contact.ts'
 import type {
@@ -122,6 +122,13 @@ export type BaileysEventMap = {
 
 	/** Receive an update on a call, including when the call was received, rejected, accepted */
 	call: WACallEvent[]
+	/**
+	 * Lifecycle and media diagnostics for one live encoded-audio call, as the
+	 * bridge reports them (`relay-allocated`, …, `ended`). baileyrs-only:
+	 * upstream has no call media surface, so this event and its payload keep
+	 * the bridge names rather than an upstream shape.
+	 */
+	'call.media': CallMediaEvent
 	'labels.edit': Label
 	'labels.association': { association: LabelAssociation; type: 'add' | 'remove' }
 

--- a/src/__fuzz__/argument-boundary.fuzz.test.ts
+++ b/src/__fuzz__/argument-boundary.fuzz.test.ts
@@ -242,6 +242,18 @@ const CASES: readonly BoundaryCase[] = [
 				}),
 				off<'buffer' | 'stream'>(v)
 			)
+	},
+	{
+		method: 'dialCall',
+		parameter: 'audioFormat',
+		source: 'Socket/calls.ts:dialCall:audioFormat',
+		call: (s, v) => s.dialCall(USER, off(v))
+	},
+	{
+		method: 'acceptCall',
+		parameter: 'audioFormat',
+		source: 'Socket/calls.ts:acceptCall:audioFormat',
+		call: (s, v) => s.acceptCall('NEVER-RANG', off(v))
 	}
 ]
 
@@ -443,7 +455,11 @@ const EXPECTED_DOMAINS: Readonly<Record<string, readonly unknown[]>> = {
 	'Socket/communities.ts:communityParticipantsUpdate:action': ['add', 'remove', 'promote', 'demote', 'modify'],
 	'Socket/communities.ts:communitySettingUpdate:setting': ['announcement', 'not_announcement', 'locked', 'unlocked'],
 	'Socket/communities.ts:communityMemberAddMode:mode': ['admin_add', 'all_member_add'],
-	'Socket/communities.ts:communityJoinApprovalMode:mode': ['on', 'off']
+	'Socket/communities.ts:communityJoinApprovalMode:mode': ['on', 'off'],
+	// `undefined`, not `null`: omitting the format takes the bridge default,
+	// and the two are different values to `includes`.
+	'Socket/calls.ts:dialCall:audioFormat': ['mlow', 'opus', undefined],
+	'Socket/calls.ts:acceptCall:audioFormat': ['mlow', 'opus', undefined]
 }
 
 /** The same values as reported by the guard itself, for the pin below. */

--- a/src/__tests__/call-audio-pump.test.ts
+++ b/src/__tests__/call-audio-pump.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Encoded-audio pumps, sources, sinks and socket-method wiring — without a
+ * live call.
+ *
+ * A live engine loop needs a connection, a peer and a relay, none of which
+ * exists here (the mock server answers no call stanzas and there is no
+ * account to dial with). What this pins is everything around that loop:
+ *
+ * - the silence and file sources packetize and pace without a microphone,
+ *   ffmpeg, or any codec in the package;
+ * - the pump moves every packet, counts shed audio instead of erroring on
+ *   it, and stops on a spent source, an abort, or a throwing push;
+ * - the media router delivers each decoded frame to the right call's sinks,
+ *   never throws back into the bridge pump, and ends pumps on `ended`;
+ * - the socket methods validate arguments ahead of the bridge and report a
+ *   missing audio domain as 501 rather than `not a function`.
+ *
+ * The real bridge surface — that the preview client carries these operations
+ * with these shapes — is `call-audio-surface.test.ts`.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+
+import {
+	asCallAudioClient,
+	makeCallAudioMethods,
+	makeCallMediaRouter,
+	makeFileCallAudioSource,
+	makeSilenceCallAudioSource,
+	MLOW_SILENCE_PACKET,
+	startCallAudioPump,
+	type CallAudioBridgeClient,
+	type CallMediaRouter
+} from '../Socket/calls.ts'
+import type { SocketContext } from '../Socket/types.ts'
+import type { CallAudioFrame, CallAudioPacketSource, CallMediaEvent } from '../Types/Call.ts'
+import { expect } from './expect.ts'
+
+const scriptedSource = (packets: Uint8Array[]): CallAudioPacketSource => {
+	let index = 0
+	return {
+		next: async () => (index < packets.length ? packets[index++]! : null)
+	}
+}
+
+const stubCtx = (client: object): SocketContext =>
+	({
+		withClient: async (operation: (client: never) => unknown) => operation(client as never)
+	}) as unknown as SocketContext
+
+const nullRouter = (): CallMediaRouter =>
+	makeCallMediaRouter({ emitMediaEvent: () => undefined, reportError: () => undefined })
+
+describe('call audio silence source', () => {
+	it('emits the MLOW silence token the core accepts as an encoded payload', async () => {
+		expect(MLOW_SILENCE_PACKET).toEqual(new Uint8Array([0x90]))
+		const source = makeSilenceCallAudioSource({ packets: 2, intervalMs: 0 })
+		expect(await source.next()).toEqual(new Uint8Array([0x90]))
+		expect(await source.next()).toEqual(new Uint8Array([0x90]))
+		expect(await source.next()).toBe(null)
+	})
+
+	it('hands each tick its own view', async () => {
+		const source = makeSilenceCallAudioSource({ packets: 2, intervalMs: 0 })
+		const first = (await source.next())!
+		first[0] = 0x00
+		expect(await source.next()).toEqual(new Uint8Array([0x90]))
+	})
+
+	it('a zero packet budget is spent immediately', async () => {
+		expect(await makeSilenceCallAudioSource({ packets: 0 }).next()).toBe(null)
+	})
+
+	it('rejects an empty custom packet and a negative interval', () => {
+		expect(() => makeSilenceCallAudioSource({ packet: new Uint8Array(0) })).toThrow(/non-empty/)
+		expect(() => makeSilenceCallAudioSource({ intervalMs: -1 })).toThrow(/intervalMs/)
+	})
+})
+
+describe('call audio file source', () => {
+	it('chunks a file into fixed packets with no codec involved', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'baileyrs-call-audio-'))
+		try {
+			const path = join(dir, 'fixture.bin')
+			await writeFile(path, new Uint8Array([0, 1, 2, 3, 4, 5, 6]))
+			const source = await makeFileCallAudioSource(path, { packetBytes: 3, intervalMs: 0 })
+			expect(await source.next()).toEqual(new Uint8Array([0, 1, 2]))
+			expect(await source.next()).toEqual(new Uint8Array([3, 4, 5]))
+			expect(await source.next()).toEqual(new Uint8Array([6]))
+			expect(await source.next()).toBe(null)
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('honours a packet cap shorter than the file', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'baileyrs-call-audio-'))
+		try {
+			const path = join(dir, 'fixture.bin')
+			await writeFile(path, new Uint8Array([9, 9, 9, 9]))
+			const source = await makeFileCallAudioSource(path, { packetBytes: 1, intervalMs: 0, packets: 2 })
+			expect(await source.next()).toEqual(new Uint8Array([9]))
+			expect(await source.next()).toEqual(new Uint8Array([9]))
+			expect(await source.next()).toBe(null)
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+
+	it('rejects a non-positive packet size', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'baileyrs-call-audio-'))
+		try {
+			const path = join(dir, 'fixture.bin')
+			await writeFile(path, new Uint8Array([1]))
+			await expect(makeFileCallAudioSource(path, { packetBytes: 0 })).rejects.toThrow(/packetBytes/)
+		} finally {
+			await rm(dir, { recursive: true, force: true })
+		}
+	})
+})
+
+describe('call audio pump', () => {
+	it('moves every packet and reports the totals', async () => {
+		const seen: number[] = []
+		const pump = startCallAudioPump(
+			data => {
+				seen.push(data[0]!)
+				return true
+			},
+			scriptedSource([new Uint8Array([1]), new Uint8Array([2])])
+		)
+		expect(await pump.done).toEqual({ pushed: 2, shed: 0 })
+		expect(seen).toEqual([1, 2])
+	})
+
+	it('counts shed packets and reports them instead of erroring', async () => {
+		const shedTotals: number[] = []
+		const pump = startCallAudioPump(
+			data => data[0] !== 0x90,
+			scriptedSource([new Uint8Array([1]), new Uint8Array([0x90]), new Uint8Array([3])]),
+			{
+				onShed: total => shedTotals.push(total)
+			}
+		)
+		expect(await pump.done).toEqual({ pushed: 2, shed: 1 })
+		expect(shedTotals).toEqual([1])
+	})
+
+	it('stop() ends the run with the totals so far', async () => {
+		let first = true
+		const pump = startCallAudioPump(
+			() => {
+				if (first) {
+					first = false
+					pump.stop()
+				}
+				return true
+			},
+			scriptedSource([new Uint8Array([1]), new Uint8Array([2]), new Uint8Array([3])])
+		)
+		expect(await pump.done).toEqual({ pushed: 1, shed: 0 })
+	})
+
+	it('an abort stops the run without an error', async () => {
+		const controller = new AbortController()
+		const pump = startCallAudioPump(() => true, makeSilenceCallAudioSource({ intervalMs: 5 }), {
+			signal: controller.signal
+		})
+		controller.abort()
+		const stats = await pump.done
+		expect(stats.pushed + stats.shed >= 0).toBe(true)
+	})
+
+	it('a throwing push rejects done so an ended call surfaces', async () => {
+		const failure = new Error('no live call for this call id')
+		const pump = startCallAudioPump(
+			() => {
+				throw failure
+			},
+			scriptedSource([new Uint8Array([1])])
+		)
+		await expect(pump.done).rejects.toThrow(failure)
+	})
+
+	it('refuses an empty packet from a broken source', async () => {
+		const pump = startCallAudioPump(() => true, scriptedSource([new Uint8Array(0)]))
+		await expect(pump.done).rejects.toThrow(/non-empty/)
+	})
+})
+
+describe('call media router', () => {
+	const frame = (callId: string): CallAudioFrame => ({
+		callId,
+		data: new Uint8Array([0x90]),
+		codec: 'mlow',
+		payloadType: 120,
+		sequenceNumber: 7,
+		timestamp: 960,
+		marker: false
+	})
+
+	it('routes frames to the right call only', () => {
+		const router = makeCallMediaRouter({ emitMediaEvent: () => undefined, reportError: () => undefined })
+		const first: CallAudioFrame[] = []
+		const second: CallAudioFrame[] = []
+		const off = router.addAudioSink('CALL-1', f => first.push(f))
+		router.addAudioSink('CALL-2', f => second.push(f))
+		router.routeAudioFrame(frame('CALL-1'))
+		router.routeAudioFrame(frame('CALL-2'))
+		off()
+		router.routeAudioFrame(frame('CALL-1'))
+		expect(first).toHaveLength(1)
+		expect(second).toHaveLength(1)
+	})
+
+	it('a throwing sink neither breaks the other sinks nor escapes to the bridge', () => {
+		const failures: unknown[] = []
+		const router = makeCallMediaRouter({
+			emitMediaEvent: () => undefined,
+			reportError: err => failures.push(err)
+		})
+		const survivors: CallAudioFrame[] = []
+		router.addAudioSink('CALL-1', () => {
+			throw new Error('broken host')
+		})
+		router.addAudioSink('CALL-1', f => survivors.push(f))
+		router.routeAudioFrame(frame('CALL-1'))
+		expect(survivors).toHaveLength(1)
+		expect(failures).toHaveLength(1)
+	})
+
+	it('drops malformed frames and events with a report instead of a throw', () => {
+		const failures: unknown[] = []
+		const router = makeCallMediaRouter({
+			emitMediaEvent: () => undefined,
+			reportError: err => failures.push(err)
+		})
+		router.routeAudioFrame({ callId: 'CALL-1' } as unknown as CallAudioFrame)
+		router.routeMediaEvent({ nope: true } as unknown as CallMediaEvent)
+		expect(failures).toHaveLength(2)
+	})
+
+	it('emits media events and ends the call on ended', () => {
+		const emitted: CallMediaEvent[] = []
+		const router = makeCallMediaRouter({
+			emitMediaEvent: event => emitted.push(event),
+			reportError: () => undefined
+		})
+		let stopped = false
+		router.trackPump('CALL-1', () => {
+			stopped = true
+		})
+		const received: CallAudioFrame[] = []
+		router.addAudioSink('CALL-1', f => received.push(f))
+		router.routeMediaEvent({ callId: 'CALL-1', kind: 'relay-allocated' })
+		expect(emitted).toEqual([{ callId: 'CALL-1', kind: 'relay-allocated' }])
+		expect(stopped).toBe(false)
+		router.routeMediaEvent({ callId: 'CALL-1', kind: 'ended' })
+		expect(stopped).toBe(true)
+		router.routeAudioFrame(frame('CALL-1'))
+		expect(received).toHaveLength(0)
+	})
+
+	it('stopAll ends every pump and drops every sink', () => {
+		const router = makeCallMediaRouter({ emitMediaEvent: () => undefined, reportError: () => undefined })
+		let stops = 0
+		router.trackPump('CALL-1', () => stops++)
+		router.trackPump('CALL-2', () => stops++)
+		router.stopAll()
+		expect(stops).toBe(2)
+	})
+})
+
+describe('call audio socket methods', () => {
+	const liveClient = (): CallAudioBridgeClient =>
+		({
+			acceptCall: async (callId: string) => callId,
+			dialCall: async () => 'CALL-NEW',
+			callPushAudio: () => true,
+			endCall: async () => ({ outcome: 'peer-notified' }),
+			setCallMuted: async () => undefined,
+			getCallMediaStats: () => ({
+				rtpReceived: 10,
+				rtpPayloadTypeUnexpected: 0,
+				srtpUnprotectFailed: 0,
+				sframeDecryptFailed: 0,
+				audioFramesDecoded: 8,
+				audioFramesDelivered: 8,
+				audioFramesConcealed: 0,
+				mlowOffPointDropped: 0,
+				mlowInactiveOrSid: 2,
+				foreignFramesDecoded: 0,
+				audioFramesWithoutDecoder: 0,
+				outboundFramesWithoutEncoder: 0,
+				playoutTrimmedSamples: 0,
+				inboundPipeDropped: 1,
+				audioSinkDropped: 0,
+				videoSinkDropped: 0,
+				peerKeyframeRequests: 0,
+				relayPacketUnclassified: 0,
+				forwardingEnvelopeRejected: 0,
+				codecSwitches: 0
+			}),
+			getActiveCalls: () => [{ callId: 'CALL-1', peerJid: '5511999999999@s.whatsapp.net' }],
+			setRelayTransportProvider: () => undefined
+		}) as CallAudioBridgeClient
+
+	it('drives the bridge operations with validated arguments', async () => {
+		const methods = makeCallAudioMethods(stubCtx(liveClient()), nullRouter())
+		expect(await methods.dialCall('5511999999999@s.whatsapp.net', 'mlow')).toBe('CALL-NEW')
+		expect(await methods.acceptCall('CALL-1')).toBe('CALL-1')
+		expect(await methods.pushCallAudio('CALL-1', new Uint8Array([0x90]))).toBe(true)
+		expect(await methods.endCall('CALL-1')).toEqual({ outcome: 'peer-notified' })
+		await methods.setCallMuted('CALL-1', true)
+		const stats = await methods.getCallMediaStats('CALL-1')
+		expect(stats.rtpReceived).toBe(10)
+		expect(stats.audioSinkDropped).toBe(0)
+		expect(await methods.getActiveCalls()).toEqual([{ callId: 'CALL-1', peerJid: '5511999999999@s.whatsapp.net' }])
+		await methods.setRelayTransportProvider({
+			createRelayConnection: async () => ({
+				send: () => undefined,
+				close: () => undefined
+			})
+		})
+	})
+
+	it('rejects bad arguments before reaching the bridge', async () => {
+		let crossed = false
+		const methods = makeCallAudioMethods(
+			stubCtx({
+				dialCall: async () => {
+					crossed = true
+					return 'CALL-NEW'
+				}
+			}),
+			nullRouter()
+		)
+		await expect(methods.dialCall('')).rejects.toThrow(/peerJid/)
+		await expect(methods.dialCall('peer@s.whatsapp.net', 'g729' as 'mlow')).rejects.toThrow(/audioFormat/)
+		await expect(methods.acceptCall('')).rejects.toThrow(/callId/)
+		expect(crossed).toBe(false)
+	})
+
+	it('reports a bridge without the audio domain as 501, not a TypeError', async () => {
+		const methods = makeCallAudioMethods(stubCtx({}), nullRouter())
+		await expect(methods.dialCall('5511999999999@s.whatsapp.net')).rejects.toThrow(/client-calls-audio/)
+	})
+
+	it('asCallAudioClient probes the method being used', () => {
+		const partial = { dialCall: async () => 'CALL-1' }
+		expect(asCallAudioClient(partial, 'dialCall').dialCall).toBe(partial.dialCall)
+		expect(() => asCallAudioClient(partial, 'acceptCall')).toThrow(/acceptCall/)
+	})
+
+	it('rejects non-numeric stats instead of forwarding them', async () => {
+		const methods = makeCallAudioMethods(
+			stubCtx({
+				getCallMediaStats: () => ({ rtpReceived: 'lots' })
+			}),
+			nullRouter()
+		)
+		await expect(methods.getCallMediaStats('CALL-1')).rejects.toThrow(/rtpReceived/)
+	})
+
+	it('endCall stops the call pumps even when the bridge reports already-ended', async () => {
+		const emitted: CallMediaEvent[] = []
+		const router = makeCallMediaRouter({
+			emitMediaEvent: event => emitted.push(event),
+			reportError: () => undefined
+		})
+		let stopped = false
+		router.trackPump('CALL-1', () => {
+			stopped = true
+		})
+		const methods = makeCallAudioMethods(stubCtx({ endCall: async () => ({ outcome: 'already-ended' }) }), router)
+		expect(await methods.endCall('CALL-1')).toEqual({ outcome: 'already-ended' })
+		expect(stopped).toBe(true)
+	})
+})

--- a/src/__tests__/call-audio-surface.test.ts
+++ b/src/__tests__/call-audio-surface.test.ts
@@ -1,0 +1,202 @@
+/**
+ * The bridge audio surface, driven directly against the preview package.
+ *
+ * Starting or driving a call needs a live connection and a peer, and no mock
+ * server answers call stanzas here — so like the bridge's own offline tests,
+ * this covers what needs neither: every encoded-audio operation is present
+ * with its sync/async shape, validates its arguments ahead of the core, names
+ * unknown call ids, and fails as a typed `WhatsAppError` rather than hanging.
+ * The one construction probe also shows the `onCallAudio` / `onCallEvent`
+ * sinks install cleanly on the callbacks object a signaling-only host would
+ * pass unchanged.
+ *
+ * Encoded packets both ways — push (JS into the engine) and the speaker pump
+ * (engine out to `onCallAudio`) — need a live call, which needs an account
+ * and a relay. Not verified here; see the PR body for the gap. The pump
+ * machinery around those crossings is `call-audio-pump.test.ts`.
+ */
+
+import { describe, it } from 'node:test'
+import {
+	createWhatsAppClient,
+	initWasmEngine,
+	type JsHttpClientConfig,
+	type JsStoreCallbacks,
+	type JsTransportCallbacks
+} from '@oxidezap/whatsapp-rust-bridge'
+
+import { asCallAudioClient, type CallAudioBridgeClient } from '../Socket/calls.ts'
+import type { CallAudioFrame, CallMediaEvent } from '../Types/Call.ts'
+import type { ILogger } from '../Utils/logger.ts'
+import { expect } from './expect.ts'
+
+const silentLogger = {
+	level: 'silent',
+	child: () => silentLogger,
+	trace: () => undefined,
+	debug: () => undefined,
+	info: () => undefined,
+	warn: () => undefined,
+	error: () => undefined
+} as unknown as ILogger
+
+const deadTransport = (): JsTransportCallbacks => ({
+	connect: async () => undefined,
+	send: () => undefined,
+	disconnect: async () => undefined
+})
+
+const deadHttp = (): JsHttpClientConfig => ({
+	execute: async () => ({ statusCode: 503, body: new Uint8Array() })
+})
+
+const memoryStore = (): JsStoreCallbacks => ({
+	get: async () => null,
+	set: async () => undefined,
+	delete: async () => undefined
+})
+
+initWasmEngine(silentLogger)
+
+type CodedError = Error & { kind?: string; field?: string }
+
+const rejection = async (promise: Promise<unknown>): Promise<CodedError> => {
+	try {
+		await promise
+	} catch (error) {
+		return error as CodedError
+	}
+	throw new Error('expected the call to reject')
+}
+
+const syncRejection = (fn: () => unknown): CodedError => {
+	try {
+		fn()
+	} catch (error) {
+		return error as CodedError
+	}
+	throw new Error('expected the call to throw')
+}
+
+const offlineAudioClient = async (): Promise<CallAudioBridgeClient> => {
+	const client = await createWhatsAppClient(deadTransport(), deadHttp(), null, memoryStore(), null)
+	for (const method of [
+		'acceptCall',
+		'dialCall',
+		'callPushAudio',
+		'endCall',
+		'setCallMuted',
+		'getCallMediaStats',
+		'getActiveCalls',
+		'setRelayTransportProvider'
+	] as const) {
+		expect(typeof (client as unknown as Record<string, unknown>)[method]).toBe('function')
+	}
+	return asCallAudioClient(client, 'acceptCall')
+}
+
+describe('call audio bridge surface', { timeout: 60_000 }, () => {
+	it('accepting needs a live offer for the id', async () => {
+		const client = await offlineAudioClient()
+		try {
+			const error = await rejection(client.acceptCall('NEVER-RANG', 'mlow'))
+			expect(error.kind).toBe('invalid-argument')
+			expect(error.field).toBe('callId')
+		} finally {
+			;(client as unknown as { free(): void }).free()
+		}
+	})
+
+	it('the audio format promise is validated ahead of the core', async () => {
+		const client = await offlineAudioClient()
+		try {
+			const error = await rejection(client.acceptCall('NEVER-RANG', 'g729' as 'mlow'))
+			expect(error.kind).toBe('invalid-argument')
+			expect(error.field).toBe('audioFormat')
+		} finally {
+			;(client as unknown as { free(): void }).free()
+		}
+	})
+
+	it('dialing names a malformed peer', async () => {
+		const client = await offlineAudioClient()
+		try {
+			const error = await rejection(client.dialCall('not-a-jid', 'mlow'))
+			expect(error.kind).toBe('invalid-argument')
+			expect(error.field).toBe('peer')
+		} finally {
+			;(client as unknown as { free(): void }).free()
+		}
+	})
+
+	it('push, stats, end and mute name an unknown call id', async () => {
+		const client = await offlineAudioClient()
+		try {
+			const push = syncRejection(() => client.callPushAudio('NEVER-LIVE', new Uint8Array([0x90])))
+			expect(push.kind).toBe('invalid-argument')
+			expect(push.field).toBe('callId')
+
+			const empty = syncRejection(() => client.callPushAudio('NEVER-LIVE', new Uint8Array(0)))
+			expect(empty.kind).toBe('invalid-argument')
+			expect(empty.field).toBe('data')
+
+			const stats = syncRejection(() => client.getCallMediaStats('NEVER-LIVE'))
+			expect(stats.kind).toBe('invalid-argument')
+			expect(stats.field).toBe('callId')
+
+			const end = await rejection(client.endCall('NEVER-LIVE'))
+			expect(end.kind).toBe('invalid-argument')
+			expect(end.field).toBe('callId')
+
+			const mute = await rejection(client.setCallMuted('NEVER-LIVE', true))
+			expect(mute.kind).toBe('invalid-argument')
+			expect(mute.field).toBe('callId')
+
+			expect(client.getActiveCalls()).toEqual([])
+		} finally {
+			;(client as unknown as { free(): void }).free()
+		}
+	})
+
+	it('the relay provider names a missing constructor', async () => {
+		const client = await offlineAudioClient()
+		try {
+			const error = syncRejection(() => client.setRelayTransportProvider({} as never))
+			expect(error.kind).toBe('invalid-argument')
+			expect(error.field).toBe('provider')
+		} finally {
+			;(client as unknown as { free(): void }).free()
+		}
+	})
+
+	it('the media sinks install on the callbacks object without disturbing signaling', async () => {
+		const audioFrames: CallAudioFrame[] = []
+		const mediaEvents: CallMediaEvent[] = []
+		const callbacks = {
+			onEvent: () => undefined
+		}
+		Object.assign(callbacks, {
+			onCallAudio: (frame: CallAudioFrame) => audioFrames.push(frame),
+			onCallEvent: (event: CallMediaEvent) => mediaEvents.push(event)
+		})
+		const client = await createWhatsAppClient(
+			deadTransport(),
+			deadHttp(),
+			callbacks as unknown as Parameters<typeof createWhatsAppClient>[2],
+			memoryStore(),
+			null
+		)
+		try {
+			expect(typeof client.disconnect).toBe('function')
+			expect(audioFrames).toEqual([])
+			expect(mediaEvents).toEqual([])
+		} finally {
+			try {
+				await client.disconnect()
+			} catch {
+				/* ignore */
+			}
+			client.free()
+		}
+	})
+})

--- a/src/__tests__/closed-domain-arguments.test.ts
+++ b/src/__tests__/closed-domain-arguments.test.ts
@@ -297,6 +297,22 @@ const CASES: DomainCase[] = [
 		values: ['on', 'off'],
 		call: (sock, value) => sock.communityJoinApprovalMode(GROUP, arg(value)),
 		source: 'communities.ts:communityJoinApprovalMode:mode'
+	},
+	{
+		label: 'dialCall',
+		parameter: 'audioFormat',
+		values: ['mlow', 'opus', undefined],
+		call: (sock, value) => sock.dialCall(USER, arg(value)),
+		source: 'calls.ts:dialCall:audioFormat',
+		defaulted: true
+	},
+	{
+		label: 'acceptCall',
+		parameter: 'audioFormat',
+		values: ['mlow', 'opus', undefined],
+		call: (sock, value) => sock.acceptCall('NEVER-RANG', arg(value)),
+		source: 'calls.ts:acceptCall:audioFormat',
+		defaulted: true
 	}
 ]
 
@@ -309,6 +325,8 @@ const EXEMPT: Record<string, string> = {
 	'business.ts:minutesPastMidnight:which': 'a module-internal helper, called with a literal at both call sites',
 	'internals.ts:resyncAppState:collections': 'a no-op wrapper: nothing is forwarded to the bridge',
 	'server-queries.ts:createCallLink:_type': 'refused with a 501 whatever the value is',
+	'calls.ts:<module>:audioFormat':
+		'the bridge-contract interface restatement, not a parameter; dialCall and acceptCall validate it',
 	'internals.ts:upsertMessage:type': 'published on the event bus, so the value comes back to the caller unchanged'
 }
 

--- a/src/__tests__/e2e/call-audio-loop.test-e2e.ts
+++ b/src/__tests__/e2e/call-audio-loop.test-e2e.ts
@@ -1,0 +1,94 @@
+/**
+ * E2E: encoded-audio call loop against the mock server.
+ *
+ * Alice dials Bob's LID with the `mlow` promise, pushes MLOW silence packets
+ * through the real engine, reads the media stats, and ends the call. Bob
+ * observes the offer on `call`, which proves the offer stanza crossed the
+ * mock — the mock answers no relay, so the media plane stays dormant and no
+ * decoded packet can come back down `onCallAudio` here. That direction is
+ * covered by the loopback half of `call-audio-pump.test.ts`.
+ *
+ * What this pins, all against the preview bridge and the mock:
+ *
+ * - `dialCall` resolves a call id the bridge also lists in `getActiveCalls`
+ *   with Bob as the peer;
+ * - Bob's `call` event carries an `offer` with the same id;
+ * - `pushCallAudio` queues silence (`true`) and the stats object keeps all
+ *   21 counters numeric;
+ * - a one-packet silence pump through `startCallAudioPump` moves exactly it;
+ * - `endCall` reports the peer told or already gone — both are honest
+ *   answers against a mock that ends dormant calls on its own schedule.
+ */
+
+import { after, before, describe, test } from 'node:test'
+
+import { makeSilenceCallAudioSource } from '../../Socket/calls.ts'
+import type { CallMediaStats } from '../../index.ts'
+import { expect } from '../expect.ts'
+import { createTestClient, destroyTestClient, type TestClient } from './test-client.ts'
+import { waitForEvent } from './wait.ts'
+
+const STAT_FIELDS = [
+	'rtpReceived',
+	'rtpPayloadTypeUnexpected',
+	'srtpUnprotectFailed',
+	'sframeDecryptFailed',
+	'audioFramesDecoded',
+	'audioFramesDelivered',
+	'audioFramesConcealed',
+	'mlowOffPointDropped',
+	'mlowInactiveOrSid',
+	'foreignFramesDecoded',
+	'audioFramesWithoutDecoder',
+	'outboundFramesWithoutEncoder',
+	'playoutTrimmedSamples',
+	'inboundPipeDropped',
+	'audioSinkDropped',
+	'videoSinkDropped',
+	'peerKeyframeRequests',
+	'relayPacketUnclassified',
+	'forwardingEnvelopeRejected',
+	'codecSwitches'
+] as const
+
+describe('E2E: encoded-audio call loop', { timeout: 120_000 }, () => {
+	let alice: TestClient
+	let bob: TestClient
+
+	before(async () => {
+		alice = await createTestClient({ label: 'caller' })
+		bob = await createTestClient({ label: 'callee' })
+	})
+
+	after(async () => {
+		await destroyTestClient(alice)
+		await destroyTestClient(bob)
+	})
+
+	test('dial, offer wire, push, stats, pump and end', async () => {
+		const bobOffer = waitForEvent(bob.sock, 'call', events => events.some(event => event.status === 'offer'))
+		const callId = await alice.sock.dialCall(bob.lid ?? bob.jid, 'mlow')
+		expect(typeof callId).toBe('string')
+
+		// Push first: the mock ends a dormant call on its own schedule, so
+		// every assertion that needs the call alive runs ahead of the waits.
+		expect(await alice.sock.pushCallAudio(callId, new Uint8Array([0x90]))).toBe(true)
+
+		const pump = await alice.sock.startCallAudioPump(callId, makeSilenceCallAudioSource({ packets: 1, intervalMs: 0 }))
+		expect(await pump.done).toEqual({ pushed: 1, shed: 0 })
+
+		const active = await alice.sock.getActiveCalls()
+		expect(active.some(call => call.callId === callId)).toBe(true)
+
+		const offer = await bobOffer
+		expect(offer.some(event => event.status === 'offer' && event.id === callId)).toBe(true)
+
+		const stats = (await alice.sock.getCallMediaStats(callId)) as CallMediaStats
+		for (const field of STAT_FIELDS) {
+			expect(typeof stats[field]).toBe('number')
+		}
+
+		const end = await alice.sock.endCall(callId)
+		expect(end.outcome === 'peer-notified' || end.outcome === 'already-ended').toBe(true)
+	})
+})


### PR DESCRIPTION
Real audio calls in baileyrs, on top of the bridge calls preview. Dial and answer
encoded-audio calls, push packets, collect decoded ones, read stats, hang up.

Which bridge ref this uses

I checked all three places. Bridge main has no calls domain at all, so there
was nothing to consume there. The pkg.pr.new build for PR 115 first served an
older push with signaling only, then refreshed to the PR head once its CI went
green. package.json points at the PR URL and the lockfile pins the exact build
I verified against, 0.0.0-preview-2071901, which carries both the signaling
slice and the encoded-audio slice. Never a release, as agreed.

What this adds

A new src/Socket/calls.ts with the audio half of the socket. dialCall and
acceptCall open a call with an mlow or opus promise, pushCallAudio queues one
packet and answers true or false, endCall reports how much of the peer was
told, and setCallMuted, getCallMediaStats, getActiveCalls and
setRelayTransportProvider round it out. I did not reimplement the relay
transport or any SDP text. The provider passes straight through to the bridge,
so the bridge stays the only place that knows WebRTC.

Two pieces around those calls. A media router takes the bridge onCallAudio
and onCallEvent callbacks, fans decoded frames out to per-call sinks, and
emits a call.media event for lifecycle steps including ended, which also stops
that call's pumps. And a pump runner pulls packets from a source into the
push, counts shed audio instead of erroring on it, and stops on a spent
source, an abort, or the call ending.

For tests without a microphone there are two sources and no new dependencies.
The silence source sends the single 0x90 byte the core accepts as an encoded
payload under both format promises, and the file source chunks a fixture into
fixed packets. Neither decodes anything. There is deliberately no ffmpeg in
this package.

Backpressure works the way the bridge contract says. A full engine queue sheds
newest-first and the push answers false, which the pump counts and reports
through onShed. The bridge exposes no watermark readout, its own docs name the
false return as the pacing signal instead, so this layer paces off the shed
count plus the audioSinkDropped and inboundPipeDropped stats counters. Frames
cross without an extra copy on this side. The bridge already paid the one copy
each way and the router hands the frame view straight to the sink.

Without a bridge that has the client-calls-audio domain, every method throws
501 naming the capability instead of failing on a missing function. The bridge
types for the new ops are written down structurally in calls.ts so this still
compiles against the release bridge, and a runtime probe picks the real client
up when the preview is installed.

Evidence

I ran the loop for real against the local Bartender mock with two paired
clients on the preview build. Alice dialed Bob's LID and got a call id back,
Bob's call event carried the offer with the same id, three silence pushes
queued true, the stats came back with all 21 counters numeric, and endCall
reported peer-notified. A one-packet silence pump through startCallAudioPump
resolved pushed 1 and shed 0. That run is now a committed e2e test and it
passed three times in a row here. It needs the mock, so fork CI skips it like
the other e2e files.

Around it, the offline suite covers what needs no peer. call-audio-pump has 24
tests for the sources, the pump totals, shed accounting, sink routing and the
method validation, all passing. call-audio-surface drives the real preview
WASM offline and checks every op is present with its sync or async shape and
that unknown ids and bad arguments come back as typed invalid-argument errors.
I also extended the two coverage ledgers this change trips, the closed-domain
list and the fuzz boundary table, with dialCall and acceptCall audioFormat
cases.

Compatibility is unchanged. The missing, wire, proto and lifecycle audits
return the exact same finding sets on base and head, so zero new divergences.
lint, format check, build and check-pack are green. The full unit suite is
1569 of 1571.

Two things I did not do

Decoded audio coming back down onCallAudio over a live relay is still
unproven. The mock answers no relay, so the media plane stays dormant and no
packet can come back that way here. The inbound half is covered by the loopback
tests, and a live relay handshake needs an account-backed rig that belongs to
the next slice. The native voip-cli target was not reachable for the same
reason, it needs real accounts.

The one failing unit test needs its own note. bridge-free-safety fails under
the preview with a wasm memory access out of bounds when free lands with a
fetchBlocklist in flight. I reproduced it on the untouched base tree with only
the preview installed, and the same tree passes 4 of 4 on the release bridge,
so this is a property of the preview build, not of this change. The fix belongs
on the bridge side and I left the assertion alone.

compat:layers did not run. It looks for the core and bridge checkouts at fixed
sibling paths that do not exist in this worktree layout, so I report it blocked
rather than passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds encoded-audio voice calls on top of the bridge calls preview. Previously only call signaling flowed; now `dialCall`, `acceptCall`, `pushCallAudio`, `endCall`, `setCallMuted`, `getCallMediaStats`, and `getActiveCalls` drive the bridge's `client-calls-audio` domain, with per-call audio sinks, a pump runner, and shed accounting.

**Dependencies**
- Swaps `@oxidezap/whatsapp-rust-bridge` from release `0.21.4` to the pkg.pr.new preview for PR 115, pinned to `0.0.0-preview-2071901` in the lockfile.
- This is never a release, and a release build without the audio domain makes every method throw `501` naming `client-calls-audio`.

**Behavior notes**
- Backpressure is loss-tolerant: a `false` push means the packet was shed, counted and reported via `onShed`, never an error.
- The media router hands frames to sinks without an extra copy and stops calls' pumps on `ended` or socket teardown.
- Decoded audio over a live relay is unproven — the mock answers no relay, so that direction stays covered by loopback tests.
- `bridge-free-safety` fails under the preview build with a wasm memory access out of bounds, reproduced on the untouched base — a preview-build property, not this change.
- `compat:layers` did not run because it needs core and bridge checkouts at fixed sibling paths this worktree lacks.

<sup>Written for commit fa363e95279a8ee8a6ecec880d1e6ebb60fa0356. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

